### PR TITLE
COMP: Remove compiler warnings

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.txx
@@ -86,7 +86,6 @@ namespace gdcm
       // tag was found, we can exit the loop:
       if ( t <= de.GetTag() )
         {
-        std::streampos pos = is.tellg();
         break;
         }
       }

--- a/Source/MediaStorageAndFileFormat/gdcmDICOMDIRGenerator.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDICOMDIRGenerator.cxx
@@ -357,8 +357,11 @@ void SingleDataElementInserter(gdcm::DataSet &ds, gdcm::Scanner const & scanner)
 {
   Attribute<Group,Element> patientsname;
   gdcm::Scanner::ValuesType patientsnames = scanner.GetValues( patientsname.GetTag() );
-  unsigned int npatient = patientsnames.size();
+#if !defined(NDEBUG)
+  const unsigned int npatient = patientsnames.size();
   assert( npatient == 1 );
+#endif
+
   gdcm::Scanner::ValuesType::const_iterator it = patientsnames.begin();
   patientsname.SetValue( it->c_str() );
   ds.Insert( patientsname.GetAsDataElement() );

--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
@@ -1541,7 +1541,6 @@ bool JPEG2000Codec::DecodeExtent(
       size_t curoffset = std::accumulate( offsets.begin(), offsets.begin() + z, 0 );
       is.seekg( thestart + curoffset + 8 * z, std::ios::beg );
       is.seekg( 8, std::ios::cur );
-      std::streampos relstart = is.tellg();
 
       const size_t buf_size = offsets[z];
       char *dummy_buffer = new char[ buf_size ];

--- a/Source/MediaStorageAndFileFormat/gdcmJPEGCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGCodec.cxx
@@ -569,15 +569,16 @@ bool JPEGCodec::DecodeExtent(
       size_t curoffset = std::accumulate( offsets.begin(), offsets.begin() + z, 0 );
       is.seekg( thestart + curoffset + 8 * z, std::ios::beg );
       is.seekg( 8, std::ios::cur );
-      std::streampos relstart = is.tellg();
 
       //const size_t buf_size = offsets[z];
       //char *dummy_buffer = new char[ buf_size ];
       //is.read( dummy_buffer, buf_size );
 
       std::stringstream os;
-      bool b = DecodeByStreams(is, os);
+#if !defined(NDEBUG)
+      const bool b = DecodeByStreams(is, os);
       assert( b );
+#endif
       /* free the memory containing the code-stream */
       //delete[] dummy_buffer;
 

--- a/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
@@ -517,7 +517,6 @@ bool JPEGLSCodec::DecodeExtent(
       size_t curoffset = std::accumulate( offsets.begin(), offsets.begin() + z, 0 );
       is.seekg( thestart + curoffset + 8 * z, std::ios::beg );
       is.seekg( 8, std::ios::cur );
-      std::streampos relstart = is.tellg();
 
       const size_t buf_size = offsets[z];
       char *dummy_buffer = new char[ buf_size ];

--- a/Source/MediaStorageAndFileFormat/gdcmPixmapReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPixmapReader.cxx
@@ -643,7 +643,6 @@ bool PixmapReader::ReadImage(MediaStorage const &ms)
   // 3. Pixel Format ?
   PixelFormat pf;
   // D 0028|0002 [US] [Samples per Pixel] [1]
-  const Tag samplesperpixel = Tag(0x0028, 0x0002);
     {
     Attribute<0x0028,0x0002> at = { 1 }; // By default assume 1 Samples Per Pixel
     at.SetFromDataSet( ds );

--- a/Source/MediaStorageAndFileFormat/gdcmRAWCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmRAWCodec.cxx
@@ -120,8 +120,10 @@ bool RAWCodec::DecodeBytes(const char* inBytes, size_t inBufferLength,
     {
     size_t len = str.size() * 16 / 12;
     char * copy = new char[len];
+#if !defined(NDEBUG)
     bool b = Unpacker12Bits::Unpack(copy, &str[0], str.size() );
     assert( b );
+#endif
     assert (len == inOutBufferLength);
     assert(inOutBufferLength == len);
     memcpy(outBytes, copy, len);

--- a/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
@@ -556,8 +556,6 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
 
 size_t RLECodec::DecodeFragment(Fragment const & frag, char *buffer, unsigned long llen)
 {
-  const unsigned int * dimensions = this->GetDimensions();
-  const PixelFormat & pf = this->GetPixelFormat();
 
   std::stringstream is;
   const ByteValue &bv = dynamic_cast<const ByteValue&>(frag.GetValue());
@@ -568,7 +566,11 @@ size_t RLECodec::DecodeFragment(Fragment const & frag, char *buffer, unsigned lo
   delete[] mybuffer;
   std::stringstream os;
   SetLength( llen );
+#if !defined(NDEBUG)
+  const unsigned int * const dimensions = this->GetDimensions();
+  const PixelFormat & pf = this->GetPixelFormat();
   assert( llen == dimensions[0] * dimensions[1] * pf.GetPixelSize() );
+#endif
   bool r = DecodeByStreams(is, os);
   assert( r == true );
   (void)r; //warning removal
@@ -630,9 +632,11 @@ bool RLECodec::Decode(DataElement const &in, DataElement &out)
     //      || GetDimension(2) == sf->GetNumberOfFragments() );
     for(unsigned int i = 0; i < sf->GetNumberOfFragments(); ++i)
       {
+#if !defined(NDEBUG)
       const Fragment &frag = sf->GetFragment(i);
-      size_t check = DecodeFragment(frag, buffer + pos, llen);
+      const size_t check = DecodeFragment(frag, buffer + pos, llen);
       assert( check == llen );
+#endif
       pos += llen;
       }
     assert( pos == len );
@@ -673,13 +677,14 @@ bool RLECodec::DecodeExtent(
     }
   for( unsigned int z = zmin; z <= zmax; ++z )
     {
-    std::streampos prestart = is.tellg();
     frag.ReadPreValue<SwapperNoOp>(is);
     std::streampos start = is.tellg();
 
     SetLength( dimensions[0] * dimensions[1] * pf.GetPixelSize() );
-    bool r = DecodeByStreams(is, os);
+#if !defined(NDEBUG)
+    const bool r = DecodeByStreams(is, os);
     assert( r );
+#endif
 
     // handle DICOM padding
     std::streampos end = is.tellg();

--- a/Source/MediaStorageAndFileFormat/gdcmStringFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStringFilter.cxx
@@ -185,9 +185,11 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
       // move to next state
       state = 2;
       assert( subtokens[1] == "number" );
-      const gdcm::ByteValue *bv = curde->GetByteValue();
+#if !defined(NDEBUG)
+      const gdcm::ByteValue * const bv = curde->GetByteValue();
       assert( bv );
       //bv->Print( std::cout << std::endl );
+#endif
       }
     else
       {
@@ -525,8 +527,10 @@ std::string StringFilter::FromString(const Tag&t, const char * value, size_t len
     {
     // VM1_n
     vl = count * vr.GetSizeof();
+#if !defined(NDEBUG)
     VM check  = VM::GetVMTypeFromLength(count, 1);
     assert( vm.Compatible( check ) );
+#endif
     }
 
   //if( vl != vm.GetLength() * vr.GetSizeof() )

--- a/Utilities/gdcmcharls/header.cpp
+++ b/Utilities/gdcmcharls/header.cpp
@@ -530,7 +530,6 @@ void JLSOutputStream::AddScan(const void* pbyteComp, const JlsParamaters* pparam
   _icompLast += 1;
   _segments.push_back(EncodeStartOfScan(pparams,pparams->ilv == ILV_NONE ? _icompLast : -1));
 
-  Size size = Size(pparams->width, pparams->height);
   int ccomp = pparams->ilv == ILV_NONE ? 1 : pparams->components;
     _segments.push_back(new JpegImageDataSegment(pbyteComp, *pparams, _icompLast, ccomp));
 }


### PR DESCRIPTION
Many unused variables detected by the
clang compiler.  In most cases, they
are variables that are only needed
for debugging asserts.
