### PR TITLE
Added empty values in unused but required tags in gdcmSurfaceWriter. 

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmSurfaceWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSurfaceWriter.cxx
@@ -583,6 +583,77 @@ bool SurfaceWriter::PrepareWrite()
 
           pointIndexListDS0.Replace( typedPointIndexListDE );
         }
+
+        //*****   Add empty values in unused but required tags (Type 2)   *****//
+
+        DataElement emptyOWDE;
+        emptyOWDE.SetVLToUndefined();
+        emptyOWDE.SetVR( VR::OW );
+        SmartPointer<ByteValue> emptyValueOW = new ByteValue;
+        emptyOWDE.SetValue(*emptyValueOW);
+
+        // Vertex Point Index List ( Type 2 )
+        Tag vertexPointIndexListTag(0x0066, 0x0025);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( vertexPointIndexListTag ) )
+        {
+          emptyOWDE.SetTag( vertexPointIndexListTag );
+          surfaceMeshPrimitivesDS.Insert( emptyOWDE );
+        }
+
+        // Edge Point Index List ( Type 2 )
+        Tag edgePointIndexListTag(0x0066, 0x0024);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( edgePointIndexListTag ) )
+        {
+          emptyOWDE.SetTag( edgePointIndexListTag );
+          surfaceMeshPrimitivesDS.Insert( emptyOWDE );
+        }
+
+        // Triangle Point Index List ( Type 2 )
+        Tag trianglePointIndexListTag(0x0066, 0x0023);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( trianglePointIndexListTag ) )
+        {
+          emptyOWDE.SetTag( trianglePointIndexListTag );
+          surfaceMeshPrimitivesDS.Insert( emptyOWDE );
+        }
+
+        DataElement emptySQDE;
+        emptySQDE.SetVLToUndefined();
+        emptySQDE.SetVR( VR::SQ );
+        SmartPointer<SequenceOfItems> emptySequenceSQ = new SequenceOfItems;
+        emptySQDE.SetValue(*emptySequenceSQ);
+
+        // Triangle Strip Sequence ( Type 2 )
+        Tag triangleStripSequenceTag(0x0066, 0x0026);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( triangleStripSequenceTag ) )
+        {
+          emptySQDE.SetTag( triangleStripSequenceTag );
+          surfaceMeshPrimitivesDS.Insert( emptySQDE );
+        }
+
+        // Triangle Fan Sequence ( Type 2 )
+        Tag triangleFanSequenceTag(0x0066, 0x0027);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( triangleFanSequenceTag ) )
+        {
+          emptySQDE.SetTag( triangleFanSequenceTag );
+          surfaceMeshPrimitivesDS.Insert( emptySQDE );
+        }
+
+        // Line Sequence ( Type 2 )
+        Tag lineSequenceTag(0x0066, 0x0028);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( lineSequenceTag ) )
+        {
+          emptySQDE.SetTag( lineSequenceTag );
+          surfaceMeshPrimitivesDS.Insert( emptySQDE );
+        }
+
+        // Facet Sequence ( Type 2 )
+        Tag facetSequenceTag(0x0066, 0x0034);
+        if( !surfaceMeshPrimitivesDS.FindDataElement( facetSequenceTag ) )
+        {
+          emptySQDE.SetTag( facetSequenceTag );
+          surfaceMeshPrimitivesDS.Insert( emptySQDE );
+        }
+
       }
       ++numSurface;
     }


### PR DESCRIPTION
Hi there,

According to the Surface Mesh Primitives Macro (Table C.27-4 of the DICOM standard), the Surface Mesh Module must contain the following tags : 
- Vertex Point Index List   (0066,0025) - Type 2
- Edge Point Index List (0066,0024) - Type 2
- Triangle Point Index List (0066,0023) - Type 2
- Triangle Strip Sequence (0066,0026) - Type 2
- Triangle Fan Sequence (0066,0027) - Type 2
- Line Sequence (0066,0028) - Type 2
- Facet Sequence (0066,0034) - Type 2

The current implementation of gdcmSurfaceWriter only writes the tags needed to store the data. 
This patch adds the writing of the tags that are required by the standard but not necessarily needed to store the data.

Thanks,

Clement
