### PR TITLE
Fix monochrome inversions not respecting the Pixel Format of the image.

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx
@@ -64,6 +64,7 @@ bool ImageChangePhotometricInterpretation::ChangeMonochrome()
 
   //ImageCodec ic;
   RAWCodec ic;
+  ic.SetPixelFormat(image.GetPixelFormat());
   std::ostringstream os;
   ic.DoInvertMonochrome( is, os );
 


### PR DESCRIPTION
The pixel format of the image is being ignored  in the monochrome
conversions causing bad conversions for images that are not 8bpp.
