### PR TITLE
Allow users to specify tags in gdcmSorter

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmSorter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSorter.cxx
@@ -34,7 +34,7 @@ Sorter::~Sorter()
 {
 }
 
-void Sorter::SetTagsToRead( std::set<Tag> tags )
+void Sorter::SetTagsToRead( std::set<Tag> const & tags )
 {
   TagsToRead = tags;
 }

--- a/Source/MediaStorageAndFileFormat/gdcmSorter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSorter.cxx
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <algorithm>
+#include <set>
 
 namespace gdcm
 {
@@ -26,11 +27,16 @@ namespace gdcm
 Sorter::Sorter()
 {
   SortFunc = NULL;
+  TagsToRead = std::set<Tag>();
 }
-
 
 Sorter::~Sorter()
 {
+}
+
+void Sorter::SetTagsToRead( std::set<Tag> tags )
+{
+  TagsToRead = tags;
 }
 
 void Sorter::SetSortFunction( SortFunction f )
@@ -83,7 +89,9 @@ bool Sorter::StableSort(std::vector<std::string> const & filenames)
     Reader reader;
     reader.SetFileName( it->c_str() );
     SmartPointer<FileWithName> &f = *it2;
-    if( reader.Read() )
+
+    bool readWasSuccessful = TagsToRead.empty() ? reader.Read() : reader.ReadSelectedTags(TagsToRead);
+    if (readWasSuccessful)
       {
       f = new FileWithName( reader.GetFile() );
       f->filename = *it;
@@ -125,7 +133,8 @@ bool Sorter::Sort(std::vector<std::string> const & filenames)
     Reader reader;
     reader.SetFileName( it->c_str() );
     SmartPointer<FileWithName> &f = *it2;
-    if( reader.Read() )
+    bool readWasSuccessful = TagsToRead.empty() ? reader.Read() : reader.ReadSelectedTags(TagsToRead);
+    if (readWasSuccessful)
       {
       f = new FileWithName( reader.GetFile() );
       f->filename = *it;

--- a/Source/MediaStorageAndFileFormat/gdcmSorter.h
+++ b/Source/MediaStorageAndFileFormat/gdcmSorter.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <set>
 
 namespace gdcm
 {
@@ -54,6 +55,7 @@ public:
 
   /// UNSUPPORTED FOR NOW
   bool AddSelect( Tag const &tag, const char *value );
+  void SetTagsToRead( std::set<Tag> tags );
 
   /// Set the sort function which compares one dataset to the other
   typedef bool (*SortFunction)(DataSet const &, DataSet const &);
@@ -66,6 +68,7 @@ protected:
   typedef std::map<Tag,std::string> SelectionMap;
   std::map<Tag,std::string> Selection;
   SortFunction SortFunc;
+  std::set<Tag> TagsToRead;
 };
 //-----------------------------------------------------------------------------
 inline std::ostream& operator<<(std::ostream &os, const Sorter &s)

--- a/Source/MediaStorageAndFileFormat/gdcmSorter.h
+++ b/Source/MediaStorageAndFileFormat/gdcmSorter.h
@@ -55,7 +55,11 @@ public:
 
   /// UNSUPPORTED FOR NOW
   bool AddSelect( Tag const &tag, const char *value );
-  void SetTagsToRead( std::set<Tag> tags );
+
+  /// Specify a set of tags to be read in during the sort procedure.
+  /// By default this set is empty, in which case the entire image,
+  /// including pixel data, is read in.
+  void SetTagsToRead( std::set<Tag> const & tags );
 
   /// Set the sort function which compares one dataset to the other
   typedef bool (*SortFunction)(DataSet const &, DataSet const &);


### PR DESCRIPTION
gdcm::Sorter allows a directory of DICOM files to be sorted according to one or more user-specified functions.  However, use of the class currently requires that the entire image, including pixel data, be read in, even if the image is being sorted based on a known subset of header tags.  This can be intractable for large images in memory constrained situations.  This patch allows the user to specify relevant tags to read, if known.  If none are specified, the class behaves as it did previously.  For large image sets, this results in a dramatic reduction in memory usage.