### PR TITLE
Support to compile GDCM with VTK7

### DIFF
--- a/Utilities/VTK/Applications/gdcm2vtk.cxx
+++ b/Utilities/VTK/Applications/gdcm2vtk.cxx
@@ -29,7 +29,7 @@
 #include "vtkPNMWriter.h"
 #include "vtkBMPWriter.h"
 #include "vtkImageChangeInformation.h"
-#if VTK_MAJOR_VERSION >= 5 && VTK_MINOR_VERSION > 0
+#if (VTK_MAJOR_VERSION >= 5 && VTK_MINOR_VERSION > 0) || (VTK_MAJOR_VERSION >= 7)
 #include "vtkMetaImageReader.h"
 #include "vtkXMLImageDataReader.h"
 #include "vtkMetaImageWriter.h"

--- a/Utilities/VTK/Applications/gdcm2vtk.cxx
+++ b/Utilities/VTK/Applications/gdcm2vtk.cxx
@@ -29,7 +29,7 @@
 #include "vtkPNMWriter.h"
 #include "vtkBMPWriter.h"
 #include "vtkImageChangeInformation.h"
-#if (VTK_MAJOR_VERSION >= 5 && VTK_MINOR_VERSION > 0) || (VTK_MAJOR_VERSION >= 7)
+#if (VTK_MAJOR_VERSION >= 5 && VTK_MINOR_VERSION > 0) || (VTK_MAJOR_VERSION >= 6)
 #include "vtkMetaImageReader.h"
 #include "vtkXMLImageDataReader.h"
 #include "vtkMetaImageWriter.h"

--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -70,24 +70,17 @@ else()
     vtkIOLegacy
     #vtksys
   )
+  set(vtkgdcm_COND_LIBS
+    vtkIOMPIImage
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingFreeTypeOpenGL
+  )
   if("${VTK_MAJOR_VERSION}" EQUAL 6)
-    set(vtkgdcm_COND_LIBS
-      vtkIOMPIImage
-      vtkInteractionStyle
-      vtkRenderingCore
-      vtkRenderingFreeType
-      vtkRenderingFreeTypeOpenGL
-      vtkRenderingOpenGL
-    )
+    list(APPEND vtkgdcm_COND_LIBS vtkRenderingOpenGL)
   else()
-    set(vtkgdcm_COND_LIBS
-      vtkIOMPIImage
-      vtkInteractionStyle
-      vtkRenderingCore
-      vtkRenderingFreeType
-      vtkRenderingFreeTypeOpenGL
-      vtkRenderingOpenGL2
-    )
+    list(APPEND vtkgdcm_COND_LIBS vtkRenderingOpenGL2)
   endif()
   foreach(TMP_LIB ${VTK_LIBRARIES})
     foreach(TRY_LIB ${vtkgdcm_COND_LIBS})
@@ -773,7 +766,7 @@ if(GDCM_WRAP_PYTHON)
     # Removing lib prefix if we are at VTK7. Based on a reply by David Gobbi to
     # this Thread
     # http://vtk.1045678.n5.nabble.com/python-wrapping-with-VTK-7-td5737442.html
-    if( "${VTK_MAJOR_VERSION}" EQUAL 7 )
+    if( "${VTK_MAJOR_VERSION}" GREATER 6 )
       set_target_properties(${VTKGDCM_NAME}Python PROPERTIES PREFIX "")
     endif()
     # Python extension modules on Windows must have the extension ".pyd"

--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -770,6 +770,12 @@ if(GDCM_WRAP_PYTHON)
     set_property(TARGET ${VTKGDCM_NAME}PythonD PROPERTY LINK_INTERFACE_LIBRARIES "")
     set_property(TARGET ${VTKGDCM_NAME}Python PROPERTY NO_SONAME 1)
     #set_property(TARGET ${VTKGDCM_NAME}PythonD PROPERTY NO_SONAME 1)
+    # Removing lib prefix if we are at VTK7. Based on a reply by David Gobbi to
+    # this Thread
+    # http://vtk.1045678.n5.nabble.com/python-wrapping-with-VTK-7-td5737442.html
+    if( "${VTK_MAJOR_VERSION}" EQUAL 7 )
+      set_target_properties(${VTKGDCM_NAME}Python PROPERTIES PREFIX "")
+    endif()
     # Python extension modules on Windows must have the extension ".pyd"
     # instead of ".dll" as of Python 2.5.  Older python versions do support
     # this suffix.

--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -70,14 +70,25 @@ else()
     vtkIOLegacy
     #vtksys
   )
-  set(vtkgdcm_COND_LIBS
-    vtkIOMPIImage
-    vtkInteractionStyle
-    vtkRenderingCore
-    vtkRenderingFreeType
-    vtkRenderingFreeTypeOpenGL
-    vtkRenderingOpenGL
-  )
+  if("${VTK_MAJOR_VERSION}" EQUAL 6)
+    set(vtkgdcm_COND_LIBS
+      vtkIOMPIImage
+      vtkInteractionStyle
+      vtkRenderingCore
+      vtkRenderingFreeType
+      vtkRenderingFreeTypeOpenGL
+      vtkRenderingOpenGL
+    )
+  else()
+    set(vtkgdcm_COND_LIBS
+      vtkIOMPIImage
+      vtkInteractionStyle
+      vtkRenderingCore
+      vtkRenderingFreeType
+      vtkRenderingFreeTypeOpenGL
+      vtkRenderingOpenGL2
+    )
+  endif()
   foreach(TMP_LIB ${VTK_LIBRARIES})
     foreach(TRY_LIB ${vtkgdcm_COND_LIBS})
       if("${TMP_LIB}" STREQUAL "${TRY_LIB}")

--- a/Utilities/VTK/Examples/Cxx/gdcmvolume.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmvolume.cxx
@@ -11,12 +11,15 @@
      PURPOSE.  See the above copyright notice for more information.
 
 =========================================================================*/
+#include "vtkVersion.h"
 #include "vtkGDCMImageReader.h"
 #include "vtkPiecewiseFunction.h"
 #include "vtkColorTransferFunction.h"
 #include "vtkVolume.h"
 #include "vtkVolumeProperty.h"
+#if VTK_MAJOR_VERSION < 7
 #include "vtkVolumeTextureMapper3D.h"
+#endif
 #include "vtkFixedPointVolumeRayCastMapper.h"
 #include "vtkInteractorStyleTrackballCamera.h"
 #include "vtkRenderer.h"

--- a/Utilities/VTK/vtkgdcm.py
+++ b/Utilities/VTK/vtkgdcm.py
@@ -42,7 +42,11 @@ if os.name == 'posix':
     #print "dl was imported"
     #sys.setdlopenflags(dl.RTLD_LAZY|dl.RTLD_GLOBAL)
     sys.setdlopenflags(dl.RTLD_NOW|dl.RTLD_GLOBAL)
-  from libvtkgdcmPython import *
+  try:
+    from libvtkgdcmPython import *
+  except ImportError:
+    # maybe vtk7
+    from vtkgdcmPython import *
   # revert:
   sys.setdlopenflags(orig_dlopen_flags)
   del sys, dl


### PR DESCRIPTION
Hi,

This pull request adapts GDCM to compile it with VTK7. Tested in MacOSX El capitain, Clang and VTK7. Also, tested in Ubuntu 16.04 , GCC 5.3.1, VTK 6.3. It compiled in all those envs. I've only tested it with python wrappers. 

The Changes:

- Replaced vtkRenderingOpenGL with vtkRenderingOpenGL2  When compiling with VTK7
- Removed the "lib" prefix from the vtkgdcm python module. Following this [tip](http://vtk.1045678.n5.nabble.com/python-wrapping-with-VTK-7-td5737442.html). Apparently, it was necessary because of a change in the new vtkWrapPython.
- Removed the include < vtkVolumeTextureMapper3D.h> when compiling with VTK7. Apparently, this header is deprecated.