### PR TITLE
Add SEMIAUTOMATIC value into gdcmSegment ALGOType enum

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
@@ -20,8 +20,9 @@ namespace gdcm
 {
 
 static const char * ALGOTypeStrings[] = {
-  "MANUAL",
   "AUTOMATIC",
+  "SEMIAUTOMATIC",
+  "MANUAL",
 
   0
 };

--- a/Source/MediaStorageAndFileFormat/gdcmSegment.h
+++ b/Source/MediaStorageAndFileFormat/gdcmSegment.h
@@ -37,8 +37,9 @@ public:
   typedef std::vector< SmartPointer< Surface > > SurfaceVector;
 
   typedef enum {
-    MANUAL = 0,
-    AUTOMATIC,
+    AUTOMATIC = 0,
+    SEMIAUTOMATIC,
+    MANUAL,
     ALGOType_END
   } ALGOType;
 


### PR DESCRIPTION
Hello,

Simple update to add SEMIAUTOMATIC value into gdcmSegment's ALGOType enum.

See: [DICOM Part 3 - Section C.8.20.4](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.20.4.html#table_C.8.20-4)