### PR TITLE
Add new Other Long (OL) VR support & Fix Other Double (OD) VR support

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmVR.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR.cxx
@@ -48,9 +48,11 @@ static const char *VRStrings[] = {
   "UN",        // 25
   "US",        // 26
   "UT",        // 27
-  "OB or OW",  // 28
-  "US or SS",  // 29
-  "US or SS or OW", //30
+  "OD",        // 28
+  "OL",        // 29
+  "OB or OW",  // 30
+  "US or SS",  // 31
+  "US or SS or OW", //32
   0
 };
 
@@ -82,7 +84,9 @@ static VR::VRType VRValue[] = {
     VR::UL ,
     VR::UN ,
     VR::US ,
-    VR::UT
+    VR::UT ,
+    VR::OD ,
+    VR::OL ,
 };
 
 bool VR::IsVRFile() const
@@ -103,7 +107,9 @@ bool VR::IsVRFile() const
   case VR::LO:
   case VR::LT:
   case VR::OB:
+  case VR::OD:
   case VR::OF:
+  case VR::OL:
   case VR::OW:
   case VR::PN:
   case VR::SH:
@@ -169,8 +175,14 @@ unsigned int VR::GetSizeof() const
   case VR::OB:
     size = sizeof(VRToType<VR::OB>::Type);
     break;
+  case VR::OD:
+    size = sizeof(VRToType<VR::OD>::Type);
+    break;
   case VR::OF:
     size = sizeof(VRToType<VR::OF>::Type);
+    break;
+  case VR::OL:
+    size = sizeof(VRToType<VR::OL>::Type);
     break;
   case VR::OW:
     size = sizeof(VRToType<VR::OW>::Type);
@@ -232,16 +244,16 @@ int VR::GetIndex(VRType vr)
     l = 0;
     break;
   case OB_OW:
-    l =  28;
-    break;
-  case US_SS:
-    l =  29;
-    break;
-  case US_SS_OW:
     l =  30;
     break;
+  case US_SS:
+    l =  31;
+    break;
+  case US_SS_OW:
+    l =  32;
+    break;
   case VR_END:
-    l = 31;
+    l = 33;
     break;
   default:
       {
@@ -264,7 +276,7 @@ const char *VR::GetVRStringFromFile(VRType vr)
 {
 #if 1
   static const int N = sizeof(VRValue) / sizeof(VRType);
-  assert( N == 28 );
+  assert( N == 30 );
   static VRType *start = VRValue;
   static VRType *end   = VRValue+N;
   const VRType *p =
@@ -299,7 +311,7 @@ VR::VRType VR::GetVRTypeFromFile(const char *vr)
  */
 #if 1
   static const int N = sizeof(VRValue) / sizeof(VRType);
-  assert( N == 28 );
+  assert( N == 30 );
   static const char **start = VRStrings+1;
   static const char **end   = VRStrings+N;
   //std::cerr << "VR=" << vr << std::endl;
@@ -356,16 +368,16 @@ VR::VRType VR::GetVRType(const char *vr)
       case 0:
         r = INVALID;
         break;
-      case 28:
+      case 30:
         r = OB_OW;
         break;
-      case 29:
+      case 31:
         r = US_SS;
         break;
-      case 30:
+      case 32:
         r = US_SS_OW;
         break;
-      case 31:
+      case 33:
         r = VR_END; assert(0);
         break;
       default:
@@ -386,7 +398,7 @@ bool VR::IsValid(const char *vr)
     // Use lazy evaluation instead of strncmp
     if (ref[0] == vr[0] && ref[1] == vr[1] )
       {
-      assert( i < 28 ); // FIXME
+      assert( i < 30 ); // FIXME
       return true;
       }
     }
@@ -429,7 +441,9 @@ VRTemplateCase(IS,rep) \
 VRTemplateCase(LO,rep) \
 VRTemplateCase(LT,rep) \
 VRTemplateCase(OB,rep) \
+VRTemplateCase(OD,rep) \
 VRTemplateCase(OF,rep) \
+VRTemplateCase(OL,rep) \
 VRTemplateCase(OW,rep) \
 VRTemplateCase(PN,rep) \
 VRTemplateCase(SH,rep) \

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR.h
@@ -72,6 +72,7 @@ public:
     OB = 4096,
     OD = 134217728, // 2^27
     OF = 8192,
+    OL = 268435456, // 2^28
     OW = 16384,
     PN = 32768,
     SH = 65536,
@@ -90,15 +91,15 @@ public:
     US_SS_OW = US | SS | OW,
     // The following do not have a VRString equivalent (ie cannot be found in PS 3.6)
     VL16 = AE | AS | AT | CS | DA | DS | DT | FD | FL | IS | LO | LT | PN | SH | SL | SS | ST | TM | UI | UL | US, // if( VR & VL16 ) => VR has its VL coded over 16bits
-    VL32 = OB | OW | OD | OF | SQ | UN | UT, // if( VR & VL32 ) => VR has its VL coded over 32bits
+    VL32 = OB | OW | OD | OF | OL | SQ | UN | UT, // if( VR & VL32 ) => VR has its VL coded over 32bits
     VRASCII = AE | AS | CS | DA | DS | DT | IS | LO | LT | PN | SH | ST | TM | UI | UT,
-    VRBINARY = AT | FL | FD | OB | OD | OF | OW | SL | SQ | SS | UL | UN | US, // FIXME: UN ?
+    VRBINARY = AT | FL | FD | OB | OD | OF | OL | OW | SL | SQ | SS | UL | UN | US, // FIXME: UN ?
     // PS 3.5:
-    // Data Elements with a VR of SQ, OD, OF, OW, OB or UN shall always have a Value Multiplicity of one.
+    // Data Elements with a VR of SQ, OD, OF, OL, OW, OB or UN shall always have a Value Multiplicity of one.
     // GDCM is adding a couple more: AS, LT, ST, UT
-    VR_VM1 = AS | LT | ST | UT | SQ | OF | OD | OW | OB | UN, // All those VR have a VM1
+    VR_VM1 = AS | LT | ST | UT | SQ | OF | OL | OD | OW | OB | UN, // All those VR have a VM1
     VRALL = VRASCII | VRBINARY,
-    VR_END = UT+1  // Invalid VR, need to be max(VRType)+1
+    VR_END = OL+1  // Invalid VR, need to be max(VRType)+1
   } VRType;
 
   static const char *GetVRString(VRType vr);
@@ -281,7 +282,9 @@ TYPETOENCODING(IS,VRASCII ,int32_t)
 TYPETOENCODING(LO,VRASCII ,LOComp)
 TYPETOENCODING(LT,VRASCII ,LTComp)
 TYPETOENCODING(OB,VRBINARY,uint8_t)
+TYPETOENCODING(OD,VRBINARY,double)
 TYPETOENCODING(OF,VRBINARY,float)
+TYPETOENCODING(OL,VRBINARY,uint32_t)
 TYPETOENCODING(OW,VRBINARY,uint16_t)
 TYPETOENCODING(PN,VRASCII ,PNComp)
 TYPETOENCODING(SH,VRASCII ,SHComp)
@@ -317,7 +320,9 @@ inline unsigned int VR::GetSize() const
     VRTypeTemplateCase(LO)
     VRTypeTemplateCase(LT)
     VRTypeTemplateCase(OB)
+    VRTypeTemplateCase(OD)
     VRTypeTemplateCase(OF)
+    VRTypeTemplateCase(OL)
     VRTypeTemplateCase(OW)
     VRTypeTemplateCase(PN)
     VRTypeTemplateCase(SH)

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestAttribute1.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestAttribute1.cxx
@@ -180,6 +180,7 @@ int TestAttributeIS()
 int TestAttributeLO() { return 0; }
 int TestAttributeLT() { return 0; }
 int TestAttributeOB() { return 0; }
+int TestAttributeOD() { return 0; }
 int TestAttributeOF()
 {
   gdcm::DataSet ds;
@@ -199,6 +200,7 @@ int TestAttributeOF()
 
   return 0;
 }
+int TestAttributeOL() { return 0; }
 int TestAttributeOW() { return 0; }
 int TestAttributePN() { return 0; }
 int TestAttributeSH() { return 0; }
@@ -230,7 +232,9 @@ int TestAttribute1(int , char *[])
   numerrors += TestAttributeLO();
   numerrors += TestAttributeLT();
   numerrors += TestAttributeOB();
+  numerrors += TestAttributeOD();
   numerrors += TestAttributeOF();
+  numerrors += TestAttributeOL();
   numerrors += TestAttributeOW();
   numerrors += TestAttributePN();
   numerrors += TestAttributeSH();

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestVR.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestVR.cxx
@@ -124,6 +124,12 @@ int TestValue()
   vr = gdcm::VR::UT; // = 67108864,
   if( (int)vr != (1 << k++) )
     return 1;
+  vr = gdcm::VR::OD; // = 134217728,
+  if( (int)vr != (1 << k++) )
+    return 1;
+  vr = gdcm::VR::OL; // = 268435456,
+  if( (int)vr != (1 << k++) )
+    return 1;
 
   return 0;
 }


### PR DESCRIPTION
Hi guys,

I tried to make a patch to integrate the new `Other Long (OL)` VR into the gdcmVR class.
As `Other Double (OD)` VR was only partially supported, I tried to fix that as well.

See: [DICOM Part 5 - Section 6.2](http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html)

If you have any comments or improvement requests, do not hesitate to give me feedbacks.


Thanks,
Clément