### PR TITLE
Add Anatomic Region Modifiers and Property Type Modifiers into gdcmSegment

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
@@ -71,8 +71,10 @@ Segment::Segment():
   SegmentLabel(""),
   SegmentDescription(""),
   AnatomicRegion(),
+  AnatomicRegionModifiers(),
   PropertyCategory(),
   PropertyType(),
+  PropertyTypeModifiers(),
   SegmentAlgorithmType(ALGOType_END),
   SegmentAlgorithmName(""),
   SurfaceCount(0),
@@ -131,6 +133,21 @@ void Segment::SetAnatomicRegion(SegmentHelper::BasicCodedEntry const & BSE)
   AnatomicRegion.CM   = BSE.CM;
 }
 
+Segment::BasicCodedEntryVector const & Segment::GetAnatomicRegionModifiers() const
+{
+  return AnatomicRegionModifiers;
+}
+
+Segment::BasicCodedEntryVector & Segment::GetAnatomicRegionModifiers()
+{
+  return AnatomicRegionModifiers;
+}
+
+void Segment::SetAnatomicRegionModifiers(BasicCodedEntryVector const & BSEV)
+{
+    AnatomicRegionModifiers = BSEV;
+}
+
 SegmentHelper::BasicCodedEntry const & Segment::GetPropertyCategory() const
 {
   return PropertyCategory;
@@ -163,6 +180,21 @@ void Segment::SetPropertyType(SegmentHelper::BasicCodedEntry const & BSE)
   PropertyType.CV   = BSE.CV;
   PropertyType.CSD  = BSE.CSD;
   PropertyType.CM   = BSE.CM;
+}
+
+Segment::BasicCodedEntryVector const & Segment::GetPropertyTypeModifiers() const
+{
+  return PropertyTypeModifiers;
+}
+
+Segment::BasicCodedEntryVector & Segment::GetPropertyTypeModifiers()
+{
+  return PropertyTypeModifiers;
+}
+
+void Segment::SetPropertyTypeModifiers(BasicCodedEntryVector const & BSEV)
+{
+    PropertyTypeModifiers = BSEV;
 }
 
 Segment::ALGOType Segment::GetSegmentAlgorithmType() const

--- a/Source/MediaStorageAndFileFormat/gdcmSegment.h
+++ b/Source/MediaStorageAndFileFormat/gdcmSegment.h
@@ -35,6 +35,7 @@ class GDCM_EXPORT Segment : public Object
 public:
 
   typedef std::vector< SmartPointer< Surface > > SurfaceVector;
+  typedef std::vector< SegmentHelper::BasicCodedEntry > BasicCodedEntryVector;
 
   typedef enum {
     AUTOMATIC = 0,
@@ -65,6 +66,10 @@ public:
   SegmentHelper::BasicCodedEntry & GetAnatomicRegion();
   void SetAnatomicRegion(SegmentHelper::BasicCodedEntry const & BSE);
 
+  BasicCodedEntryVector const & GetAnatomicRegionModifiers() const;
+  BasicCodedEntryVector & GetAnatomicRegionModifiers();
+  void SetAnatomicRegionModifiers(BasicCodedEntryVector const & BSEV);
+
   SegmentHelper::BasicCodedEntry const & GetPropertyCategory() const;
   SegmentHelper::BasicCodedEntry & GetPropertyCategory();
   void SetPropertyCategory(SegmentHelper::BasicCodedEntry const & BSE);
@@ -72,6 +77,10 @@ public:
   SegmentHelper::BasicCodedEntry const & GetPropertyType() const;
   SegmentHelper::BasicCodedEntry & GetPropertyType();
   void SetPropertyType(SegmentHelper::BasicCodedEntry const & BSE);
+
+  BasicCodedEntryVector const & GetPropertyTypeModifiers() const;
+  BasicCodedEntryVector & GetPropertyTypeModifiers();
+  void SetPropertyTypeModifiers(BasicCodedEntryVector const & BSEV);
 
   ALGOType GetSegmentAlgorithmType() const;
   void SetSegmentAlgorithmType(ALGOType type);
@@ -102,10 +111,14 @@ protected :
 
   // General Anatomic Region
   SegmentHelper::BasicCodedEntry AnatomicRegion;
+  // General Anatomic Region Modifier
+  BasicCodedEntryVector AnatomicRegionModifiers;
   // Property Category Code
   SegmentHelper::BasicCodedEntry PropertyCategory;
   // Property Type Code
   SegmentHelper::BasicCodedEntry PropertyType;
+  // Property Type Modifier Code
+  BasicCodedEntryVector PropertyTypeModifiers;
 
   //0062 0008 CS 1 Segment Algorithm Type
   ALGOType        SegmentAlgorithmType;

--- a/Source/MediaStorageAndFileFormat/gdcmSegmentReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegmentReader.cxx
@@ -145,6 +145,51 @@ bool SegmentReader::ReadSegments()
   return res;
 }
 
+
+Segment::BasicCodedEntryVector readCodeSequenceMacroAttributes(const Tag & tag, const DataSet & dataset)
+{
+  Segment::BasicCodedEntryVector result;
+
+  if(dataset.FindDataElement(tag))
+  {
+    SmartPointer<SequenceOfItems> sequence = dataset.GetDataElement(tag).GetValueAsSQ();
+
+    SequenceOfItems::Iterator it = sequence->Begin();
+    for(; it != sequence->End(); ++it)
+    {
+      const Item & item = *it;
+      const DataSet & itemDataSet = item.GetNestedDataSet();
+
+      SegmentHelper::BasicCodedEntry entry;
+
+      // Code Value (Type 1C)
+      Attribute<0x0008, 0x0100> codeValueAttribute;
+      codeValueAttribute.SetFromDataSet(itemDataSet);
+      entry.CV = codeValueAttribute.GetValue();
+
+      // Coding Scheme Designator (Type 1C)
+      Attribute<0x0008, 0x0102> codingSchemeDesignatorAttribute;
+      codingSchemeDesignatorAttribute.SetFromDataSet(itemDataSet);
+      entry.CSD = codingSchemeDesignatorAttribute.GetValue();
+
+      // Coding Scheme Version (Type 1C)
+      Attribute<0x0008, 0x0103> codingSchemeVersionAttribute;
+      codingSchemeVersionAttribute.SetFromDataSet(itemDataSet);
+      entry.CSV = codingSchemeVersionAttribute.GetValue();
+
+      // Code Meaning (Type 1)
+      Attribute<0x0008, 0x0104> codeMeaningAttribute;
+      codeMeaningAttribute.SetFromDataSet(itemDataSet);
+      entry.CM = codeMeaningAttribute.GetValue();
+
+      result.push_back(entry);
+    }
+  }
+
+  return result;
+}
+
+
 bool SegmentReader::ReadSegment(const Item & segmentItem, const unsigned int idx)
 {
   SmartPointer< Segment > segment   = new Segment;
@@ -191,101 +236,68 @@ bool SegmentReader::ReadSegment(const Item & segmentItem, const unsigned int idx
   if (surfaceCount > 0
    || rootDs.FindDataElement( Tag(0x0066, 0x0002) ))
   {
-    //*****   GENERAL ANATOMY MANDATORY MACRO ATTRIBUTES   *****//
-    // Anatomic Region Sequence (0008,2218) Type 1
-    if( segmentDS.FindDataElement( Tag(0x0008, 0x2218) ) )
+
+    //Basic Coded Entries in each sequences
+    Segment::BasicCodedEntryVector basicCodedEntries;
+
+    // Anatomic Region Sequence (Type 3)
+    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0008, 0x2218), segmentDS);
+    if(!basicCodedEntries.empty())
     {
-      SmartPointer<SequenceOfItems> anatRegSQ = segmentDS.GetDataElement( Tag(0x0008, 0x2218) ).GetValueAsSQ();
-
-      if (anatRegSQ->GetNumberOfItems() > 0)  // Only one item is a type 1
+      segment->SetAnatomicRegion(basicCodedEntries[0]);
+      // Only a single Item is permitted in this Sequence
+      if(basicCodedEntries.size() > 1)
       {
-        const Item &    anatRegItem = anatRegSQ->GetItem(1);
-        const DataSet & anatRegDS   = anatRegItem.GetNestedDataSet();
-
-        //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-        SegmentHelper::BasicCodedEntry & anatReg = segment->GetAnatomicRegion();
-
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetFromDataSet( anatRegDS );
-        anatReg.CV = codeValueAt.GetValue();
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetFromDataSet( anatRegDS );
-        anatReg.CSD = codingSchemeAt.GetValue();
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetFromDataSet( anatRegDS );
-        anatReg.CM = codeMeaningAt.GetValue();
+        gdcmWarningMacro("Only a single Item is permitted in Anatomic Region Sequence, other items will be ignored");
       }
     }
-    // else assert? return false? gdcmWarning?
 
-    //*****   Segmented Property Category Code Sequence   *****//
-    // Segmented Property Category Code Sequence (0062,0003) Type 1
-    if( segmentDS.FindDataElement( Tag(0x0062, 0x0003) ) )
+    // Anatomic Region Modifier Sequence (Type 3)
+    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0008, 0x2220), segmentDS);
+    if(!basicCodedEntries.empty())
     {
-      SmartPointer<SequenceOfItems> propCatSQ = segmentDS.GetDataElement( Tag(0x0062, 0x0003) ).GetValueAsSQ();
+      segment->SetAnatomicRegionModifiers(basicCodedEntries);
+    }
 
-      if (propCatSQ->GetNumberOfItems() > 0)  // Only one item is a type 1
+    // Segmented Property Category Code Sequence (Type 1)
+    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x0003), segmentDS);
+    if(!basicCodedEntries.empty())
+    {
+      segment->SetPropertyCategory(basicCodedEntries[0]);
+      // Only a single Item shall be included in this Sequence
+      if(basicCodedEntries.size() > 1)
       {
-        const Item &    propCatItem = propCatSQ->GetItem(1);
-        const DataSet & propCatDS   = propCatItem.GetNestedDataSet();
-
-        //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-        SegmentHelper::BasicCodedEntry & propCat = segment->GetPropertyCategory();
-
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetFromDataSet( propCatDS );
-        propCat.CV = codeValueAt.GetValue();
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetFromDataSet( propCatDS );
-        propCat.CSD = codingSchemeAt.GetValue();
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetFromDataSet( propCatDS );
-        propCat.CM = codeMeaningAt.GetValue();
+        gdcmWarningMacro("Only a single Item shall be included in Segmented Property Category Code Sequence, other items will be ignored");
       }
     }
-    // else assert? return false? gdcmWarning?
-
-    //*****   Segmented Property Type Code Sequence   *****//
-    // Segmented Property Type Code Sequence (0062,000F) Type 1
-    if( segmentDS.FindDataElement( Tag(0x0062, 0x000F) ) )
+    else
     {
-      SmartPointer<SequenceOfItems> propTypSQ = segmentDS.GetDataElement( Tag(0x0062, 0x000F) ).GetValueAsSQ();
+        gdcmWarningMacro("No Item have been found in Segmented Property Category Code Sequence.");
+    }
 
-      if (propTypSQ->GetNumberOfItems() > 0)  // Only one item is a type 1
+    // Segmented Property Type Code Sequence (Type 1)
+    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x000F), segmentDS);
+    if(!basicCodedEntries.empty())
+    {
+      segment->SetPropertyType(basicCodedEntries[0]);
+      // Only a single Item shall be included in this Sequence
+      if(basicCodedEntries.size() > 1)
       {
-        const Item &    propTypItem = propTypSQ->GetItem(1);
-        const DataSet & propTypDS   = propTypItem.GetNestedDataSet();
-
-        //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-        SegmentHelper::BasicCodedEntry & propTyp = segment->GetPropertyType();
-
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetFromDataSet( propTypDS );
-        propTyp.CV = codeValueAt.GetValue();
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetFromDataSet( propTypDS );
-        propTyp.CSD = codingSchemeAt.GetValue();
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetFromDataSet( propTypDS );
-        propTyp.CM = codeMeaningAt.GetValue();
+        gdcmWarningMacro("Only a single Item shall be included in Segmented Property Type Code Sequence, other items will be ignored");
       }
     }
-    // else assert? return false? gdcmWarning?
+    else
+    {
+        gdcmWarningMacro("No Item have been found in Segmented Property Type Code Sequence.");
+    }
+
+    // Segmented Property Type Modifier Sequence (Type 3)
+    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x0011), segmentDS);
+    if(!basicCodedEntries.empty())
+    {
+      segment->SetPropertyTypeModifiers(basicCodedEntries);
+    }
+
 
     // Referenced Surface Sequence
     const Tag refSurfaceSQTag(0x0066, 0x002B);

--- a/Source/MediaStorageAndFileFormat/gdcmSegmentReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegmentReader.cxx
@@ -233,8 +233,7 @@ bool SegmentReader::ReadSegment(const Item & segmentItem, const unsigned int idx
   segment->SetSurfaceCount( surfaceCount );
 
   // Check if there is a Surface Segmentation Module
-  if (surfaceCount > 0
-   || rootDs.FindDataElement( Tag(0x0066, 0x0002) ))
+  if (surfaceCount > 0 || rootDs.FindDataElement(Tag(0x0066, 0x0002)))
   {
 
     //Basic Coded Entries in each sequences
@@ -250,14 +249,19 @@ bool SegmentReader::ReadSegment(const Item & segmentItem, const unsigned int idx
       {
         gdcmWarningMacro("Only a single Item is permitted in Anatomic Region Sequence, other items will be ignored");
       }
+
+      SmartPointer<SequenceOfItems> sequence = segmentDS.GetDataElement(Tag(0x0008, 0x2218)).GetValueAsSQ();
+      Item& item = sequence->GetItem(1);
+      DataSet& itemDataSet = item.GetNestedDataSet();
+
+      // Anatomic Region Modifier Sequence (Type 3)
+      basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0008, 0x2220), itemDataSet);
+      if(!basicCodedEntries.empty())
+      {
+          segment->SetAnatomicRegionModifiers(basicCodedEntries);
+      }
     }
 
-    // Anatomic Region Modifier Sequence (Type 3)
-    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0008, 0x2220), segmentDS);
-    if(!basicCodedEntries.empty())
-    {
-      segment->SetAnatomicRegionModifiers(basicCodedEntries);
-    }
 
     // Segmented Property Category Code Sequence (Type 1)
     basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x0003), segmentDS);
@@ -285,18 +289,23 @@ bool SegmentReader::ReadSegment(const Item & segmentItem, const unsigned int idx
       {
         gdcmWarningMacro("Only a single Item shall be included in Segmented Property Type Code Sequence, other items will be ignored");
       }
+
+      SmartPointer<SequenceOfItems> sequence = segmentDS.GetDataElement(Tag(0x0062, 0x000F)).GetValueAsSQ();
+      Item& item = sequence->GetItem(1);
+      DataSet& itemDataSet = item.GetNestedDataSet();
+
+      // Segmented Property Type Modifier Sequence (Type 3)
+      basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x0011), itemDataSet);
+      if(!basicCodedEntries.empty())
+      {
+          segment->SetPropertyTypeModifiers(basicCodedEntries);
+      }
     }
     else
     {
         gdcmWarningMacro("No Item have been found in Segmented Property Type Code Sequence.");
     }
 
-    // Segmented Property Type Modifier Sequence (Type 3)
-    basicCodedEntries = readCodeSequenceMacroAttributes(Tag(0x0062, 0x0011), segmentDS);
-    if(!basicCodedEntries.empty())
-    {
-      segment->SetPropertyTypeModifiers(basicCodedEntries);
-    }
 
 
     // Referenced Surface Sequence

--- a/Source/MediaStorageAndFileFormat/gdcmSegmentWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegmentWriter.cxx
@@ -61,6 +61,84 @@ void SegmentWriter::SetSegments(SegmentVector & segments)
   Segments = segments;
 }
 
+
+void writeCodeSequenceMacroAttributes(const SegmentHelper::BasicCodedEntry & entry,
+                                      const Tag & tag,
+                                      DataSet & dataset,
+                                      bool severalItemsAllowed)
+{
+  SmartPointer<SequenceOfItems> sequence;
+
+  // If the sequence does not exist, we create it
+  if(!dataset.FindDataElement(tag))
+  {
+    sequence = new SequenceOfItems();
+    DataElement dataElement( tag );
+    dataElement.SetVR( VR::SQ );
+    dataElement.SetValue(*sequence);
+    dataElement.SetVLToUndefined();
+    dataset.Insert(dataElement);
+  }
+
+  // Retrieve the sequence from the dataset
+  sequence = dataset.GetDataElement(tag).GetValueAsSQ();
+
+  // Check if an item is already present in the sequence
+  if (!severalItemsAllowed && sequence->GetNumberOfItems() > 0)
+  {
+    // Obviously the user has already added an item to the sequence
+    // Let's assume the user knows what he does
+    return;
+  }
+
+  // Fill the Sequence
+  sequence->SetLengthToUndefined();
+
+  Item item;
+  item.SetVLToUndefined();
+  DataSet & itemDataSet = item.GetNestedDataSet();
+
+  // Code Sequence Macro Attributes
+  {
+    // Code Value (Type 1C)
+    Attribute<0x0008, 0x0100> codeValueAttribute;
+    codeValueAttribute.SetValue(entry.CV);
+    itemDataSet.Replace(codeValueAttribute.GetAsDataElement());
+
+    // Coding Scheme Designator (Type 1C)
+    Attribute<0x0008, 0x0102> codingSchemeDesignatorAttribute;
+    codingSchemeDesignatorAttribute.SetValue(entry.CSD);
+    itemDataSet.Replace(codingSchemeDesignatorAttribute.GetAsDataElement());
+
+    // Coding Scheme Version (Type 1C)
+    if(!entry.CSV.empty())
+    {
+      Attribute<0x0008, 0x0103> codingSchemeVersionAttribute;
+      codingSchemeVersionAttribute.SetValue(entry.CSV);
+      itemDataSet.Replace(codingSchemeVersionAttribute.GetAsDataElement());
+    }
+
+    // Code Meaning (Type 1)
+    Attribute<0x0008, 0x0104> codeMeaningAttribute;
+    codeMeaningAttribute.SetValue(entry.CM);
+    itemDataSet.Replace(codeMeaningAttribute.GetAsDataElement());
+  }
+
+  sequence->AddItem(item);
+
+}
+
+void writeCodeSequenceMacroAttributes(const Segment::BasicCodedEntryVector & entries,
+                                      const Tag & tag,
+                                      DataSet & dataset)
+{
+  Segment::BasicCodedEntryVector::const_iterator it = entries.begin();
+  for(; it != entries.end(); ++it)
+  {
+    writeCodeSequenceMacroAttributes(*it, tag, dataset, true);
+  }
+}
+
 bool SegmentWriter::PrepareWrite()
 {
   File &      file    = GetFile();
@@ -149,172 +227,54 @@ bool SegmentWriter::PrepareWrite()
     }
     else
     {
-    Attribute<0x0062, 0x0008> segmentAlgorithmTypeAt;
-    segmentAlgorithmTypeAt.SetValue( segmentAlgorithmType );
-    segmentDS.Replace( segmentAlgorithmTypeAt.GetAsDataElement() );
+      Attribute<0x0062, 0x0008> segmentAlgorithmTypeAt;
+      segmentAlgorithmTypeAt.SetValue( segmentAlgorithmType );
+      segmentDS.Replace( segmentAlgorithmTypeAt.GetAsDataElement() );
     }
 
-    //*****   GENERAL ANATOMY MANDATORY MACRO ATTRIBUTES   *****//
+
+    // General Anatomy Optional Macro Attributes
     {
-      const SegmentHelper::BasicCodedEntry & anatReg = segment->GetAnatomicRegion();
-      if (anatReg.IsEmpty())
+      // Anatomic Region Sequence (Type 3) - Only a single Item allowed
+      const SegmentHelper::BasicCodedEntry & anatomicRegion = segment->GetAnatomicRegion();
+      if(!anatomicRegion.IsEmpty())
       {
-        gdcmWarningMacro("Anatomic region not specified or incomplete");
+        writeCodeSequenceMacroAttributes(anatomicRegion, Tag(0x0008, 0x2218), segmentDS, false);
       }
 
-      // Anatomic Region Sequence (0008,2218) Type 1
-      SmartPointer<SequenceOfItems> anatRegSQ;
-      const Tag anatRegSQTag(0x0008, 0x2218);
-      if( !segmentDS.FindDataElement( anatRegSQTag ) )
+      // Anatomic Region Modifier Sequence (Type 3)
+      const Segment::BasicCodedEntryVector & anatomicRegionModifiers = segment->GetAnatomicRegionModifiers();
+      if(!anatomicRegionModifiers.empty())
       {
-        anatRegSQ = new SequenceOfItems;
-        DataElement detmp( anatRegSQTag );
-        detmp.SetVR( VR::SQ );
-        detmp.SetValue( *anatRegSQ );
-        detmp.SetVLToUndefined();
-        segmentDS.Insert( detmp );
-      }
-      anatRegSQ = segmentDS.GetDataElement( anatRegSQTag ).GetValueAsSQ();
-      anatRegSQ->SetLengthToUndefined();
-
-      // Fill the Anatomic Region Sequence
-      const size_t nbItems = anatRegSQ->GetNumberOfItems();
-      if (nbItems < 1)  // Only one item is a type 1
-      {
-        Item item;
-        item.SetVLToUndefined();
-        anatRegSQ->AddItem(item);
-      }
-
-      Item &    anatRegItem = anatRegSQ->GetItem(1);
-      DataSet & anatRegDS   = anatRegItem.GetNestedDataSet();
-
-      //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-      {
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetValue( anatReg.CV );
-        anatRegDS.Replace( codeValueAt.GetAsDataElement() );
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetValue( anatReg.CSD );
-        anatRegDS.Replace( codingSchemeAt.GetAsDataElement() );
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetValue( anatReg.CM );
-        anatRegDS.Replace( codeMeaningAt.GetAsDataElement() );
+        writeCodeSequenceMacroAttributes(anatomicRegionModifiers, Tag(0x0008, 0x2220), segmentDS);
       }
     }
 
-    //*****   Segmented Property Category Code Sequence   *****//
+    // Segmented Property Category Code Sequence (Type 1) - Only a single Item allowed
+    const SegmentHelper::BasicCodedEntry & propertyCategory = segment->GetPropertyCategory();
+    if(propertyCategory.IsEmpty())
     {
-      const SegmentHelper::BasicCodedEntry & propCat = segment->GetPropertyCategory();
-      if (propCat.IsEmpty())
-      {
-        gdcmWarningMacro("Segmented property category not specified or incomplete");
-      }
-
-      // Segmented Property Category Code Sequence (0062,0003) Type 1
-      SmartPointer<SequenceOfItems> propCatSQ;
-      const Tag propCatSQTag(0x0062, 0x0003);
-      if( !segmentDS.FindDataElement( propCatSQTag ) )
-      {
-        propCatSQ = new SequenceOfItems;
-        DataElement detmp( propCatSQTag );
-        detmp.SetVR( VR::SQ );
-        detmp.SetValue( *propCatSQ );
-        detmp.SetVLToUndefined();
-        segmentDS.Insert( detmp );
-      }
-      propCatSQ = segmentDS.GetDataElement( propCatSQTag ).GetValueAsSQ();
-      propCatSQ->SetLengthToUndefined();
-
-      // Fill the Segmented Property Category Code Sequence
-      const size_t nbItems = propCatSQ->GetNumberOfItems();
-      if (nbItems < 1)  // Only one item is a type 1
-      {
-        Item item;
-        item.SetVLToUndefined();
-        propCatSQ->AddItem(item);
-      }
-
-      Item &    propCatItem = propCatSQ->GetItem(1);
-      DataSet & propCatDS   = propCatItem.GetNestedDataSet();
-
-      //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-      {
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetValue( propCat.CV );
-        propCatDS.Replace( codeValueAt.GetAsDataElement() );
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetValue( propCat.CSD );
-        propCatDS.Replace( codingSchemeAt.GetAsDataElement() );
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetValue( propCat.CM );
-        propCatDS.Replace( codeMeaningAt.GetAsDataElement() );
-      }
+        gdcmWarningMacro("The property category is not specified or incomplete");
     }
+    writeCodeSequenceMacroAttributes(propertyCategory, Tag(0x0062, 0x0003), segmentDS, false);
 
-    //*****   Segmented Property Type Code Sequence   *****//
+
+    // Segmented Property Type Code Sequence (Type 1) - Only a single Item allowed
+    const SegmentHelper::BasicCodedEntry & propertyType = segment->GetPropertyType();
+    if(propertyType.IsEmpty())
     {
-      const SegmentHelper::BasicCodedEntry & propType = segment->GetPropertyType();
-      if (propType.IsEmpty())
-      {
-        gdcmWarningMacro("Segmented property type not specified or incomplete");
-      }
-
-      // Segmented Property Type Code Sequence (0062,000F) Type 1
-      SmartPointer<SequenceOfItems> propTypeSQ;
-      const Tag propTypeSQTag(0x0062, 0x000F);
-      if( !segmentDS.FindDataElement( propTypeSQTag ) )
-      {
-        propTypeSQ = new SequenceOfItems;
-        DataElement detmp( propTypeSQTag );
-        detmp.SetVR( VR::SQ );
-        detmp.SetValue( *propTypeSQ );
-        detmp.SetVLToUndefined();
-        segmentDS.Insert( detmp );
-      }
-      propTypeSQ = segmentDS.GetDataElement( propTypeSQTag ).GetValueAsSQ();
-      propTypeSQ->SetLengthToUndefined();
-
-      // Fill the Segmented Property Type Code Sequence
-      const size_t nbItems = propTypeSQ->GetNumberOfItems();
-      if (nbItems < 1)  // Only one item is a type 1
-      {
-        Item item;
-        item.SetVLToUndefined();
-        propTypeSQ->AddItem(item);
-      }
-
-      Item &    propTypeItem = propTypeSQ->GetItem(1);
-      DataSet & propTypeDS   = propTypeItem.GetNestedDataSet();
-
-      //*****   CODE SEQUENCE MACRO ATTRIBUTES   *****//
-      {
-        // Code Value (Type 1)
-        Attribute<0x0008, 0x0100> codeValueAt;
-        codeValueAt.SetValue( propType.CV );
-        propTypeDS.Replace( codeValueAt.GetAsDataElement() );
-
-        // Coding Scheme (Type 1)
-        Attribute<0x0008, 0x0102> codingSchemeAt;
-        codingSchemeAt.SetValue( propType.CSD );
-        propTypeDS.Replace( codingSchemeAt.GetAsDataElement() );
-
-        // Code Meaning (Type 1)
-        Attribute<0x0008, 0x0104> codeMeaningAt;
-        codeMeaningAt.SetValue( propType.CM );
-        propTypeDS.Replace( codeMeaningAt.GetAsDataElement() );
-      }
+        gdcmWarningMacro("The property type is not specified or incomplete");
     }
+    writeCodeSequenceMacroAttributes(propertyType, Tag(0x0062, 0x000F), segmentDS, false);
+
+
+    // Segmented Property Type Modifier Code Sequence (Type 3)
+    const Segment::BasicCodedEntryVector & propertyTypeModifiers = segment->GetPropertyTypeModifiers();
+    if(!propertyTypeModifiers.empty())
+    {
+        writeCodeSequenceMacroAttributes(propertyTypeModifiers, Tag(0x0062, 0x0011), segmentDS);
+    }
+
 
     //*****   Surface segmentation    *****//
     const unsigned long surfaceCount = segment->GetSurfaceCount();


### PR DESCRIPTION
- Add Anatomic Region Modifiers (0008,2220) and Property Type Modifiers (0062,0011) into gdcmSegment
- Update gdcmSegmentReader accordingly
- Update gdcmSegmentWriter accordingly

See:
- [Table C.8.20-4. Segment Description Macro Attributes](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.20.4.html#table_C.8.20-4)
- [Table 10-7. General Anatomy Optional Macro Attributes](http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_10.5.html#table_10-7)

