### PR TITLE
solve problem of compiler error C2555

### DIFF
--- a/Utilities/VTK/vtkImageMapToColors16.cxx
+++ b/Utilities/VTK/vtkImageMapToColors16.cxx
@@ -62,7 +62,7 @@ vtkImageMapToColors16::~vtkImageMapToColors16()
 }
 
 //----------------------------------------------------------------------------
-unsigned long vtkImageMapToColors16::GetMTime()
+unsigned long vtkImageMapToColors16::GDCM_GetMTime()
 {
   unsigned long t1, t2;
 

--- a/Utilities/VTK/vtkImageMapToColors16.h
+++ b/Utilities/VTK/vtkImageMapToColors16.h
@@ -81,7 +81,7 @@ public:
 
   // Description:
   // We need to check the modified time of the lookup table too.
-  virtual unsigned long GetMTime();
+  virtual unsigned long GDCM_GetMTime();
 
 protected:
   vtkImageMapToColors16();


### PR DESCRIPTION
A virtual function and a derived overriding function have identical parameter lists but different return types.An overriding function in a derived class cannot differ from a virtual function in a base class only by its return type.
I solved this problem by changing virual function's name.

virtual unsigned long GetMTime()  ->  virtual unsigned long GDCM_GetMTime();