### PR TITLE
Detect Windows with _WIN32 in socket++/fork.cpp

### DIFF
--- a/Utilities/socketxx/socket++/fork.cpp
+++ b/Utilities/socketxx/socket++/fork.cpp
@@ -8,7 +8,7 @@
 //
 // Version: 12Jan97 1.11
 
-#ifndef WIN32
+#ifndef _WIN32
 
 #include <config.h>
 


### PR DESCRIPTION
_WIN32 is more reliably defined, especially for MinGW.