### PR TITLE
Use GDCM_HAVE_BYTESWAP_H in gdcmSwapper.txx

### DIFF
--- a/Source/Common/gdcmSwapper.txx
+++ b/Source/Common/gdcmSwapper.txx
@@ -22,7 +22,7 @@
 #define bswap_32(X) _byteswap_ulong(X)
 #define bswap_64(X) _byteswap_uint64(X)
 
-#elif defined(__GLIBC__) || defined(__CYGWIN__) || defined(__ANDROID__) || defined(__EMSCRIPTEN__) // linux and al
+#elif defined(GDCM_HAVE_BYTESWAP_H)
 
 #include <endian.h>
 #include <byteswap.h>


### PR DESCRIPTION
This prevents build errors with the musl C library (used by Alpine linux),
which does not have a preprocessor macro defined.