### PR TITLE
Subdirectory 'doc' does not exist

### DIFF
--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -290,12 +290,6 @@ configure_file(
  )
 
 #-----------------------------------------------------------------------------
-# build documentation in doc subdir:
-if(BUILD_DOC)
-  add_subdirectory(doc)
-endif()
-
-#-----------------------------------------------------------------------------
 # Buld Testing
 option(BUILD_TESTING "Build the tests." OFF)
 if(BUILD_TESTING)


### PR DESCRIPTION
CMakeLists.txt was adding the subdirectory 'doc' if the CMake option BUILD_DOC
was set to ON. That directory does not exist, so this is removed.