### PR TITLE
COMP: Fix Python wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,23 +612,6 @@ if(GDCM_STANDALONE)
 endif()
 
 #-----------------------------------------------------------------------------
-# Special CMake Module required when doing Python Testing
-if(GDCM_STANDALONE)
-  if(BUILD_TESTING AND GDCM_WRAP_PYTHON)
-    include(${GDCM_SOURCE_DIR}/CMake/UsePythonTest.cmake)
-  endif()
-
-# Special CMake Module required when doing C# Testing
-  if(BUILD_TESTING AND GDCM_WRAP_CSHARP)
-    include(${GDCM_SOURCE_DIR}/CMake/UseCSharpTest.cmake)
-  endif()
-
-# Special CMake Module required when doing Java Testing
-  if(BUILD_TESTING AND GDCM_WRAP_JAVA)
-    include(${GDCM_SOURCE_DIR}/CMake/UseJavaTest.cmake)
-  endif()
-endif()
-#-----------------------------------------------------------------------------
 # Need pthread for the following class:
 CHECK_INCLUDE_FILE("pthread.h"      GDCM_HAVE_PTHREAD_H)
 

--- a/Wrapping/Csharp/CMakeLists.txt
+++ b/Wrapping/Csharp/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Special CMake Module required when doing C# Testing
+if(BUILD_TESTING AND GDCM_WRAP_CSHARP)
+  include(${GDCM_SOURCE_DIR}/CMake/UseCSharpTest.cmake)
+endif()
 # C# Cmd line options:
 # http://msdn.microsoft.com/en-us/library/ms379563(VS.80).aspx
 # http://msdn.microsoft.com/en-us/library/aa288436(VS.71).aspx

--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Special CMake Module required when doing Java Testing
+if(BUILD_TESTING AND GDCM_WRAP_JAVA)
+  include(${GDCM_SOURCE_DIR}/CMake/UseJavaTest.cmake)
+endif()
+
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 option(GDCM_AUTOLOAD_GDCMJNI "Automatically load gdcmjni" ON)

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Special CMake Module required when doing Python Testing
+if(BUILD_TESTING AND GDCM_WRAP_PYTHON)
+  include(${GDCM_SOURCE_DIR}/CMake/UsePythonTest.cmake)
+endif()
 # Try to rebuild wrapping a little more often:
 include_regular_expression("^(gdcm).*$")
 # TODO:
@@ -90,7 +94,15 @@ endif()
 # well no, you cannot, it get rid of some important flags, and make the _gdcm.so incompatible with
 # the other gdcm lib. bad !!!
 #set (SWIG_MODULE_${MODULE_NAME}_EXTRA_DEPS ${SWIG_MODULE_${MODULE_NAME}_EXTRA_DEPS} ${CMAKE_CURRENT_SOURCE_DIR}/docstrings.i)
-SWIG_ADD_MODULE(${GDCM_PYTHON_IMPLEMENTATION_NAME} python gdcmswig.i gdcmPythonFilter.cxx)
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+  SWIG_ADD_MODULE(${GDCM_PYTHON_IMPLEMENTATION_NAME} python gdcmswig.i gdcmPythonFilter.cxx)
+else()
+  SWIG_ADD_LIBRARY(
+    ${GDCM_PYTHON_IMPLEMENTATION_NAME}
+    LANGUAGE python
+    SOURCES gdcmswig.i gdcmPythonFilter.cxx
+  )
+endif()
 SWIG_LINK_LIBRARIES(${GDCM_PYTHON_IMPLEMENTATION_NAME} gdcmMEXD gdcmMSFF gdcmIOD)
 # Apparently on my UNIX, python module (/usr/lib/pyshared/pythonX.Y/*/*.so) do not explicitly
 # link to python libraries...Leave default to always link to python libraries since


### PR DESCRIPTION
================
 CMake Error at Wrapping/Python/CMakeLists.txt:150 (ADD_PYTHON_TEST):
   Unknown CMake command "ADD_PYTHON_TEST".

${GDCM_SOURCE_DIR}/CMake/UsePythonTest.cmake was not included
because set(GDCM_STANDALONE 0) was preventing the
include from occuring.

================
Also fixed warning:
 CMake Deprecation Warning at /usr/local/Cellar/cmake/3.10.1/share/cmake/Modules/UseSWIG.cmake:231 (message):
   SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
 Call Stack (most recent call first):
   Wrapping/Python/CMakeLists.txt:93 (SWIG_ADD_MODULE)