### PR TITLE
COMP: API changes for charls

### DIFF
--- a/Examples/Cxx/FixJAIBugJPEGLS.cxx
+++ b/Examples/Cxx/FixJAIBugJPEGLS.cxx
@@ -97,15 +97,16 @@ int main(int argc, char *argv[])
       }
 
     JlsParameters metadata;
-    if (JpegLsReadHeader(buffer, totalLen, &metadata) != OK)
+    char errorMsg[256+1]={'\0'};
+    if (JpegLsReadHeader(buffer, totalLen, &metadata, errorMsg) != charls::ApiResult::OK)
       {
-      std::cerr << "Cant parse jpegls" << std::endl;
+      std::cerr << "Cant parse jpegls: " << errorMsg << std::endl;
       return 1;
       }
 
     std::cout << metadata.width << std::endl;
     std::cout << metadata.height << std::endl;
-    std::cout << metadata.bitspersample << std::endl;
+    std::cout << metadata.bitsPerSample << std::endl;
 
     gdcm::PixelFormat const & pf = image.GetPixelFormat();
     std::cout << pf << std::endl;
@@ -152,7 +153,7 @@ int main(int argc, char *argv[])
     };
 
     const unsigned char *marker_lse = NULL;
-    switch( metadata.bitspersample )
+    switch( metadata.bitsPerSample )
       {
     case 13:
       marker_lse = marker_lse_13;
@@ -169,7 +170,7 @@ int main(int argc, char *argv[])
       }
     if( !marker_lse )
       {
-      std::cerr << "Cant handle: " << metadata.bitspersample << std::endl;
+      std::cerr << "Cant handle: " << metadata.bitsPerSample << std::endl;
       return 1;
       }
 
@@ -186,18 +187,18 @@ int main(int argc, char *argv[])
     size_t cbyteCompressed = vbuffer.size(); // updated legnth
 
     JlsParameters params;
-    JpegLsReadHeader(pbyteCompressed, cbyteCompressed, &params);
+    JpegLsReadHeader(pbyteCompressed, cbyteCompressed, &params, nullptr);
 
     std::vector<unsigned char> rgbyteOut;
     //rgbyteOut.resize( image.GetBufferLength() );
-    rgbyteOut.resize(params.height *params.width * ((params.bitspersample + 7)
+    rgbyteOut.resize(params.height *params.width * ((params.bitsPerSample + 7)
         / 8) * params.components);
 
-    JLS_ERROR result =
-      JpegLsDecode(&rgbyteOut[0], rgbyteOut.size(), pbyteCompressed, cbyteCompressed, &params );
-    if (result != OK)
+    CharlsApiResultType result =
+      JpegLsDecode(&rgbyteOut[0], rgbyteOut.size(), pbyteCompressed, cbyteCompressed, &params, errorMsg );
+    if (result != charls::ApiResult::OK)
       {
-      std::cerr << "Could not patch JAI-JPEGLS" << std::endl;
+      std::cerr << "Could not patch JAI-JPEGLS: " << errorMsg << std::endl;
       return 1;
       }
     rgbyteOutall.insert( rgbyteOutall.end(), rgbyteOut.begin(), rgbyteOut.end() );


### PR DESCRIPTION
Build error related API update of charls.

gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:100:9: error: no matching function for call to 'JpegLsReadHeader'
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:100:58: error: use of undeclared identifier 'OK'
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:108:27: error: no member named 'bitspersample' in 'JlsParameters'; did you mean 'bitsPerSample'?
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:155:22: error: no member named 'bitspersample' in 'JlsParameters'; did you mean 'bitsPerSample'?
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:172:48: error: no member named 'bitspersample' in 'JlsParameters'; did you mean 'bitsPerSample'?
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:189:5: error: no matching function for call to 'JpegLsReadHeader'
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:193:61: error: no member named 'bitspersample' in 'JlsParameters'; did you mean 'bitsPerSample'?
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:196:5: error: unknown type name 'JLS_ERROR'
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:197:7: error: no matching function for call to 'JpegLsDecode'
gdcm/Examples/Cxx/FixJAIBugJPEGLS.cxx:198:19: error: use of undeclared identifier 'OK'