### PR TITLE
Do not use absolute path to TestBigEndian.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,7 +634,7 @@ CHECK_INCLUDE_FILE("pthread.h"      GDCM_HAVE_PTHREAD_H)
 
 # Big endian thing:
 if(GDCM_STANDALONE)
-  include(${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
+  include(TestBigEndian)
   TEST_BIG_ENDIAN(GDCM_WORDS_BIGENDIAN)
 endif()
 

--- a/Utilities/gdcmmd5/CMakeLists.txt
+++ b/Utilities/gdcmmd5/CMakeLists.txt
@@ -28,7 +28,7 @@ endif ()
 # Optimized function needs to define:
 # ARCH_IS_BIG_ENDIAN
 # Big endian thing:
-#include (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
+#include (TestBigEndian)
 #TEST_BIG_ENDIAN(MD5_WORDS_BIGENDIAN)
 #set_source_files_properties(${MD5_SOURCES}
 #  PROPERTIES COMPILE_FLAGS -DARCH_IS_BIG_ENDIAN

--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -160,7 +160,7 @@ endif()
 
 #-----------------------------------------------------------------------------
 # Big endian test:
-include (${CMAKE_ROOT}/Modules/TestBigEndian.cmake)
+include (TestBigEndian)
 TEST_BIG_ENDIAN(OPJ_BIG_ENDIAN)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This prevents the use of an alternative TestBigEndian.cmake provided
by the Emscripten toolchain.

CC: @malaterre 