### PR TITLE
Jar file expects no lib prefix on Windows

### DIFF
--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -44,6 +44,10 @@ SWIG_LINK_LIBRARIES(gdcmjni gdcmMSFF
   #${JNI_LIBRARIES}
 )
 set_target_properties(${SWIG_MODULE_gdcmjni_REAL_NAME} PROPERTIES LINK_INTERFACE_LIBRARIES "")
+if (WIN32)
+  # disable lib prefix on windows with mingw
+  set_target_properties(${SWIG_MODULE_gdcmjni_REAL_NAME} PROPERTIES PREFIX "")
+endif()
 set_property(TARGET ${SWIG_MODULE_gdcmjni_REAL_NAME} PROPERTY NO_SONAME 1)
 
 # swig-java dummy run:


### PR DESCRIPTION
When compiling on Windows with MinGW, a prefix of "lib" is automatically prepended to the JNI library name.  However, the library loader in gdcmJNI assumes there is no lib prefix if running on Windows.

This modification manually disables the "lib" prefix when compiling for Windows.