### PR TITLE
Fixed errors with paths ended with a dot

### DIFF
--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -787,9 +787,9 @@ if(GDCM_WRAP_PYTHON)
     add_custom_command(
       TARGET    ${VTKGDCM_NAME}Python
       POST_BUILD
-      COMMAND   ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/vtkgdcm.py ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR}
+      COMMAND   ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/vtkgdcm.py ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR}/
       DEPENDS   "${CMAKE_CURRENT_SOURCE_DIR}/vtkgdcm.py"
-      COMMENT   "Copy vtkgdcm.py into ${LIBRARY_OUTPUT_PATH}"
+      COMMENT   "Copy vtkgdcm.py into ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR}/"
     )
     if(NOT GDCM_INSTALL_NO_LIBRARIES)
       install(TARGETS ${VTKGDCM_NAME}Python


### PR DESCRIPTION
Sometimes the `${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR}` path can be ended with a dot, which seems to be invalid for CMake (even though is perfectly working in Bash). e.g.

```
Copy vtkgdcm.py into /home/pepe/Downloads/gdcm-pypi/build/temp.linux-x86_64-3.6/bin/.
Error copying file "/home/pepe/Downloads/gdcm-pypi/GDCM/Utilities/VTK/vtkgdcm.py" to "/home/pepe/Downloads/gdcm-pypi/build/temp.linux-x86_64-3.6/bin/.".
make[3]: *** [Utilities/VTK/CMakeFiles/vtkgdcmPython.dir/build.make:107: /home/pepe/Downloads/gdcm-pypi/build/lib.linux-x86_64-3.6/vtkgdcmPython.so] Error 1
make[3]: *** Deleting file '/home/pepe/Downloads/gdcm-pypi/build/lib.linux-x86_64-3.6/vtkgdcmPython.so'
make[2]: *** [CMakeFiles/Makefile2:1298: Utilities/VTK/CMakeFiles/vtkgdcmPython.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1310: Utilities/VTK/CMakeFiles/vtkgdcmPython.dir/rule] Error 2
make: *** [Makefile:407: vtkgdcmPython] Error 2
error: command 'cmake' failed with exit status 2
```

No the other hand, a double slash, `//` is interpreted as a single slash. So better specifically appending a slash to the destination path