### PR TITLE
Building VTK applications if requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,6 +577,11 @@ endif()
 
 # Need to add_subdirectory in Source/Common before Wrapping
 # to have gdcmConfigure.h around
+if(GDCM_STANDALONE)
+  set(BUILD_APPLICATIONS ${GDCM_BUILD_APPLICATIONS})
+else()
+  set(BUILD_APPLICATIONS OFF)
+endif()
 add_subdirectory(Utilities)
 add_subdirectory(Source)
 


### PR DESCRIPTION
Tiny patch to fix an error that makes impossible to build gdcm2pnm, gdcm2vtk and gdcmviewer