### PR TITLE
Add GDCM_INSTALL_INCLUDE_DIR to the export interface

### DIFF
--- a/CMake/InstallMacros.cmake
+++ b/CMake/InstallMacros.cmake
@@ -41,6 +41,7 @@ macro(install_library library)
       EXPORT ${GDCM_TARGETS_NAME}
       RUNTIME DESTINATION ${GDCM_INSTALL_BIN_DIR} COMPONENT Applications
       LIBRARY DESTINATION ${GDCM_INSTALL_LIB_DIR} COMPONENT Libraries ${NAMELINK_SKIP}
+      INCLUDES DESTINATION ${GDCM_INSTALL_INCLUDE_DIR}
       ARCHIVE DESTINATION ${GDCM_INSTALL_LIB_DIR} COMPONENT DebugDevel
       )
     # need recent cmake: http://cmake.org/gitweb?p=cmake.git;a=commitdiff;h=cbe7e8fa


### PR DESCRIPTION
This helps to make a better relocatable package using only the IMPORTED target.

Without this fix, when compiling a target with GDCM, one have to explicitly set the include directories with:

```
find_package(GDCM REQUIRED)
target_include_directories(foo PUBLIC ${GDCM_INCLUDE_DIRS})
target_link_libraries(foo PUBLIC gdcmMSFF)
```

With this proposal, the `target_link_libraries` call is enough and automatically import the include directory :

```
find_package(GDCM REQUIRED)
target_link_libraries(foo PUBLIC gdcmMSFF)
```