### PR TITLE
Add python swig typemap for (const char *, gdcm::VL)

### DIFF
--- a/Wrapping/Python/gdcmswig.i
+++ b/Wrapping/Python/gdcmswig.i
@@ -22,6 +22,19 @@
 // http://matt.eifelle.com/2008/11/04/exposing-an-array-interface-with-swig-for-a-cc-structure/
 
 %module(docstring="A DICOM library",directors=1) gdcmswig
+
+%typemap(in) (const char* array, gdcm::VL length) {
+  $1 = PyString_AsString($input);
+  if ($1 == NULL) {
+    SWIG_exception_fail(SWIG_TypeError, "in method '$symname', argument $argnum expected byte string.");
+  }
+  Py_ssize_t length = PyString_Size($input);
+  if (length >= 0 && static_cast<uint32_t>(length) != static_cast<size_t>(length)) {
+    SWIG_exception_fail(SWIG_OverflowError, "in method '$symname', array in argument $argnum is too large.");
+  }
+  $2 = gdcm::VL(length);
+}
+
 // http://www.swig.org/Doc1.3/Warnings.html
 // "There is no option to suppress all SWIG warning messages."
 #pragma SWIG nowarn=302,303,312,362,383,389,401,503,504,509,510,514,516


### PR DESCRIPTION
Add a swig typemap for `(const char *, gdcm::VL)` that takes a byte string (i.e. `byte` in Python 3 and `str` in Python 2) to make it possible to use `DataElement::SetByteValue()` and `CSAElement::SetByteValue()` from Python 3.