### PR TITLE
Fix DataElement binary input

### DIFF
--- a/Examples/Python/CreateRAWStorage.py
+++ b/Examples/Python/CreateRAWStorage.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 #  f = gdcm.File()
 #  ds = f.GetDataSet()
   de = gdcm.DataElement( gdcm.Tag(0x0008,0x0016) )
-  de.SetByteValue( uid, gdcm.VL(len(uid)) )
+  de.SetByteStringValue( uid )
   vr = gdcm.VR( gdcm.VR.UI )
   de.SetVR( vr )
   ds.Replace( de )
@@ -138,7 +138,7 @@ if __name__ == "__main__":
 #
 #  uid = gen.Generate()
 #  de.SetTag( gdcm.Tag(0x0008,0x0018) )
-#  de.SetByteValue( uid, gdcm.VL(len(uid)) )
+#  de.SetByteStringValue( uid )
 #  ds.Insert( de )
 
   # init FMI now:
@@ -149,7 +149,7 @@ if __name__ == "__main__":
   #print fmi.GetDataSetTransferSyntax()
   #de.SetTag( gdcm.Tag(0x0002,0x0010) )
   #uid = "1.2.840.10008.1.2"
-  #de.SetByteValue( uid, gdcm.VL(len(uid)) )
+  #de.SetByteStringValue( uid )
   #fmi.Insert( de )
 #  f.SetHeader( r.GetFile().GetHeader() )
 

--- a/Examples/Python/DecompressImage.py
+++ b/Examples/Python/DecompressImage.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
   pixeldata = gdcm.DataElement( gdcm.Tag(0x7fe0,0x0010) )
   str1 = ir.GetBuffer()
   #print ir.GetBufferLength()
-  pixeldata.SetByteValue( str1, gdcm.VL( len(str1) ) )
+  pixeldata.SetByteStringValue( str1 )
   image.SetDataElement( pixeldata )
 
   w.SetFileName( file2 )

--- a/Examples/Python/FindAllPatientName.py
+++ b/Examples/Python/FindAllPatientName.py
@@ -29,7 +29,7 @@ tag = gdcm.Tag(0x10,0x10)
 de = gdcm.DataElement(tag)
 
 # Search all patient name where string match 'F*'
-de.SetByteValue('F*',gdcm.VL(2))
+de.SetByteStringValue('F*')
 
 ds = gdcm.DataSet()
 ds.Insert(de)

--- a/Examples/Python/ManipulateSequence.py
+++ b/Examples/Python/ManipulateSequence.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
           if nestedds2.FindDataElement( tcm ):
             cm = nestedds2.GetDataElement( tcm )
             mystr = "GDCM was here"
-            cm.SetByteValue( mystr, gdcm.VL( len(mystr) ) )
+            cm.SetByteStringValue( mystr )
 
   w = gdcm.Writer()
   w.SetFile( f )

--- a/Examples/Python/NewSequence.py
+++ b/Examples/Python/NewSequence.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
   # Create a dataelement
   de = gdcm.DataElement(gdcm.Tag(0x0010, 0x2180))
-  de.SetByteValue("Occupation", gdcm.VL(len("Occupation")))
+  de.SetByteStringValue("Occupation")
   de.SetVR(gdcm.VR(gdcm.VR.SH))
 
   # Create an item

--- a/Testing/Source/MediaStorageAndFileFormat/Python/TestModifyFields.py
+++ b/Testing/Source/MediaStorageAndFileFormat/Python/TestModifyFields.py
@@ -1,4 +1,4 @@
-############################################################################
+###########################################################################
 #
 #  Program: GDCM (Grassroots DICOM). A DICOM library
 #
@@ -35,15 +35,14 @@ def TestModifyFields(filename):
     de = ds.GetDataElement( replacetag )
     #print dir(de)
     patname = "This^is^an^example"
-    vl = gdcm.VL( len(patname) )
-    de.SetByteValue( patname, vl )
+    de.SetByteStringValue( patname )
 
   # let's insert a new dataelement
   # <entry group="0012" element="0062" vr="CS" vm="1" name="Patient Identity Removed"/>
   pir = gdcm.DataElement( gdcm.Tag(0x0012,0x0062) )
   pir.SetVR( gdcm.VR( gdcm.VR.CS ) ) # specify the VR explicitly
   yes = "YES"
-  pir.SetByteValue( yes, gdcm.VL(len(yes)) )
+  pir.SetByteStringValue( yes )
   ds.Insert( pir )
 
   # try again but pretend we don't know the VR
@@ -56,8 +55,8 @@ def TestModifyFields(filename):
   deid = gdcm.DataElement( deidmethod )
   deid.SetVR( dictel.GetVR() )
   methodstr = "Well known Company"
-  #deid.SetByteValue( methodstr, gdcm.VL(len(methodstr)) )
-  deid.SetByteValue( methodstr, gdcm.VL(len(methodstr)) )
+  #deid.SetByteStringValue( methodstr )
+  deid.SetByteStringValue( methodstr )
   ds.Insert( deid )
 
   #w = gdcm.Writer()

--- a/Wrapping/Python/gdcmswig.i
+++ b/Wrapping/Python/gdcmswig.i
@@ -328,7 +328,24 @@ EXTEND_CLASS_PRINT(gdcm::ByteValue)
 %include "gdcmSmartPointer.h"
 %template(SmartPtrSQ) gdcm::SmartPointer<gdcm::SequenceOfItems>;
 %template(SmartPtrFrag) gdcm::SmartPointer<gdcm::SequenceOfFragments>;
+%typemap(in) (const char* array, uint32_t length) {
+  $1 = PyString_AsString($input);
+  if ($1 == NULL) {
+    SWIG_exception_fail(SWIG_ArgError(SWIG_TypeError), "in method '$symname', argument $argnum expected byte string.");
+  }
+  Py_ssize_t length = PyString_Size($input);
+  if (static_cast<size_t>(length) > std::numeric_limits<uint32_t>::max()) {
+    SWIG_exception_fail(SWIG_ArgError(SWIG_OverflowError), "in method '$symname', array in argument $argnum is too large.");
+  }
+  $2 = static_cast<uint32_t>(length);
+}
 %include "gdcmDataElement.h"
+%extend gdcm::DataElement
+{
+    void SetByteStringValue(const char *array, uint32_t length) {
+        self->SetByteValue(array, gdcm::VL(length));
+    }
+}
 EXTEND_CLASS_PRINT(gdcm::DataElement)
 %include "gdcmItem.h"
 EXTEND_CLASS_PRINT(gdcm::Item)
@@ -449,6 +466,12 @@ EXTEND_CLASS_PRINT(gdcm::PDBHeader)
 EXTEND_CLASS_PRINT(gdcm::MrProtocol)
 %include "gdcmCSAElement.h"
 EXTEND_CLASS_PRINT(gdcm::CSAElement)
+%extend gdcm::CSAElement
+{
+    void SetByteStringValue(const char *array, uint32_t length) {
+        self->SetByteValue(array, gdcm::VL(length));
+    }
+}
 %include "gdcmCSAHeader.h"
 EXTEND_CLASS_PRINT(gdcm::CSAHeader)
 %include "gdcmSequenceOfFragments.h"

--- a/Wrapping/Python/gdcmswig.i
+++ b/Wrapping/Python/gdcmswig.i
@@ -22,19 +22,6 @@
 // http://matt.eifelle.com/2008/11/04/exposing-an-array-interface-with-swig-for-a-cc-structure/
 
 %module(docstring="A DICOM library",directors=1) gdcmswig
-
-%typemap(in) (const char* array, gdcm::VL length) {
-  $1 = PyString_AsString($input);
-  if ($1 == NULL) {
-    SWIG_exception_fail(SWIG_TypeError, "in method '$symname', argument $argnum expected byte string.");
-  }
-  Py_ssize_t length = PyString_Size($input);
-  if (length >= 0 && static_cast<uint32_t>(length) != static_cast<size_t>(length)) {
-    SWIG_exception_fail(SWIG_OverflowError, "in method '$symname', array in argument $argnum is too large.");
-  }
-  $2 = gdcm::VL(length);
-}
-
 // http://www.swig.org/Doc1.3/Warnings.html
 // "There is no option to suppress all SWIG warning messages."
 #pragma SWIG nowarn=302,303,312,362,383,389,401,503,504,509,510,514,516


### PR DESCRIPTION
Remove api-breaking `typemap` for `(const char *, gdcm::VL)`, extend `gdcm::CSAElement` and `gdcm::DataElement` with `SetByteStringValue(const char *, uint32_t)`, add a `typemap` for `(const char *, uint32_t)` that accepts Python 2 `str` and Python 3 `byte` data.
Change usage of `SetByteValue()` to `SetByteStringValue()` in tests and examples.