### PR TITLE
Add support to XRay3DAngiographicImageIOD and optional Slope/Intercept

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
@@ -911,8 +911,14 @@ std::vector<double> ImageHelper::GetRescaleInterceptSlopeValue(File const & f)
     {
     const Tag t1(0x5200,0x9229);
     const Tag t2(0x5200,0x9230);
+    const Tag t3(0x0018,0x9530); 
+      // t3: X-Ray 3D Angiographic Image Functional Group Macros defines
+      // Pixel Value Transformation Macro as User Option. Indeed, 
+      // Slope/Intercept have been found in X-Ray 3D Reconstruction Sequence
+      // sometimes.
     if( GetInterceptSlopeValueFromSequence(ds,t1, interceptslope)
-     || GetInterceptSlopeValueFromSequence(ds,t2, interceptslope) )
+     || GetInterceptSlopeValueFromSequence(ds,t2, interceptslope) 
+     || GetInterceptSlopeValueFromSequence(ds,t3, interceptslope) )
       {
       assert( interceptslope.size() == 2 );
       return interceptslope;


### PR DESCRIPTION
Have found that an interventional workspot from Philips writes the Slope/Intercept values inside the XRay3DReconstructionSequence. The [DCS](http://incenter.medical.philips.com/doclib/enc/fetch/2000/4504/577242/577256/588723/5144873/5144488/5144772/DICOM_Conformance_Statement_Interventional_Workspot_R1.3.pdf%3fnodeid%3d10953608%26vernum%3d1) doesn't give word about this decision.

Indeed, in the XRay3DReconstructionImageIOD, the multi-frame functional group doesn't define the Pixel Value Transformation as mandatory, but user option. 

This PR adds support to these specific DICOM files.