### PR TITLE
Return error from Writer::Write() if Ofstream fails to write

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmWriter.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmWriter.cxx
@@ -108,7 +108,7 @@ bool Writer::Write()
 		  return false;
 	  }
 
-    return true;//os;
+    return !os.fail();
     }
 
   try
@@ -159,7 +159,7 @@ bool Writer::Write()
     Ofstream->close();
     }
 
-  return true;
+  return !os.fail();
 }
 
 void Writer::SetFileName(const char *filename)


### PR DESCRIPTION
If writing to the `ofstream` in `Writer::Write()` fails for some reason (e.g., the target disk runs out of space), there is currently no way to know. This PR will cause `Writer::Write()` to return false if the `ofstream` encounters an error while writing.