### PR TITLE
BUG: crash with some JPEG-LS files (Weasis samples)

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
@@ -187,7 +187,7 @@ bool JPEGLSCodec::Decode(DataElement const &in, DataElement &out)
   if( NumberOfDimensions == 2 )
     {
     const SequenceOfFragments *sf = in.GetSequenceOfFragments();
-    assert( sf );
+    if (!sf) return false;
     size_t totalLen = sf->ComputeByteLength();
     char *buffer = new char[totalLen];
     sf->GetBuffer(buffer, totalLen);
@@ -205,15 +205,15 @@ bool JPEGLSCodec::Decode(DataElement const &in, DataElement &out)
   else if( NumberOfDimensions == 3 )
     {
     const SequenceOfFragments *sf = in.GetSequenceOfFragments();
-    assert( sf );
-    gdcmAssertAlwaysMacro( sf->GetNumberOfFragments() == Dimensions[2] );
+    if (!sf) return false;
+    if (sf->GetNumberOfFragments() != Dimensions[2]) return false;
     std::stringstream os;
     for(unsigned int i = 0; i < sf->GetNumberOfFragments(); ++i)
       {
       const Fragment &frag = sf->GetFragment(i);
       if( frag.IsEmpty() ) return false;
       const ByteValue *bv = frag.GetByteValue();
-      assert( bv );
+      if (!bv) return false;
       size_t totalLen = bv->GetLength();
       char *mybuffer = new char[totalLen];
 


### PR DESCRIPTION
Hello,
some JPEG-LS files (found on Weasis site) crash reader
in gdcmJPEGLSCodex.cxx, in Decode()
gdcmAssertAlwaysMacro( sf->GetNumberOfFragments() == Dimensions[2] );

[File 1](https://drive.google.com/file/d/1nsbq6VLaWf3ePFyUhZ-OOVkEJ5vrUWeK/view?usp=sharing)

[File 2](https://drive.google.com/file/d/1W-cl1-vXw0fZQgqXPBNP0RAeZgiqDc1K/view?usp=sharing)