### PR TITLE
PERF: readability container size empty

### DIFF
--- a/Examples/Cxx/DumpImageHeaderInfo.cxx
+++ b/Examples/Cxx/DumpImageHeaderInfo.cxx
@@ -58,7 +58,7 @@ std::istream & element::read( std::istream & is )
   os << str << " (" << l << ")" << std::endl;
   std::vector<char> bytes;
   bytes.resize( l - 16 );
-  if( bytes.size() )
+  if( !bytes.empty() )
     {
     is.read( &bytes[0], l - 16 );
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.cxx
@@ -44,7 +44,7 @@ std::string DataSet::GetPrivateCreator(const Tag &t) const
       std::string owner = std::string(bv->GetPointer(),bv->GetLength());
       // There should not be any trailing space character...
       // TODO: tmp.erase(tmp.find_last_not_of(' ') + 1);
-      while( owner.size() && owner[owner.size()-1] == ' ' )
+      while( !owner.empty() && owner[owner.size()-1] == ' ' )
         {
         // osirix/AbdominalCT/36382443
         owner.erase(owner.size()-1,1);
@@ -135,7 +135,7 @@ MediaStorage DataSet::GetMediaStorage() const
       }
     }
   // Paranoid check: if last character of a VR=UI is space let's pretend this is a \0
-  if( ts.size() )
+  if( !ts.empty() )
     {
     char &last = ts[ts.size()-1];
     if( last == ' ' )

--- a/Source/DataStructureAndEncodingDefinition/gdcmFileMetaInformation.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFileMetaInformation.cxx
@@ -878,7 +878,7 @@ std::string FileMetaInformation::GetMediaStorageAsString() const
       }
     }
   // Paranoid check: if last character of a VR=UI is space let's pretend this is a \0
-  if( ts.size() )
+  if( !ts.empty() )
     {
     char &last = ts[ts.size()-1];
     if( last == ' ' )

--- a/Source/MediaStorageAndFileFormat/gdcmBitmap.h
+++ b/Source/MediaStorageAndFileFormat/gdcmBitmap.h
@@ -121,7 +121,7 @@ public:
   const PhotometricInterpretation &GetPhotometricInterpretation() const;
   void SetPhotometricInterpretation(PhotometricInterpretation const &pi);
 
-  bool IsEmpty() const { return Dimensions.size() == 0; }
+  bool IsEmpty() const { return Dimensions.empty(); }
   void Clear();
 
   /// Return the length of the image after decompression


### PR DESCRIPTION
The emptiness of a container should be checked using the empty() method
instead of the size() method. It is not guaranteed that size() is a
constant-time function, and it is generally more efficient and also
shows clearer intent to use empty(). Furthermore some containers may
implement the empty() method but not implement the size() method. Using
empty() whenever possible makes it easier to switch to another container
in the future.

SRCDIR=/Users/johnsonhj/src/gdcm #My local SRC
BLDDIR=/Users/johnsonhj/src/gdcm-bld/ #My local BLD

cd /Users/johnsonhj/src/gdcm-bld/
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,readability-container-size-empty  -header-filter=.* -fix