### PR TITLE
Address CMP0042 MACOSX_RPATH warning with shared libraried

### DIFF
--- a/Utilities/gdcmcharls/CMakeLists.txt
+++ b/Utilities/gdcmcharls/CMakeLists.txt
@@ -9,9 +9,14 @@ string(TOLOWER ${CHARLS_NAMESPACE} CHARLS_LIBRARY_NAME)
 
 project(${CHARLS_NAMESPACE} CXX)
 
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
+foreach(p
+    CMP0042
+    CMP0063
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 #-----------------------------------------------------------------------------
 # CHARLS version number

--- a/Utilities/gdcmjpeg/CMakeLists.txt
+++ b/Utilities/gdcmjpeg/CMakeLists.txt
@@ -15,9 +15,14 @@ string(TOLOWER ${JPEG_NAMESPACE} JPEG_LIBRARY_NAME)
 
 project(${JPEG_NAMESPACE} C)
 
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
+foreach(p
+    CMP0042
+    CMP0063
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 # Do full dependency headers.
 include_regular_expression("^.*$")

--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -14,9 +14,15 @@ if(COMMAND CMAKE_POLICY)
   if (NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
     cmake_policy(SET CMP0042 NEW)
   endif()
-  if(POLICY CMP0063)
-    cmake_policy(SET CMP0063 NEW)
-  endif()
+
+  foreach(p
+      CMP0042
+      CMP0063
+      )
+    if(POLICY ${p})
+      cmake_policy(SET ${p} NEW)
+    endif()
+  endforeach()
 endif()
 
 if(NOT OPENJPEG_NAMESPACE)

--- a/Utilities/gdcmuuid/CMakeLists.txt
+++ b/Utilities/gdcmuuid/CMakeLists.txt
@@ -9,9 +9,14 @@ string(TOLOWER ${UUID_NAMESPACE} UUID_LIBRARY_NAME)
 
 project(${UUID_NAMESPACE} C)
 
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
+foreach(p
+    CMP0042
+    CMP0063
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 # Do full dependency headers.
 include_regular_expression("^.*$")

--- a/Utilities/socketxx/CMakeLists.txt
+++ b/Utilities/socketxx/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 2.8.7)
-if(POLICY CMP0022)
-  cmake_policy(SET CMP0022 NEW)
-endif()
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
+
+foreach(p
+    CMP0022
+    CMP0042
+    CMP0063 # CMake 3.3.2
+    )
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 # http://www.linuxhacker.at/socketxx
 if(NOT SOCKETXX_NAMESPACE)


### PR DESCRIPTION
When shared libraries are enabled in ITK the CMake CMP0042 warning
occour for several utility libraries. Additionally, there has been
runtime dependency loading issues too. Setting the policy to NEW
resolves both issues.