### PR TITLE
gdcminfo, gdcmpdf: Adapt to poppler-0.72.

### DIFF
--- a/Applications/Cxx/gdcminfo.cxx
+++ b/Applications/Cxx/gdcminfo.cxx
@@ -202,7 +202,7 @@ static std::string getInfoDate(Dict *infoDict, const char *key)
 #endif
     {
     const GooString* gs = obj.getString();
-    s = gs->getCString();
+    s = gs->c_str();
     if (s[0] == 'D' && s[1] == ':')
       {
       s += 2;

--- a/Applications/Cxx/gdcmpdf.cxx
+++ b/Applications/Cxx/gdcmpdf.cxx
@@ -50,7 +50,7 @@ static std::string getInfoDate(Dict *infoDict, const char *key)
 #endif
     {
     const GooString* gs = obj.getString();
-    s = gs->getCString();
+    s = gs->c_str();
     if (s[0] == 'D' && s[1] == ':')
       {
       s += 2;


### PR DESCRIPTION
Rename GooString::getCString to GooString::c_str (cf. https://poppler.freedesktop.org/releases.html).

Not sure if anything else is needed, e.g. some check for the currently installed poppler version?