### PR TITLE
FIX: Anonymize names of non-UID tags

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmAnonymizer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmAnonymizer.cxx
@@ -886,6 +886,15 @@ bool Anonymizer::BALCPProtect(DataSet &ds, Tag const & tag, IOD const & iod)
       {
       TagValueKey tvk;
       tvk.first = tag;
+      std::string tagValue;
+      if( !copy.IsEmpty() )
+        {
+        if( const ByteValue *bv = copy.GetByteValue() )
+          {
+          tagValue = std::string( bv->GetPointer(), bv->GetLength() );
+          }
+        }
+      tvk.second = tagValue;
 
       assert( dummyMapNonUIDTags.count( tvk ) == 0 || dummyMapNonUIDTags.count( tvk ) == 1 );
       if( dummyMapNonUIDTags.count( tvk ) == 0 )


### PR DESCRIPTION
Currently gdcmanon does not create dummy names of Patient's Name, Patient ID, Study ID and Series Number, despite of these tags are explicitly listed to be prevented (see `gdcmAnonymizer.cxx` lie 761 and 804-809). This commit fixes incoplete initialization of a dictionary `dummyMapNonUIDTags`.

Behavior of `gdcmanon --de-identify` before the patch:
```
$ gdcmdump outfile_orig | grep -E '0010,0010|0010,0020|0020,0010'
(0010,0010) PN (no value)                                         # 0,1 Patient's Name
(0010,0020) LO (no value)                                         # 0,1 Patient ID
(0020,0010) SH (no value)                                         # 0,1 Study ID
```
After the patch:

```
$ gdcmdump outfile_patch | grep -E '0010,0010|0010,0020|0020,0010'
(0010,0010) PN [3b304717c479a4272b707048dbe7ee63]                 # 32,1 Patient's Name
(0010,0020) LO [5d82026296e8b502d8eb9c5fa87d5b12]                 # 32,1 Patient ID
(0020,0010) SH [a569398d13eb87b14276380d2921ddbc]                 # 32,1 Study ID
```