### PR TITLE
BUG: rle2img.cxx example fails

### DIFF
--- a/Examples/Cxx/rle2img.cxx
+++ b/Examples/Cxx/rle2img.cxx
@@ -149,8 +149,8 @@ int main(int argc, char *argv [])
   if( !isrle )
     {
     std::cerr << "Tamar Compression Type is not PMSCT_RLE1" << std::endl;
-	return 1;
-	}
+    return 1;
+    }
 
   gdcm::Attribute<0x0028,0x0010> at1;
   at1.SetFromDataSet( ds );
@@ -170,7 +170,7 @@ int main(int argc, char *argv [])
     if( compressionpixeldata.IsEmpty() )
       {
       std::cerr << "ELSCINT1 Pixel Data is empty" << std::endl;
-	  return 1;
+      return 1;
       }
     const gdcm::ByteValue * bv2 = compressionpixeldata.GetByteValue();
     // If standard pixel data element does not exist, create it
@@ -212,12 +212,12 @@ int main(int argc, char *argv [])
     if( compressionpixeldata.IsEmpty() )
       {
       std::cerr << "Pixel Data is empty" << std::endl;
-	  return 1;
+      return 1;
       }
     const gdcm::ByteValue * bv2 = compressionpixeldata.GetByteValue();
     if( bv2->GetLength() == at1l )
       {
-	  // Handle special case that is not compressed
+      // Handle special case that is not compressed
       ;;
       }
     else


### PR DESCRIPTION
rle2img valuable example works again with ELSCINT1 private pixel data element. The core of the example _delta_decode_ function is not modified. Unfortunately i could not test with PMSCT_RLE1 compressed standard pixel data element, no example files, usually i don't do PRs without a lot of testing, but in particular case there is no choice. 

BWT, it is absolutely not a problem for me if you will reject this PR and recover the version previous to buggy commit

Best regards

**Edit**: in 2nd commit only removed tabs, sorry