### PR TITLE
output RGB for Jpeg YBR_FULL_422

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmJPEGBITSCodec.hxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGBITSCodec.hxx
@@ -855,8 +855,7 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         //cinfo.jpeg_color_space = JCS_UNKNOWN;
         //cinfo.out_color_space = JCS_UNKNOWN;
         }
-      if( GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL
-      || GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL_422 )
+      if( GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL )
         {
         cinfo.jpeg_color_space = JCS_UNKNOWN;
         cinfo.out_color_space = JCS_UNKNOWN;


### PR DESCRIPTION
Output RGB for Jpeg YBR_FULL_422 by default, s. discussion in  [ITK PR 1240](https://github.com/InsightSoftwareConsortium/ITK/pull/1240)