### PR TITLE
gdcmMediaStorage.cxx: remove some string copies and avoid passing additional argument

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmMediaStorage.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmMediaStorage.h
@@ -201,12 +201,10 @@ protected:
 
 private:
   bool SetFromDataSetOrHeader(DataSet const &ds, const Tag & tag);
-  /// THREAD SAFE
-  const char* GetFromDataSetOrHeader(DataSet const &ds, const Tag & tag, std::string &buf);
-  /// THREAD SAFE
-  const char* GetFromHeader(FileMetaInformation const &fmi, std::string &buf);
-  /// THREAD SAFE
-  const char* GetFromDataSet(DataSet const &ds, std::string &buf);
+
+  std::string GetFromDataSetOrHeader(DataSet const &ds, const Tag & tag);
+  std::string GetFromHeader(FileMetaInformation const &fmi);
+  std::string GetFromDataSet(DataSet const &ds);
 
 private:
   MSType MSField;


### PR DESCRIPTION
Hi, we use GDCM library in a project in the company I work for.
I had some across a thread safety issue in gdcmMediaStorage and fixed it.

Today, I was about to contribute it upstream when I noticed that this issue has just been fixed in the repository (revision 2d7dc483f8dbe3d2f0e8131797eb7c057de7cc0c on 7 Dec 2020), which is nice!

However, as the patch we had done simplifies a little bit the code and avoids some string copies, I would like to propose it.
This version has been well tested in our project, so you may consider it.

Thanks for reading.
