### PR TITLE
Fixed null deref from gdcmWarningMacro invocation with null pointer

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
@@ -104,7 +104,8 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
       const VR &devr = de.GetVR();
       if( devr != VR::INVALID && devr != VR::UN )
         {
-        gdcmWarningMacro("Please report. Missing dict entry for: [" << owner << "]" << " de is: "  << de );
+        const char* ownerString = owner ? owner : "<null>";
+        gdcmWarningMacro("Please report. Missing dict entry for: [" << ownerString << "]" << " de is: "  << de );
         return devr;
         }
       // CP-246


### PR DESCRIPTION
@malaterre a quickie I noticed running the tests...