### PR TITLE
Add ability to use multiple component transformation when encoding J2K

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
@@ -470,7 +470,7 @@ void JPEG2000Codec::SetReversible(bool res)
   Internals->coder_param.irreversible = !res;
 }
 
-void JPEG2000Codec::SetMCT(unsigned int mct)
+void JPEG2000Codec::SetMCT(char mct)
 {
     // Set the Multiple Component Transformation value (COD -> SGcod)
     // 0 for none, 1 to apply to components 0, 1, 2

--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
@@ -394,7 +394,7 @@ class JPEG2000Internals
 {
 public:
   JPEG2000Internals()
-   
+
     {
     memset(&coder_param, 0, sizeof(coder_param));
     opj_set_default_encoder_parameters(&coder_param);
@@ -468,6 +468,13 @@ void JPEG2000Codec::SetReversible(bool res)
 {
   LossyFlag = !res;
   Internals->coder_param.irreversible = !res;
+}
+
+void JPEG2000Codec::SetMCT(unsigned int mct)
+{
+    // Set the Multiple Component Transformation value (COD -> SGcod)
+    // 0 for none, 1 to apply to components 0, 1, 2
+    Internals->coder_param.tcp_mct = mct;
 }
 
 JPEG2000Codec::JPEG2000Codec()
@@ -775,7 +782,7 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
     b = parsejp2_imp( dummy_buffer, buf_size, &lossless, &mct);
   else if( parameters.decod_format == J2K_CFMT )
     b = parsej2k_imp( dummy_buffer, buf_size, &lossless, &mct);
- 
+
   reversible = 0;
   if( b ) {
     reversible = lossless;
@@ -1441,7 +1448,7 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     return false;
     }
 
-#if ((OPJ_VERSION_MAJOR == 2 && OPJ_VERSION_MINOR >= 3) || (OPJ_VERSION_MAJOR > 2)) 
+#if ((OPJ_VERSION_MAJOR == 2 && OPJ_VERSION_MINOR >= 3) || (OPJ_VERSION_MAJOR > 2))
   opj_codec_set_threads(dinfo, Internals->nNumberOfThreadsForDecompression);
 #endif
 
@@ -1497,7 +1504,7 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     b = parsejp2_imp( dummy_buffer, buf_size, &lossless, &mctb);
   else if( parameters.decod_format == J2K_CFMT )
     b = parsej2k_imp( dummy_buffer, buf_size, &lossless, &mctb);
- 
+
   reversible = 0;
   if( b ) {
     reversible = lossless;

--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.h
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.h
@@ -61,6 +61,7 @@ public:
   void SetNumberOfThreadsForDecompression(int nThreads);
 
   void SetReversible(bool res);
+  void SetMCT(unsigned int mct);
 
 protected:
   bool DecodeExtent(

--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.h
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.h
@@ -61,7 +61,7 @@ public:
   void SetNumberOfThreadsForDecompression(int nThreads);
 
   void SetReversible(bool res);
-  void SetMCT(unsigned int mct);
+  void SetMCT(char mct);
 
 protected:
   bool DecodeExtent(


### PR DESCRIPTION
I might be wrong, but there doesn't seem to be any way to enable multiple component transformation (MCT) when encoding using the `JPEG2000Codec`, which from my reading of the standard should be [required for both YBR_RCT and YBR_ICT](http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.4.html):

> The JPEG 2000 bit stream specifies whether or not a reversible or irreversible multi-component (color) transformation [ISO 15444-1 Annex G], if any, has been applied. If no multi-component transformation has been applied, then the components shall correspond to those specified by the DICOM Attribute Photometric Interpretation (0028,0004). If the JPEG 2000 Part 1 reversible multi-component transformation has been applied then the DICOM Attribute Photometric Interpretation (0028,0004) shall be YBR_RCT. If the JPEG 2000 Part 1 irreversible multi-component transformation has been applied then the DICOM Attribute Photometric Interpretation (0028,0004) shall be YBR_ICT.

and

> (...) a Photometric Interpretation of RGB could be specified as long as no multi-component transformation [ISO 15444-1 Annex G] was specified by the JPEG 2000 bit stream

As I understand it, for 3 sample/px:
Input RGB + MCT 0 -> Photometric Interpretation RGB
Input YBR_FULL + MCT 0 -> Photometric Interpretation YBR_FULL
Input RGB + MCT 1 -> Photometric Interpretation YBR_RCT or YBR_ICT
Input YBR_FULL + MCT 1 -> Not allowed

And for 1 sample/px:
Input PI + MCT 0 -> PI
Input PI + MCT 1 -> Not allowed

This seems to be borne out in the results as the compression ratio is higher with MCT when the input is RGB (for US1_UNCR.dcm: the J2K codestream is 334.4 kB without MCT vs. 152.3 kB with MCT). 

I've used an ~`int`~ `char` (after checking the JPEG Standard and openjpeg) rather than `bool` in case J2K Multicomponent was wanted (i.e. from 15444-2), which I think would mean values other than 0 or 1.