### PR TITLE
Add gdcmDefaultDicts to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ appveyor.yml merge=ours
 
 /Source/DataDictionary/gdcmDefaultDicts.cxx hooks.MaxObjectKiB=2048
 /Source/InformationObjectDefinition/Part3.xml hooks.MaxObjectKiB=4096
+/Source/DataDictionary/gdcmDefaultDicts.cxx hooks-max-size=1200000


### PR DESCRIPTION
Fix the following error triggered in ITK when updating GDCM:

```bash
commit c9a27c3 creates blob d5b218569316b6c637edc33d253bc5251439a863 at Source/DataDictionary/gdcmDefaultDicts.cxx with size 1194766 bytes (1166.76 KiB) which is greater than the maximum size 1048576 bytes (1024.00 KiB). If the file is intended to be committed, set the hooks-max-size attribute on its path.
```

Reference: https://github.com/InsightSoftwareConsortium/ITK/pull/2618