### PR TITLE
Fixed possible crash in Reader::CanRead if Stream pointer is null

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx
@@ -735,6 +735,8 @@ static inline bool isasciiupper( char c ) {
 // scope of this function.
 bool Reader::CanRead() const
 {
+  if( !Stream ) return false;
+
   // fastpath
   std::istream &is = *Stream;
   if( is.bad() ) return false;


### PR DESCRIPTION
If [Reader::SetFileName](https://github.com/malaterre/GDCM/blob/fe028c0d80a7dce6c395c25fc03fbed1b5d524ac/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx#L850) fails to open the file then `Reader::Stream` is `null` and `Reader::CanRead` crashes on the `Stream` [pointer evaluation](https://github.com/malaterre/GDCM/blob/fe028c0d80a7dce6c395c25fc03fbed1b5d524ac/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx#L739) with "Access violation reading location 0x0000000000000000"