### PR TITLE
Fix private dictionary entry

### DIFF
--- a/Source/DataDictionary/privatedicts.xml
+++ b/Source/DataDictionary/privatedicts.xml
@@ -4283,7 +4283,7 @@
   <entry owner="HOLOGIC, Inc." group="0019" element="xx40" vr="DS" vm="1" name="?"/>
   <entry owner="HOLOGIC, Inc." group="0019" element="xx41" vr="DS" vm="1" name="?"/>
   <entry owner="HOLOGIC, Inc." group="0019" element="xx42" vr="IS" vm="1" name="?"/>
-  <entry owner="HOLOGIC, Inc." group="0019" element="xx43" vr="IS" vm="1" name="?"/>
+  <entry owner="HOLOGIC, Inc." group="0019" element="xx43" vr="DS" vm="1" name="?"/>
   <entry owner="HOLOGIC, Inc." group="0019" element="xx44" vr="IS" vm="1" name="?"/>
   <entry owner="HOLOGIC, Inc." group="0019" element="xx45" vr="IS" vm="1" name="?"/>
   <entry owner="HOLOGIC, Inc." group="0019" element="xx46" vr="IS" vm="1" name="?"/>


### PR DESCRIPTION
**The issue**
Wrong value (_IS_ instead of _DS_) in private dictionary

**Examples**
Here are a few examples of _(0019, 0043)_ from a Hologic Selenia Dimensions machine:
`(0019, 1043) DS: '1.58'`
`(0019, 1043) DS: '1.93'`
`(0019, 1043) DS: '1.34'`