### PR TITLE
Cleanup up ghostflow size hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 appveyor.yml merge=ours
 * -whitespace
 
-/Source/DataDictionary/gdcmDefaultDicts.cxx hooks.MaxObjectKiB=2048
-/Source/InformationObjectDefinition/Part3.xml hooks.MaxObjectKiB=4096
+/Source/DataDictionary/gdcmDefaultDicts.cxx hooks-max-size=1500000
+/Source/DataDictionary/gdcmPrivateDefaultDicts.cxx hooks-max-size=1500000
+/Source/DataDictionary/gdcmTagToType.h hooks-max-size=1500000
+/Source/InformationObjectDefinition/Part3.xml hooks-max-size=3000000


### PR DESCRIPTION
Removed obsolete hooks.MaxObjectKiB statements.

Added hooks-max-size statements, from ITK, with updated sizes that are a healthy size larger than current file sizes.