### PR TITLE
socketxx wasi

### DIFF
--- a/Utilities/socketxx/socket++/sockstream.cpp
+++ b/Utilities/socketxx/socket++/sockstream.cpp
@@ -272,7 +272,7 @@ bool sockerr::op () const
   case EHOSTDOWN:
   case EHOSTUNREACH:
   case ENOTEMPTY:
-#   if !defined(__linux__) && !defined(__sun) && !defined(__hpux) && !defined(__EMSCRIPTEN__) // LN
+#   if !defined(__linux__) && !defined(__sun) && !defined(__hpux) && !defined(__EMSCRIPTEN__) && !defined(__wasi__) // LN
   case EPROCLIM:
 #   endif
   case EUSERS:


### PR DESCRIPTION
COMP: Exclude EPROCLIM for __wasi__ in socketxx

__wasi__ is set by the WASI WebAssembly WASI-SDK.