### PR TITLE
Allow vtkgdcm to work with VTK 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(GDCM_MAJOR_VERSION ${GDCM_VERSION_MAJOR})
 set(GDCM_MINOR_VERSION ${GDCM_VERSION_MINOR})
 set(GDCM_BUILD_VERSION ${GDCM_VERSION_PATCH})
 set(GDCM_VERSION "${GDCM_VERSION_MAJOR}.${GDCM_VERSION_MINOR}.${GDCM_VERSION_PATCH}") # ${GDCM_VERSION_TWEAK}
+set(GDCM_SHORT_VERSION "${GDCM_VERSION_MAJOR}.${GDCM_VERSION_MINOR}")
 
 mark_as_advanced(CMAKE_BACKWARDS_COMPATIBILITY CMAKE_BUILD_TYPE CMAKE_INSTALL_PREFIX)
 set(GDCM_CMAKE_DIR "${GDCM_SOURCE_DIR}/CMake" CACHE INTERNAL "")
@@ -132,6 +133,12 @@ if(NOT LIBRARY_OUTPUT_PATH)
   set(LIBRARY_OUTPUT_PATH ${GDCM_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
   mark_as_advanced(LIBRARY_OUTPUT_PATH)
 endif()
+
+# TODO: The following should be used for CMake 3 and beyond,
+# EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH are deprecated
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
 
 #-----------------------------------------------------------------------------
 # Adding GDCM_DATA_ROOT
@@ -650,7 +657,96 @@ if(GDCM_STANDALONE)
     mark_as_advanced(VTK_DIR)
     set(GDCM_VTK_DIR ${VTK_DIR})
     mark_as_advanced(GDCM_USE_PARAVIEW)
-    add_subdirectory(Utilities/VTK)
+
+    set(VTKGDCM_NAME vtkgdcm CACHE STRING "vtk-gdcm lib name")
+    mark_as_advanced(VTKGDCM_NAME)
+
+    if(VTK_VERSION VERSION_LESS 8.90)
+      add_subdirectory(Utilities/VTK)
+    else()
+      message(STATUS "Building Utilities/VTK as a VTK 9 Module")
+      # TODO: use VTKGDCM_NAME instead of vtkgdcm
+
+      option(VTKGDCM_VERSIONED_INSTALL "Install with versioned names." ON)
+      mark_as_advanced(VTKGDCM_VERSIONED_INSTALL)
+      if(VTKGDCM_VERSIONED_INSTALL)
+        set(vtk_version_suffix "-${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
+        set(vtkgdcm_library_suffix "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
+      else()
+        set(vtk_version_suffix "")
+        set(vtkgdcm_library_suffix "")
+      endif()
+      if(DEFINED GDCM_CUSTOM_LIBRARY_SUFFIX)
+        set(vtkgdcm_library_suffix "${GDCM_CUSTOM_LIBRARY_SUFFIX}")
+      endif()
+
+      vtk_module_scan(
+        MODULE_FILES          "${CMAKE_CURRENT_SOURCE_DIR}/Utilities/VTK/vtkgdcm.module"
+        REQUEST_MODULES       "GDCM::vtkgdcm"
+        PROVIDES_MODULES      vtkgdcm_modules
+        ENABLE_TESTS          "${GDCM_BUILD_TESTING}"
+      )
+
+      # documented at https://vtk.org/doc/nightly/html/group__module.html
+      vtk_module_build(
+        MODULES               ${vtkgdcm_modules}
+        INSTALL_EXPORT        GDCM
+        ARCHIVE_DESTINATION   "${GDCM_INSTALL_LIB_DIR}"
+        HEADERS_DESTINATION   "${GDCM_INSTALL_INCLUDE_DIR}/vtk${vtk_version_suffix}"
+        CMAKE_DESTINATION     "${GDCM_INSTALL_PACKAGE_DIR}"
+        LICENSE_DESTINATION   "${GDCM_INSTALL_DATA_DIR}/vtkgdcm-${GDCM_SHORT_VERSION}"
+        HIERARCHY_DESTINATION "${GDCM_INSTALL_LIB_DIR}/vtk${vtk_version_suffix}/hierarchy/vtkgdcm"
+        LIBRARY_NAME_SUFFIX   "${vtkgdcm_library_suffix}"
+        VERSION               "${GDCM_VERSION}"
+        SOVERSION             "1"
+        # TODO: these are probably not set as they should be
+        #USE_EXTERNAL          "${GDCM_USE_EXTERNAL}"
+        #TEST_DATA_TARGET      vtkgdcmData
+        #TEST_INPUT_DATA_DIRECTORY  "${vtkgdcm_test_data_directory_input}"
+        #TEST_OUTPUT_DATA_DIRECTORY "${vtkgdcm_test_data_directory_output}"
+      )
+
+      if(GDCM_WRAP_PYTHON AND VTK_WRAP_PYTHON)
+        find_package(PythonInterp ${VTK_PYTHON_VERSION} QUIET)
+
+        vtk_module_wrap_python(
+          MODULES             ${vtkgdcm_modules}
+          TARGET              GDCM::vtkgdcmpython
+          INSTALL_EXPORT      vtkgdcmPython
+          PYTHON_PACKAGE      "vtkgdcm"
+          CMAKE_DESTINATION   "${GDCM_INSTALL_PACKAGE_DIR}"
+          LIBRARY_DESTINATION "${GDCM_INSTALL_LIB_DIR}"
+          MODULE_DESTINATION  "${GDCM_VTK_INSTALL_PYTHONMODULE_DIR}"
+          SOABI               "${Python${VTK_PYTHON_VERSION}_SOABI}"
+          BUILD_STATIC        OFF
+        )
+
+        file(GENERATE
+          OUTPUT  "${CMAKE_BINARY_DIR}/${GDCM_VTK_INSTALL_PYTHONMODULE_DIR}/vtkgdcm/__init__.py"
+          CONTENT "from .vtkgdcm import *\n\n__all__ = ['vtkgdcm']\n__version__ = \"${GDCM_VERSION}\"\n")
+        install(
+          FILES       "${CMAKE_BINARY_DIR}/${GDCM_VTK_INSTALL_PYTHONMODULE_DIR}/vtkgdcm/__init__.py"
+          DESTINATION "${GDCM_VTK_INSTALL_PYTHONMODULE_DIR}/vtkgdcm/")
+
+        export(
+          EXPORT    vtkgdcmPython
+          NAMESPACE GDCM::
+          FILE      "${GDCM_INSTALL_PACKAGE_DIR}/vtkgdcmPython-targets.cmake")
+        install(
+          EXPORT      vtkgdcmPython
+          NAMESPACE   GDCM::
+          FILE        vtkgdcmPython-targets.cmake
+          DESTINATION "${GDCM_INSTALL_PACKAGE_DIR}")
+      endif()
+
+      if(GDCM_WRAP_JAVA AND VTK_WRAP_JAVA)
+        # TODO: this is broken, incomplete, needs lots of work
+        vtk_module_wrap_java(
+          MODULES         ${vtkgdcm_modules}
+          WRAPPED_MODULES vtkgdcm_java_wrapped_modules
+          JAVA_OUTPUT     "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")
+      endif()
+    endif()
   endif()
 endif()
 

--- a/Utilities/VTK/Applications/CMakeLists.txt
+++ b/Utilities/VTK/Applications/CMakeLists.txt
@@ -40,9 +40,23 @@ foreach(app ${GDCM_VTK_APPS})
     if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 5.0 )
       target_link_libraries(${app} vtkWidgets vtkHybrid)
     endif()
-  else()
-    # >= 6.0
+  elseif(VTK_VERSION VERSION_LESS 8.90)
+    # >= 6.0 and < 8.90
     target_link_libraries(${app} ${VTK_LIBRARIES} vtkIOXML)
+  else()
+    # >= 8.90
+    target_link_libraries(${app}
+      VTK::CommonCore VTK::CommonMisc
+      VTK::FiltersModeling VTK::ImagingColor
+      VTK::IOImage VTK::IOMINC VTK::IOXML
+      VTK::tiff)
+    set(_rendering_libs
+      VTK::InteractionWidgets VTK::RenderingAnnotation VTK::RenderingCore
+      VTK::InteractionStyle VTK::RenderingFreeType VTK::RenderingOpenGL2)
+    if(VTK_USE_RENDERING)
+      target_link_libraries(${app} ${_rendering_libs})
+      vtk_module_autoinit(TARGETS ${app} MODULES ${_rendering_libs})
+    endif()
   endif()
   if(WIN32 AND NOT CYGWIN)
     target_link_libraries(${app} gdcmgetopt)

--- a/Utilities/VTK/Applications/CMakeLists.txt
+++ b/Utilities/VTK/Applications/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Build the vtk-gdcm simple viewer
 include_directories(
+  ${GDCM_BINARY_DIR}/Utilities/VTK
   ${GDCM_SOURCE_DIR}/Utilities/VTK
   )
 

--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -16,9 +16,14 @@ if(GDCM_HAVE_PTHREAD_H AND CMAKE_USE_PTHREADS)
   )
 endif()
 
-#if( ${VTK_VERSION_MAJOR} LESS 7 )
+if(VTK_VERSION VERSION_LESS 8.90)
   include(${VTK_USE_FILE})
-#endif()
+else()
+  if(VTK::RenderingCore IN_LIST VTK_LIBRARIES)
+    # VTK 5 used to export VTK_USE_RENDERING, now we set it ourselves
+    set(VTK_USE_RENDERING 1)
+  endif()
+endif()
 
 if( ${VTK_MAJOR_VERSION} GREATER 5 )
   list(APPEND vtkgdcm_SRCS
@@ -63,7 +68,7 @@ if("${VTK_MAJOR_VERSION}" LESS 6)
       vtkRendering
       )
   endif()
-else()
+elseif(VTK_VERSION VERSION_LESS 8.90)
   set(vtkgdcm_LIBS
     vtkCommonCore
     vtkImagingCore
@@ -92,13 +97,13 @@ else()
       endif()
     endforeach()
   endforeach()
+elseif() # (VTK_VERSION VERSION_LESS 8.90)
+  # for VTK 9, target dependencies are handled automatically
+  set(vtkgdcm_LIBS)
 endif()
 
 # Use wrapping hints for this project.
 #set(VTK_WRAP_HINTS "${PROJECT_SOURCE_DIR}/hints")
-
-set(VTKGDCM_NAME vtkgdcm CACHE STRING "vtk-gdcm lib name")
-mark_as_advanced(VTKGDCM_NAME)
 
 # Create the instantiator for these classes.
 # FIXME: Are instantiator really needed when only doing python wrapping ?
@@ -158,6 +163,8 @@ else()
   endif()
 endif()
 
+if(VTK_VERSION VERSION_LESS 8.90)
+
 #Hum... not sure why this is needed.
 #if(NOT VTK_BUILD_SHARED_LIBS AND GDCM_BUILD_SHARED_LIBS)
 #  add_library(vtkgdcm STATIC ${vtkgdcm_SRCS} ${vtkgdcmInstantiator_SRCS})
@@ -195,6 +202,20 @@ if(NOT GDCM_INSTALL_NO_DEVELOPMENT)
   install(FILES ${header_files}
     DESTINATION ${GDCM_INSTALL_INCLUDE_DIR} COMPONENT VTKHeaders
   )
+endif()
+
+elseif(DEFINED VTK_MODULE_ENABLE_GDCM_vtkgdcm)
+  # When building as a module for VTK 8.90 or later
+  set(vtkgdcm_SRC_HDRS)
+  foreach(_src ${vtkgdcm_SRCS})
+    get_filename_component(_base ${_src} NAME_WE)
+    list(APPEND vtkgdcm_SRC_HDRS ${_base}.h)
+  endforeach()
+  vtk_module_add_module(GDCM::vtkgdcm
+    SOURCES ${vtkgdcm_SRCS}
+    HEADERS ${vtkgdcm_SRC_HDRS} ${vtkgdcm_HDRS})
+  vtk_module_link(GDCM::vtkgdcm
+    PRIVATE gdcmMSFF)
 endif()
 
 if(GDCM_WRAP_PHP)
@@ -642,6 +663,8 @@ if(GDCM_WRAP_CSHARP)
 
 endif()
 
+if(VTK_VERSION VERSION_LESS 8.90)
+
 if( (GDCM_WRAP_JAVA AND VTK_WRAP_JAVA) OR
     (GDCM_WRAP_PYTHON AND VTK_WRAP_PYTHON) )
   if( ${VTK_MAJOR_VERSION} GREATER 7 )
@@ -832,6 +855,8 @@ endif()
 if(BUILD_TESTING)
   add_subdirectory(Testing)
 endif()
+
+endif() #(VTK_VERSION VERSION_LESS 8.90)
 
 if(BUILD_APPLICATIONS)
   add_subdirectory(Applications)

--- a/Utilities/VTK/CMakeLists.txt
+++ b/Utilities/VTK/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(
   ${GDCM_SOURCE_DIR}/Source/DataStructureAndEncodingDefinition
   ${GDCM_SOURCE_DIR}/Source/MediaStorageAndFileFormat
   ${GDCM_SOURCE_DIR}/Source/DataDictionary
+  ${GDCM_BINARY_DIR}/Utilities/VTK
   ${GDCM_SOURCE_DIR}/Utilities/VTK
   )
 
@@ -191,8 +192,12 @@ if(NOT GDCM_INSTALL_NO_LIBRARIES)
 #  endif()
 endif()
 
+# Generate the header file for VTKGDCM_EXPORT
+configure_file(vtkgdcmModule.h.in
+  "${CMAKE_CURRENT_BINARY_DIR}/vtkgdcmModule.h" COPYONLY)
+
 if(NOT GDCM_INSTALL_NO_DEVELOPMENT)
-  set(header_files_glob "*.h" "*.txx")
+  set(header_files_glob "${CMAKE_CURRENT_BINARY_DIR}/*.h" "*.h" "*.txx")
   if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 4.5 )
     set(header_files_glob ${header_files_glob}
       "VTK4/*.h"

--- a/Utilities/VTK/Examples/Cxx/CMakeLists.txt
+++ b/Utilities/VTK/Examples/Cxx/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(
+  ${GDCM_BINARY_DIR}/Utilities/VTK
   ${GDCM_SOURCE_DIR}/Utilities/VTK
   )
 

--- a/Utilities/VTK/Examples/Cxx/CMakeLists.txt
+++ b/Utilities/VTK/Examples/Cxx/CMakeLists.txt
@@ -8,9 +8,14 @@ if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 5.0 )
     CreateFakeRTDOSE
     CreateFakePET
     ConvertSingleBitTo8Bits
-    GenerateRTSTRUCT
-    offscreenimage
   )
+  if(VTK_USE_RENDERING OR vtkRenderingCore_LOADED)
+    set(GDCM_VTK_APPS
+      ${GDCM_VTK_APPS}
+      GenerateRTSTRUCT
+      offscreenimage
+      )
+  endif()
   if( ${VTK_MAJOR_VERSION} GREATER 5 )
     set(GDCM_VTK_APPS
       ${GDCM_VTK_APPS}
@@ -58,7 +63,18 @@ foreach(app ${GDCM_VTK_APPS})
     # gdcmTesting is in Common:
     target_link_libraries(${app} gdcmCommon)
   endif()
-  if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 6.0 )
+  if(NOT VTK_VERSION VERSION_LESS 8.90)
+    target_link_libraries(${app}
+      VTK::FiltersCore VTK::FiltersModeling VTK::ImagingColor VTK::IOXML)
+    set(_rendering_libs
+      VTK::InteractionWidgets VTK::RenderingAnnotation VTK::RenderingCore
+      VTK::InteractionStyle VTK::RenderingFreeType VTK::RenderingOpenGL2
+      VTK::RenderingVolume VTK::RenderingVolumeOpenGL2)
+    if(VTK_USE_RENDERING)
+      target_link_libraries(${app} ${_rendering_libs})
+      vtk_module_autoinit(TARGETS ${app} MODULES ${_rendering_libs})
+    endif()
+  elseif( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 6.0 )
     target_link_libraries(${app} ${VTK_LIBRARIES})
   else()
     if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 5.0 )

--- a/Utilities/VTK/Examples/Cxx/Compute3DSpacing.cxx
+++ b/Utilities/VTK/Examples/Cxx/Compute3DSpacing.cxx
@@ -14,6 +14,7 @@
 #include "vtkGDCMImageReader2.h"
 #include "vtkImageChangeInformation.h"
 #include "vtkStringArray.h"
+#include "vtkVersion.h"
 #include "gdcmIPPSorter.h"
 
 #ifndef vtkFloatingPointType

--- a/Utilities/VTK/Examples/Cxx/Convert16BitsTo8Bits.cxx
+++ b/Utilities/VTK/Examples/Cxx/Convert16BitsTo8Bits.cxx
@@ -15,6 +15,7 @@
 #include "vtkGDCMImageWriter.h"
 #include "vtkImageData.h"
 #include "vtkImageCast.h"
+#include "vtkVersion.h"
 
 #include "gdcmTesting.h"
 // The following file is 16/16/15 but the scalar range of the image is [0,192]

--- a/Utilities/VTK/Examples/Cxx/ConvertMultiFrameToSingleFrame.cxx
+++ b/Utilities/VTK/Examples/Cxx/ConvertMultiFrameToSingleFrame.cxx
@@ -15,6 +15,7 @@
 #include "vtkGDCMImageWriter.h"
 #include "vtkImageData.h"
 #include "vtkStringArray.h"
+#include "vtkVersion.h"
 
 #include "gdcmTesting.h"
 #include "gdcmFilenameGenerator.h"

--- a/Utilities/VTK/Examples/Cxx/ConvertRGBToLuminance.cxx
+++ b/Utilities/VTK/Examples/Cxx/ConvertRGBToLuminance.cxx
@@ -15,6 +15,7 @@
 #include "vtkGDCMImageWriter.h"
 #include "vtkImageData.h"
 #include "vtkImageLuminance.h"
+#include "vtkVersion.h"
 
 #include "gdcmTesting.h"
 

--- a/Utilities/VTK/Examples/Cxx/ConvertSingleBitTo8Bits.cxx
+++ b/Utilities/VTK/Examples/Cxx/ConvertSingleBitTo8Bits.cxx
@@ -18,6 +18,7 @@
 #include "vtkPointData.h"
 #include "vtkBitArray.h"
 #include "vtkUnsignedCharArray.h"
+#include "vtkVersion.h"
 
 int main(int argc, char *argv[])
 {

--- a/Utilities/VTK/Examples/Cxx/CreateFakePET.cxx
+++ b/Utilities/VTK/Examples/Cxx/CreateFakePET.cxx
@@ -19,6 +19,7 @@
 #include "vtkDataArray.h"
 #include "vtkMedicalImageProperties.h"
 #include "vtkStringArray.h"
+#include "vtkVersion.h"
 
 #include "gdcmTrace.h"
 #include "gdcmReader.h"

--- a/Utilities/VTK/Examples/Cxx/CreateFakeRTDOSE.cxx
+++ b/Utilities/VTK/Examples/Cxx/CreateFakeRTDOSE.cxx
@@ -18,6 +18,7 @@
 #include "vtkPointData.h"
 #include "vtkDataArray.h"
 #include "vtkMedicalImageProperties.h"
+#include "vtkVersion.h"
 
 #include "gdcmTrace.h"
 #include "gdcmReader.h"

--- a/Utilities/VTK/Examples/Cxx/GenerateRTSTRUCT.cxx
+++ b/Utilities/VTK/Examples/Cxx/GenerateRTSTRUCT.cxx
@@ -31,6 +31,7 @@
 #include "vtkProperty.h"
 #include "vtkProperty2D.h"
 #include "vtkImageData.h"
+#include "vtkVersion.h"
 
 #include <algorithm> //for std::find
 

--- a/Utilities/VTK/Examples/Cxx/MagnifyFile.cxx
+++ b/Utilities/VTK/Examples/Cxx/MagnifyFile.cxx
@@ -16,6 +16,7 @@
 #include "vtkImageData.h"
 #include "vtkImageMagnify.h"
 #include "vtkImageCast.h"
+#include "vtkVersion.h"
 
 #include "gdcmTesting.h"
 #include "gdcmSystem.h"

--- a/Utilities/VTK/Examples/Cxx/gdcmorthoplanes.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmorthoplanes.cxx
@@ -45,6 +45,7 @@
 #include "vtkGDCMImageReader.h"
 #include "vtkGDCMImageWriter.h"
 #include "vtkStringArray.h"
+#include "vtkVersion.h"
 
 #include "gdcmSystem.h"
 #include "gdcmDirectory.h"

--- a/Utilities/VTK/Examples/Cxx/gdcmreslice.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmreslice.cxx
@@ -32,6 +32,7 @@
 #include "vtkLookupTable.h"
 #include "vtkTexture.h"
 #include "vtkPlaneSource.h"
+#include "vtkVersion.h"
 
 int main( int argc, char *argv[] )
 {

--- a/Utilities/VTK/Examples/Cxx/gdcmrtionplan.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmrtionplan.cxx
@@ -25,6 +25,7 @@
 #include <vtkXMLPolyDataWriter.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkImageColorViewer.h>
+#include "vtkVersion.h"
 
 #include "gdcmReader.h"
 #include "gdcmAttribute.h"

--- a/Utilities/VTK/Examples/Cxx/gdcmrtplan.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmrtplan.cxx
@@ -24,6 +24,7 @@
 #include <vtkXMLImageDataWriter.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkImageColorViewer.h>
+#include "vtkVersion.h"
 
 #include "gdcmReader.h"
 #include "gdcmAttribute.h"

--- a/Utilities/VTK/Examples/Cxx/gdcmscene.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmscene.cxx
@@ -25,6 +25,7 @@
 #include "vtkCamera.h"
 #include "vtkProperty.h"
 #include "vtkProperty2D.h"
+#include "vtkVersion.h"
 
 
 // gdcmDataExtra/gdcmNonImageData/exRT_Structure_Set_Storage.dcm

--- a/Utilities/VTK/Examples/Cxx/gdcmtexture.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmtexture.cxx
@@ -30,6 +30,7 @@
 #include "vtkLookupTable.h"
 #include "vtkTexture.h"
 #include "vtkPlaneSource.h"
+#include "vtkVersion.h"
 
 int main( int argc, char *argv[] )
 {

--- a/Utilities/VTK/Examples/Cxx/gdcmvolume.cxx
+++ b/Utilities/VTK/Examples/Cxx/gdcmvolume.cxx
@@ -26,6 +26,7 @@
 #include "vtkRenderWindow.h"
 #include "vtkImageClip.h"
 #include "vtkRenderWindowInteractor.h"
+#include "vtkVersion.h"
 
 
 // gdcmvolume gdcmData/GE_DLX-8-MONO2-Multiframe-Jpeg_Lossless.dcm

--- a/Utilities/VTK/Examples/Cxx/offscreenimage.cxx
+++ b/Utilities/VTK/Examples/Cxx/offscreenimage.cxx
@@ -19,6 +19,7 @@
 #include "vtkPNGWriter.h"
 #include "vtkWindowToImageFilter.h"
 #include "vtkMedicalImageProperties.h"
+#include "vtkVersion.h"
 
 int main(int argc, char *argv[])
 {

--- a/Utilities/VTK/Examples/Cxx/reslicesphere.cxx
+++ b/Utilities/VTK/Examples/Cxx/reslicesphere.cxx
@@ -59,6 +59,7 @@ date  Tue, May 11, 2010 at 7:01 PM
 #include <vtkProperty2D.h>
 #include <vtkGDCMImageReader.h>
 #include <vtkImageChangeInformation.h>
+#include <vtkVersion.h>
 
 #include "gdcmDirectory.h"
 #include "gdcmTesting.h"

--- a/Utilities/VTK/Examples/Cxx/rtstructapp.cxx
+++ b/Utilities/VTK/Examples/Cxx/rtstructapp.cxx
@@ -27,6 +27,7 @@
 #include "vtkProperty2D.h"
 #include "vtkAppendPolyData.h"
 #include "vtkImageData.h"
+#include "vtkVersion.h"
 
 /*
  * Small example to read in a RTSTUCT and write it out (displays it too).

--- a/Utilities/VTK/Examples/Cxx/threadgdcm.cxx
+++ b/Utilities/VTK/Examples/Cxx/threadgdcm.cxx
@@ -18,6 +18,7 @@
 
 #include "vtkImageData.h"
 #include "vtkStructuredPointsWriter.h"
+#include "vtkVersion.h"
 
 #include <pthread.h>
 

--- a/Utilities/VTK/Testing/Cxx/CMakeLists.txt
+++ b/Utilities/VTK/Testing/Cxx/CMakeLists.txt
@@ -55,8 +55,21 @@ if(VTK_USE_RENDERING)
 endif()
 
 # Add the include paths
+if(VTK_VERSION VERSION_LESS 8.90)
+  include_directories(
+    "${GDCM_SOURCE_DIR}/Utilities/VTK"
+    )
+else()
+  include_directories(
+    "${GDCM_BINARY_DIR}/Source/Common"
+    "${GDCM_SOURCE_DIR}/Source/Common"
+    "${GDCM_SOURCE_DIR}/Source/DataDictionary"
+    "${GDCM_SOURCE_DIR}/Source/DataStructureAndEncodingDefinition"
+    "${GDCM_SOURCE_DIR}/Source/MediaStorageAndFileFormat"
+    )
+endif()
+
 include_directories(
-  "${GDCM_SOURCE_DIR}/Utilities/VTK"
   "${GDCM_BINARY_DIR}/Testing/Source/Data" # for gdcmDataImages.h
   )
 
@@ -65,18 +78,23 @@ create_test_sourcelist(vtkGDCMTests gdcmvtkGDCMTests.cxx ${VTK_GDCM_TEST_SRCS}
   )
 add_executable(gdcmvtkGDCMTests ${vtkGDCMTests})
 target_link_libraries(gdcmvtkGDCMTests ${VTKGDCM_NAME} gdcmMSFF)
-target_link_libraries(gdcmvtkGDCMTests vtksys)
-if(VTK_USE_RENDERING)
-  if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 4.5 )
-    target_link_libraries(gdcmvtkGDCMTests vtkRendering)
-  elseif( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 6.0 )
-    target_link_libraries(gdcmvtkGDCMTests vtkVolumeRendering)
+
+if(VTK_VERSION VERSION_LESS 8.90)
+  target_link_libraries(gdcmvtkGDCMTests vtksys)
+  if(VTK_USE_RENDERING)
+    if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 4.5 )
+      target_link_libraries(gdcmvtkGDCMTests vtkRendering)
+    elseif( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 6.0 )
+      target_link_libraries(gdcmvtkGDCMTests vtkVolumeRendering)
+    endif()
   endif()
-endif()
-# VTK 6.0 does not set VTK_USE_RENDERING anymore ?
-if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 6.0 )
-  target_link_libraries(gdcmvtkGDCMTests ${vtkgdcm_LIBS})
-  target_link_libraries(gdcmvtkGDCMTests vtkIOLegacy vtkCommonCore)
+  # VTK 6.0 does not set VTK_USE_RENDERING anymore ?
+  if( "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" GREATER 6.0 )
+    target_link_libraries(gdcmvtkGDCMTests ${vtkgdcm_LIBS})
+    target_link_libraries(gdcmvtkGDCMTests vtkIOLegacy vtkCommonCore)
+  endif()
+else()
+  target_link_libraries(gdcmvtkGDCMTests VTK::vtksys VTK::RenderingCore)
 endif()
 
 # Need full path to executable:

--- a/Utilities/VTK/Testing/Cxx/CMakeLists.txt
+++ b/Utilities/VTK/Testing/Cxx/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 # Add the include paths
 if(VTK_VERSION VERSION_LESS 8.90)
   include_directories(
+    "${GDCM_BINARY_DIR}/Utilities/VTK"
     "${GDCM_SOURCE_DIR}/Utilities/VTK"
     )
 else()

--- a/Utilities/VTK/VTK4/vtkMedicalImageProperties.h
+++ b/Utilities/VTK/VTK4/vtkMedicalImageProperties.h
@@ -43,11 +43,12 @@
 #error Something went terribly wrong
 #endif
 
+#include "vtkgdcmModule.h"
 #include "vtkObject.h"
 
 class vtkMedicalImagePropertiesInternals;
 
-class VTK_IO_EXPORT vtkMedicalImageProperties : public vtkObject
+class VTKGDCM_EXPORT vtkMedicalImageProperties : public vtkObject
 {
 public:
   static vtkMedicalImageProperties *New();

--- a/Utilities/VTK/VTK4/vtkStringArray.h
+++ b/Utilities/VTK/VTK4/vtkStringArray.h
@@ -25,12 +25,13 @@
 #error Something went terribly wrong
 #endif
 
+#include "vtkgdcmModule.h"
 #include "vtkObject.h"
 
 #include <string>
 
 class vtkStringArrayInternals;
-class VTK_EXPORT vtkStringArray : public vtkObject
+class VTKGDCM_EXPORT vtkStringArray : public vtkObject
 {
 public:
   static vtkStringArray *New();

--- a/Utilities/VTK/vtkGDCMImageReader.h
+++ b/Utilities/VTK/vtkGDCMImageReader.h
@@ -64,6 +64,7 @@
 #ifndef VTKGDCMIMAGEREADER_H
 #define VTKGDCMIMAGEREADER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkMedicalImageReader2.h"
 #include "vtkImageData.h"
 #include "vtkVersion.h"
@@ -100,7 +101,7 @@ class vtkPolyData;
 namespace gdcm { class ImageReader; }
 //ETX
 class vtkMatrix4x4;
-class VTK_EXPORT vtkGDCMImageReader : public vtkMedicalImageReader2
+class VTKGDCM_EXPORT vtkGDCMImageReader : public vtkMedicalImageReader2
 {
 public:
   static vtkGDCMImageReader *New();

--- a/Utilities/VTK/vtkGDCMImageReader2.h
+++ b/Utilities/VTK/vtkGDCMImageReader2.h
@@ -64,6 +64,7 @@
 #ifndef VTKGDCMIMAGEREADER2_H
 #define VTKGDCMIMAGEREADER2_H
 
+#include "vtkgdcmModule.h"
 #include "vtkMedicalImageReader2.h"
 #include "vtkImageData.h"
 
@@ -91,7 +92,7 @@ class vtkPolyData;
 namespace gdcm { class ImageReader; }
 //ETX
 class vtkMatrix4x4;
-class VTK_EXPORT vtkGDCMImageReader2 : public vtkMedicalImageReader2
+class VTKGDCM_EXPORT vtkGDCMImageReader2 : public vtkMedicalImageReader2
 {
 public:
   static vtkGDCMImageReader2 *New();

--- a/Utilities/VTK/vtkGDCMImageWriter.h
+++ b/Utilities/VTK/vtkGDCMImageWriter.h
@@ -38,6 +38,7 @@
 #ifndef VTKGDCMIMAGEWRITER_H
 #define VTKGDCMIMAGEWRITER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkImageWriter.h"
 #include "vtkVersion.h"
 
@@ -45,7 +46,7 @@ class vtkLookupTable;
 class vtkMedicalImageProperties;
 class vtkMatrix4x4;
 class vtkStringArray;
-class VTK_EXPORT vtkGDCMImageWriter : public vtkImageWriter
+class VTKGDCM_EXPORT vtkGDCMImageWriter : public vtkImageWriter
 {
 public:
   static vtkGDCMImageWriter *New();

--- a/Utilities/VTK/vtkGDCMMedicalImageProperties.h
+++ b/Utilities/VTK/vtkGDCMMedicalImageProperties.h
@@ -23,6 +23,7 @@
 #ifndef VTKGDCMMEDICALIMAGEPROPERTIES_H
 #define VTKGDCMMEDICALIMAGEPROPERTIES_H
 
+#include "vtkgdcmModule.h"
 #include "vtkMedicalImageProperties.h"
 
 class vtkGDCMMedicalImagePropertiesInternals;
@@ -30,7 +31,7 @@ class vtkGDCMMedicalImagePropertiesInternals;
 namespace gdcm { class File; }
 //ETX
 
-class VTK_EXPORT vtkGDCMMedicalImageProperties : public vtkMedicalImageProperties
+class VTKGDCM_EXPORT vtkGDCMMedicalImageProperties : public vtkMedicalImageProperties
 {
 public:
   static vtkGDCMMedicalImageProperties *New();

--- a/Utilities/VTK/vtkGDCMPolyDataReader.h
+++ b/Utilities/VTK/vtkGDCMPolyDataReader.h
@@ -28,6 +28,7 @@
 #ifndef VTKGDCMPOLYDATAREADER_H
 #define VTKGDCMPOLYDATAREADER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkPolyDataAlgorithm.h"
 
 class vtkMedicalImageProperties;
@@ -35,7 +36,7 @@ class vtkRTStructSetProperties;
 //BTX
 namespace gdcm { class Reader; }
 //ETX
-class VTK_EXPORT vtkGDCMPolyDataReader : public vtkPolyDataAlgorithm
+class VTKGDCM_EXPORT vtkGDCMPolyDataReader : public vtkPolyDataAlgorithm
 {
 public:
   static vtkGDCMPolyDataReader *New();

--- a/Utilities/VTK/vtkGDCMPolyDataWriter.cxx
+++ b/Utilities/VTK/vtkGDCMPolyDataWriter.cxx
@@ -496,7 +496,11 @@ void vtkGDCMPolyDataWriter::WriteRTSTRUCTData(gdcm::File &file, int pdidx )
   sqi = new SequenceOfItems;
 
   vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION >= 9 
+  const vtkIdType *indx = 0;
+#else
   vtkIdType *indx = 0;
+#endif
   double v[3];
   unsigned int cellnum = 0;
 
@@ -759,7 +763,11 @@ void vtkGDCMPolyDataWriter::InitializeRTStructSet(vtkStdString inDirectory,
     vtkPoints *pts;
     vtkCellArray *polys;
     vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION >= 9 
+    const vtkIdType *indx = 0;
+#else
     vtkIdType *indx = 0;
+#endif
     pts = theData->GetPoints();
     polys = theData->GetPolys();
     vtkCellArray* lines = theData->GetLines();

--- a/Utilities/VTK/vtkGDCMPolyDataWriter.h
+++ b/Utilities/VTK/vtkGDCMPolyDataWriter.h
@@ -25,6 +25,7 @@
 #ifndef VTKGDCMPOLYDATAWRITER_H
 #define VTKGDCMPOLYDATAWRITER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkPolyDataWriter.h"
 #include "vtkStringArray.h"
 #include "vtkStdString.h"
@@ -35,7 +36,7 @@ class vtkRTStructSetProperties;
 //BTX
 namespace gdcm { class File; }
 //ETX
-class VTK_EXPORT vtkGDCMPolyDataWriter : public vtkPolyDataWriter
+class VTKGDCM_EXPORT vtkGDCMPolyDataWriter : public vtkPolyDataWriter
 {
 public:
   static vtkGDCMPolyDataWriter *New();

--- a/Utilities/VTK/vtkGDCMTesting.h
+++ b/Utilities/VTK/vtkGDCMTesting.h
@@ -21,9 +21,10 @@
 #ifndef VTKGDCMTESTING_H
 #define VTKGDCMTESTING_H
 
+#include "vtkgdcmModule.h"
 #include "vtkObject.h"
 
-class VTK_EXPORT vtkGDCMTesting : public vtkObject
+class VTKGDCM_EXPORT vtkGDCMTesting : public vtkObject
 {
 public:
   static vtkGDCMTesting *New();

--- a/Utilities/VTK/vtkGDCMThreadedImageReader.h
+++ b/Utilities/VTK/vtkGDCMThreadedImageReader.h
@@ -37,10 +37,11 @@
 #ifndef VTKGDCMTHREADEDIMAGEREADER_H
 #define VTKGDCMTHREADEDIMAGEREADER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkGDCMImageReader.h"
 #include "vtkVersion.h"
 
-class VTK_EXPORT vtkGDCMThreadedImageReader : public vtkGDCMImageReader
+class VTKGDCM_EXPORT vtkGDCMThreadedImageReader : public vtkGDCMImageReader
 {
 public:
   static vtkGDCMThreadedImageReader *New();

--- a/Utilities/VTK/vtkGDCMThreadedImageReader2.h
+++ b/Utilities/VTK/vtkGDCMThreadedImageReader2.h
@@ -43,10 +43,11 @@
 #ifndef VTKGDCMTHREADEDIMAGEREADER2_H
 #define VTKGDCMTHREADEDIMAGEREADER2_H
 
+#include "vtkgdcmModule.h"
 #include "vtkThreadedImageAlgorithm.h"
 
 class vtkStringArray;
-class VTK_EXPORT vtkGDCMThreadedImageReader2 : public vtkThreadedImageAlgorithm
+class VTKGDCM_EXPORT vtkGDCMThreadedImageReader2 : public vtkThreadedImageAlgorithm
 {
 public:
   static vtkGDCMThreadedImageReader2 *New();

--- a/Utilities/VTK/vtkImageColorViewer.h
+++ b/Utilities/VTK/vtkImageColorViewer.h
@@ -53,6 +53,7 @@
 #ifndef VTKIMAGECOLORVIEWER_H
 #define VTKIMAGECOLORVIEWER_H
 
+#include "vtkgdcmModule.h"
 #include "vtkObject.h"
 #include "vtkVersion.h"
 
@@ -68,7 +69,7 @@ class vtkRenderer;
 class vtkRenderWindowInteractor;
 class vtkPolyData;
 
-class VTK_EXPORT vtkImageColorViewer : public vtkObject
+class VTKGDCM_EXPORT vtkImageColorViewer : public vtkObject
 {
 public:
   static vtkImageColorViewer *New();

--- a/Utilities/VTK/vtkImageMapToColors16.h
+++ b/Utilities/VTK/vtkImageMapToColors16.h
@@ -42,11 +42,12 @@
 #define VTKIMAGEMAPTOCOLORS16_H
 
 
+#include "vtkgdcmModule.h"
 #include "vtkThreadedImageAlgorithm.h"
 
 class vtkScalarsToColors;
 
-class VTK_EXPORT vtkImageMapToColors16 : public vtkThreadedImageAlgorithm
+class VTKGDCM_EXPORT vtkImageMapToColors16 : public vtkThreadedImageAlgorithm
 {
 public:
   static vtkImageMapToColors16 *New();

--- a/Utilities/VTK/vtkImageMapToWindowLevelColors2.cxx
+++ b/Utilities/VTK/vtkImageMapToWindowLevelColors2.cxx
@@ -37,6 +37,8 @@
 #include "vtkScalarsToColors.h"
 #include "vtkPointData.h"
 
+#include <cmath>
+
 //vtkCxxRevisionMacro(vtkImageMapToWindowLevelColors2, "$Revision: 1.3 $")
 vtkStandardNewMacro(vtkImageMapToWindowLevelColors2)
 

--- a/Utilities/VTK/vtkImageMapToWindowLevelColors2.h
+++ b/Utilities/VTK/vtkImageMapToWindowLevelColors2.h
@@ -43,9 +43,10 @@
 #ifndef VTKIMAGEMAPTOWINDOWLEVELCOLORS2_H
 #define VTKIMAGEMAPTOWINDOWLEVELCOLORS2_H
 
+#include "vtkgdcmModule.h"
 #include "vtkImageMapToColors.h"
 
-class VTK_EXPORT vtkImageMapToWindowLevelColors2 : public vtkImageMapToColors
+class VTKGDCM_EXPORT vtkImageMapToWindowLevelColors2 : public vtkImageMapToColors
 {
 public:
   static vtkImageMapToWindowLevelColors2 *New();

--- a/Utilities/VTK/vtkImagePlanarComponentsToComponents.h
+++ b/Utilities/VTK/vtkImagePlanarComponentsToComponents.h
@@ -37,6 +37,7 @@
 #ifndef VTKIMAGEPLANARCOMPONENTSTOCOMPONENTS_H
 #define VTKIMAGEPLANARCOMPONENTSTOCOMPONENTS_H
 
+#include "vtkgdcmModule.h"
 #include "vtkImageAlgorithm.h"
 
 // everything is now handled within the vtkGDCMImageReader as Planar Configuration can not
@@ -44,8 +45,8 @@
 
 #error do not use this class
 
-//class VTK_EXPORT vtkImagePlanarComponentsToComponents : public vtkThreadedImageAlgorithm
-class VTK_EXPORT vtkImagePlanarComponentsToComponents : public vtkImageAlgorithm
+//class VTKGDCM_EXPORT vtkImagePlanarComponentsToComponents : public vtkThreadedImageAlgorithm
+class VTKGDCM_EXPORT vtkImagePlanarComponentsToComponents : public vtkImageAlgorithm
 {
 public:
   static vtkImagePlanarComponentsToComponents *New();

--- a/Utilities/VTK/vtkImageRGBToYBR.h
+++ b/Utilities/VTK/vtkImageRGBToYBR.h
@@ -39,9 +39,10 @@
 #ifndef VTKIMAGERGBTOYBR_H
 #define VTKIMAGERGBTOYBR_H
 
+#include "vtkgdcmModule.h"
 #include "vtkThreadedImageAlgorithm.h"
 
-class VTK_EXPORT vtkImageRGBToYBR : public vtkThreadedImageAlgorithm
+class VTKGDCM_EXPORT vtkImageRGBToYBR : public vtkThreadedImageAlgorithm
 {
 public:
   static vtkImageRGBToYBR *New();

--- a/Utilities/VTK/vtkImageYBRToRGB.h
+++ b/Utilities/VTK/vtkImageYBRToRGB.h
@@ -39,9 +39,10 @@
 #ifndef VTKIMAGEYBRTORGB_H
 #define VTKIMAGEYBRTORGB_H
 
+#include "vtkgdcmModule.h"
 #include "vtkThreadedImageAlgorithm.h"
 
-class VTK_EXPORT vtkImageYBRToRGB : public vtkThreadedImageAlgorithm
+class VTKGDCM_EXPORT vtkImageYBRToRGB : public vtkThreadedImageAlgorithm
 {
 public:
   static vtkImageYBRToRGB *New();

--- a/Utilities/VTK/vtkLookupTable16.h
+++ b/Utilities/VTK/vtkLookupTable16.h
@@ -38,10 +38,11 @@
 #ifndef VTKLOOKUPTABLE16_H
 #define VTKLOOKUPTABLE16_H
 
+#include "vtkgdcmModule.h"
 #include "vtkLookupTable.h"
 #include "vtkUnsignedShortArray.h"
 
-class VTK_EXPORT vtkLookupTable16 : public vtkLookupTable
+class VTKGDCM_EXPORT vtkLookupTable16 : public vtkLookupTable
 {
 public:
   static vtkLookupTable16 *New();

--- a/Utilities/VTK/vtkRTStructSetProperties.h
+++ b/Utilities/VTK/vtkRTStructSetProperties.h
@@ -20,11 +20,12 @@
 #ifndef VTKRTSTRUCTSETPROPERTIES_H
 #define VTKRTSTRUCTSETPROPERTIES_H
 
+#include "vtkgdcmModule.h"
 #include "vtkObject.h"
 
 class vtkRTStructSetPropertiesInternals;
 
-class VTK_EXPORT vtkRTStructSetProperties : public vtkObject
+class VTKGDCM_EXPORT vtkRTStructSetProperties : public vtkObject
 {
 public:
   static vtkRTStructSetProperties *New();

--- a/Utilities/VTK/vtkgdcm.module
+++ b/Utilities/VTK/vtkgdcm.module
@@ -1,0 +1,22 @@
+NAME
+  GDCM::vtkgdcm
+LIBRARY_NAME
+  vtkgdcm
+GROUPS
+  StandAlone
+DEPENDS
+  VTK::CommonCore
+  VTK::CommonDataModel
+  VTK::CommonExecutionModel
+  VTK::IOImage
+  VTK::IOLegacy
+  VTK::ImagingSources
+PRIVATE_DEPENDS
+  VTK::CommonMisc
+  VTK::ImagingCore
+  VTK::IOCore
+OPTIONAL_DEPENDS
+  VTK::InteractionStyle
+  VTK::RenderingCore
+TEST_DEPENDS
+  VTK::TestingCore

--- a/Utilities/VTK/vtkgdcmModule.h.in
+++ b/Utilities/VTK/vtkgdcmModule.h.in
@@ -1,0 +1,19 @@
+/* Export macros for shared libraries */
+
+#ifndef vtkgdcmModule_h
+#define vtkgdcmModule_h
+
+#include "vtkABI.h"
+#include "gdcmConfigure.h"
+
+#if defined(GDCM_BUILD_SHARED_LIBS)
+# if defined(vtkgdcm_EXPORTS)
+#  define VTKGDCM_EXPORT VTK_ABI_EXPORT
+# else
+#  define VTKGDCM_EXPORT VTK_ABI_IMPORT
+# endif
+#else
+# define VTKGDCM_EXPORT
+#endif
+
+#endif


### PR DESCRIPTION
VTK 9 adds a [Module API](https://vtk.org/doc/nightly/html/group__module.html) for cmake projects that build against VTK.  The purpose of this API is to automate the linking and include directories for dependencies, and it also provides automated wrapping (currently only fully functional for Python).  As can be seen from the changes in this pull request, most of the module API calls are in the base CMakeLists.txt, while very few are made from the CMakeLists.txt file that lists the source files.

This is currently incomplete and is placed here for discussion. 