### PR TITLE
Preamble mem leak was fixed

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmPreamble.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmPreamble.h
@@ -63,7 +63,7 @@ public:
     }
   Preamble& operator=(Preamble const &)
     {
-    Internal = nullptr;
+    Remove();
     Create();
     return *this;
     }


### PR DESCRIPTION
Preamble's assign operator did not free allocated memory. Fixed.