### PR TITLE
Preamble mem leak was fixed

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmPreamble.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmPreamble.h
@@ -63,7 +63,6 @@ public:
     }
   Preamble& operator=(Preamble const &)
     {
-    Internal = nullptr;
     Create();
     return *this;
     }


### PR DESCRIPTION
Preamble's assign operator does not delete allocated memory before assigning nullptr to pointer. After the fix an allocated memory is reused.  