### PR TITLE
Fixed Emscripten compilation error: unknown type name 'off64_t'

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
@@ -35,7 +35,7 @@
 #include <io.h>
 typedef int64_t off64_t;
 #else
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)
 #  define off64_t off_t
 #endif
 #include <unistd.h> // ftruncate


### PR DESCRIPTION
off64_t is missing on some Emscripten versions (3.1.44 and 3.1.45)