### PR TITLE
BUG: fixed regression in gdcmImageCodec.cxx

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx
@@ -460,7 +460,8 @@ bool ImageCodec::CleanupUnusedBits(char * data8, size_t datalen)
       smask = (uint16_t)(
         smask << ( 16 - (PF.GetBitsAllocated() - PF.GetBitsStored() + 1) ));
       // nmask : to propagate sign bit on negative values
-      int16_t nmask = (int16_t)(0x8000U >> ( PF.GetBitsAllocated() - PF.GetBitsStored() - 1 ));
+      int16_t nmask = (int16_t)0x8000;
+      nmask = (int16_t)(nmask >> ( PF.GetBitsAllocated() - PF.GetBitsStored() - 1 ));
 
       uint16_t *start = (uint16_t*)data;
       for( uint16_t *p = start ; p != start + datalen / 2; ++p )
@@ -515,7 +516,8 @@ bool ImageCodec::DoOverlayCleanup(std::istream &is, std::ostream &os)
       smask = (uint16_t)(
         smask << ( 16 - (PF.GetBitsAllocated() - PF.GetBitsStored() + 1) ));
       // nmask : to propagate sign bit on negative values
-      int16_t nmask = (int16_t)(0x8000U >> ( PF.GetBitsAllocated() - PF.GetBitsStored() - 1 ));
+      int16_t nmask = (int16_t)0x8000;
+      nmask = (int16_t)(nmask >> ( PF.GetBitsAllocated() - PF.GetBitsStored() - 1 ));
 
       uint16_t c;
       while( is.read((char*)&c,2) )


### PR DESCRIPTION
S. post https://sourceforge.net/p/gdcm/bugs/554/

-----------------------------------------------------------------------------------------------------------------------------

An unexpected behavior was introduced in commit https://github.com/malaterre/GDCM/commit/4ecd77a6bbccd32eaa939d0b06d441ec7a07da6e, causing pixel values being all greater or equal to zero on DICOM images where negative values are expected. When trying to solve the following cppcheck issues:
```
shiftNegativeLHS,GDCM/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx:465,portability,Shifting a negative value is technically undefined behaviour
shiftNegativeLHS,GDCM/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx:521,portability,Shifting a negative value is technically undefined behaviour
```

The changes in gdcmImageCodec.cxx:465 and gdcmImageCodec.cxx:521 implies a potential difference in the sign of nmask, depending on the specific values of PF.GetBitsAllocated() and PF.GetBitsStored(). If the right shift operation in the modified version produces a non-negative value, the result will be positive, whereas the result in the non modified version will always be negative due to the initial assignment of 0x8000 as a signed integer.

-----------------------------------------------------------------------------------------------------------------------------

I could reproduce the issue:

```cpp
#include <iostream>
#include <cstdint>
#include <vector>

int main()
{
  const std::vector<unsigned short> a{ 7, 6, 5, 4, 3, 2, 1, 0 };

  std::cout << "Old:" << '\n';
  for (size_t x = 0; x < a.size(); ++x)
  {
    //////////////////////////////////////////////
    //
    //
    int16_t nmask = (int16_t)0x8000;
    nmask = (int16_t)(nmask >> a.at(x));
    //
    //
    //////////////////////////////////////////////
    std::cout << nmask << '\n';
  }

  std::cout << "New:" << '\n';
  for (size_t x = 0; x < a.size(); ++x)
  {
    //////////////////////////////////////////////
    //
    //
    int16_t nmask = (int16_t)(0x8000U >> a.at(x));
    //
    //
    //////////////////////////////////////////////
    std::cout << nmask << '\n';
  }

  return 0;
}
```

```
Old:
-256
-512
-1024
-2048
-4096
-8192
-16384
-32768
New:
256
512
1024
2048
4096
8192
16384
-32768
```