### PR TITLE
Python 3.13: Replace deprecated PyEval_CallObject()

### DIFF
--- a/Wrapping/Python/gdcmswig.i
+++ b/Wrapping/Python/gdcmswig.i
@@ -623,7 +623,7 @@ static bool callback_helper(gdcm::DataSet const & ds1, gdcm::DataSet const & ds2
     /* fail */
     assert(0);
   }
-  result = PyEval_CallObject(func, arglist);
+  result = PyObject_CallObject(func, arglist);
   Py_DECREF(arglist);
   if (result && result != Py_None) {
     PyErr_SetString(PyExc_TypeError,

--- a/Wrapping/SWIGCommon/gdcmcommon.i
+++ b/Wrapping/SWIGCommon/gdcmcommon.i
@@ -631,7 +631,7 @@ static bool callback_helper(gdcm::DataSet const & ds1, gdcm::DataSet const & ds2
     /* fail */
     assert(0);
   }
-  result = PyEval_CallObject(func, arglist);
+  result = PyObject_CallObject(func, arglist);
   Py_DECREF(arglist);
   if (result && result != Py_None) {
     PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
The function has been deprecated since Python 3.9 and will be removed
from Python 3.13.

See: https://docs.python.org/3.13/whatsnew/3.13.html#id9
