### PR TITLE
Mark COREFOUNDATION_LIBRARY as an advanced setting in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,6 +564,7 @@ if(APPLE)
   if(GDCM_USE_COREFOUNDATION_LIBRARY)
     find_library(COREFOUNDATION_LIBRARY CoreFoundation )
   endif()
+  mark_as_advanced(COREFOUNDATION_LIBRARY)
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
On macOS, just about everything links to CoreFoundation, and no user is ever going to want to change the automatic setting.