### PR TITLE
do not set INSTALL_NAME_DIR for MacOS builds for CMake >= 3.0

### DIFF
--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -166,8 +166,14 @@ if(NOT OPENJPEG_INSTALL_PACKAGE_DIR)
 endif()
 
 if (APPLE)
-	list(APPEND OPENJPEG_LIBRARY_PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${OPENJPEG_INSTALL_LIB_DIR}")
-	option(OPJ_USE_DSYMUTIL "Call dsymutil on binaries after build." OFF)
+  if (${CMAKE_VERSION} VERSION_LESS 3.0)
+    # For cmake >= 3.0, we turn on CMP0042 and
+    # https://cmake.org/cmake/help/v3.0/policy/CMP0042.html mentions
+    # "Projects wanting @rpath in a target’s install name may remove any
+    # setting of the INSTALL_NAME_DIR and CMAKE_INSTALL_NAME_DIR variables"
+    list(APPEND OPENJPEG_LIBRARY_PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${OPENJPEG_INSTALL_LIB_DIR}")
+  endif()
+  option(OPJ_USE_DSYMUTIL "Call dsymutil on binaries after build." OFF)
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Applies [this commit](https://github.com/uclouvain/openjpeg/pull/1410) from official openjpeg repository to the GDCM one. This commit fixes this problem with https://github.com/uclouvain/openjpeg/issues/1404 and makes easier to package GDCM.