### PR TITLE
Iterator invalidation bug

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmByteSwapFilter.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteSwapFilter.cxx
@@ -135,7 +135,6 @@ bool ByteSwapFilter::ByteSwap()
       de.SetTag(
         Tag( SwapperDoOp::Swap( tag.GetGroup() ), SwapperDoOp::Swap( tag.GetElement() ) ) );
       copy.Insert( de );
-      DS.Remove( de.GetTag() );
       }
     DS = copy;
     }


### PR DESCRIPTION
This `DS.Remove()` invalidates the iterator `it` because it deletes the current element of the `std::set` within `DS`.

This is a use-after-free, that in rare circumstances can lead to memory corruption (but in practice, for single-threaded programs, has possibly never actually caused any issues).

The removal is extraneous anyways, due to the subsequent `DS = copy`.