### PR TITLE
fix -Werror=stringop-truncation

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmElement.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmElement.h
@@ -392,7 +392,7 @@ static void x16printf(char *buf, int size, Float f) {
       strcpy(buf, mant);
       return;
     }
-    strncpy(buf, mant, iexp + 1);
+    memcpy(buf, mant, iexp + 1);
     buf[iexp + 1] = '.';
     strncpy(buf + iexp + 2, mant + iexp + 1, size - iexp - 1);
     buf[size] = 0;
@@ -409,7 +409,7 @@ static void x16printf(char *buf, int size, Float f) {
     for(j=0; j< -1 - iexp; j++) {
       buf[j+1] = '0';
     }
-    strncpy(buf - iexp, mant, size + 1 + iexp);
+    memcpy(buf - iexp, mant, size + 1 + iexp);
     buf[size] = 0;
     clean(buf);
   }


### PR DESCRIPTION
While building Source\DataStructureAndEncodingDefinition\gdcmElement.h GCC 12 shows two stringop-truncation warnings. I have tried different approaches to tackle it (adding terminating nulls, some magic with indecies), but have not manage to fix it. Thus, I have used memcpy instead of strncpy. It should work fine as indicies seem calculated fine and terminating nulls are adede manually.   