### PR TITLE
Reduce number of warnings

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
@@ -22,6 +22,7 @@
 #include <iterator>
 #include <iomanip>
 #include <algorithm>
+#include <cstring>
 
 namespace gdcm_ns
 {
@@ -34,14 +35,15 @@ using namespace gdcm;
 class GDCM_EXPORT ByteValue : public Value
 {
 public:
-  ByteValue(const char* array = nullptr, VL const &vl = 0):
-    Internal(array, array+vl),Length(vl) {
+  ByteValue(const char* array = nullptr, VL const &vl = 0): Length(vl) {
       if( vl.IsOdd() )
         {
         gdcmDebugMacro( "Odd length" );
-        Internal.resize(vl+1);
         ++Length;
         }
+      Internal.resize(Length);
+      if(array)
+        std::memcpy(Internal.data(), array, Length);
   }
 
   /// \warning casting to uint32_t

--- a/Source/DataStructureAndEncodingDefinition/gdcmElement.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmElement.h
@@ -607,7 +607,7 @@ public:
         Save = true; // ????
         if( Internal )
           {
-          memcpy(internal, Internal, len);
+          memcpy((void*)internal, (void*)Internal, Length);
           delete[] Internal;
           }
         Internal = internal;
@@ -622,7 +622,7 @@ public:
     bool save = false) {
     if( save ) {
       SetLength(len); // realloc
-      memcpy(Internal, array, len/*/sizeof(Type)*/);
+      memcpy((void*)Internal, (void*)array, len/*/sizeof(Type)*/);
       assert( Save == false );
       }
     else {

--- a/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
@@ -213,7 +213,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
       {
       // For Pixel Data:
       // if( !ds.FindDataElement( bitsallocated ) ) return VR::UN;
-      Attribute<0x0028,0x0100> at;
+      // Attribute<0x0028,0x0100> at;
       // at.SetFromDataElement( ds.GetDataElement( bitsallocated ) );
       }
     (void)v;

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestElement1.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestElement1.cxx
@@ -114,7 +114,7 @@ int TestAT()
   list[0] = Tag(0x0010,0x0010);
   list[1] = Tag(0x0010,0x0020);
   list[2] = Tag(0x0020,0x0013);
-  memcpy(&a, list, sizeof(list));
+  memcpy((void*)&a, (void*)list, sizeof(list));
   a.Print( std::cout );
   std::cout << std::endl;
 

--- a/Utilities/gdcmcharls/jpegmarkersegment.cpp
+++ b/Utilities/gdcmcharls/jpegmarkersegment.cpp
@@ -58,7 +58,7 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateJpegFileInterchangeFormat
     content.push_back(static_cast<uint8_t>(params.Ythumbnail));
     if (params.Xthumbnail > 0)
     {
-        if (params.thumbnail)
+        if (!params.thumbnail)
             throw CreateSystemError(ApiResult::InvalidJlsParameters, "params.Xthumbnail is > 0 but params.thumbnail == null_ptr");
 
         content.insert(content.end(), static_cast<uint8_t*>(params.thumbnail),

--- a/Utilities/gdcmrle/io.cxx
+++ b/Utilities/gdcmrle/io.cxx
@@ -78,6 +78,7 @@ int source::read_into_segments( char * out, int len, image_info const & ii )
         int nvalues = read(out + 0 * llen, llen);
         assert( nvalues == llen ); (void)nvalues;
         bool b = seek(pos + 1 * plane);
+        (void)b;
         assert(b);
         nvalues = read(out + 1 * llen, llen);
         assert( nvalues == llen ); (void)nvalues;

--- a/Utilities/socketxx/socket++/fork.cpp
+++ b/Utilities/socketxx/socket++/fork.cpp
@@ -37,14 +37,15 @@ Fork::~Fork ()
 Fork::KillForks::~KillForks ()
   // First, kill all children whose kill_child flag is set.
   // Second, wait for other children to die.
-{
-  
-  for (ForkProcess* cur = Fork::ForkProcess::list; cur != nullptr; cur = cur->next)
-    if (cur->kill_child) {
+{ 
+  ForkProcess* cur = Fork::ForkProcess::list;
+  while(cur != nullptr){
+    ForkProcess* next = cur->next; 
+    if(cur->kill_child)
       delete cur;
-      break;
-    }
-
+    cur = next;  
+  }
+ 
   while (Fork::ForkProcess::list && wait (nullptr) > 0) {}
 }
 

--- a/Utilities/socketxx/socket++/fork.cpp
+++ b/Utilities/socketxx/socket++/fork.cpp
@@ -38,9 +38,12 @@ Fork::KillForks::~KillForks ()
   // First, kill all children whose kill_child flag is set.
   // Second, wait for other children to die.
 {
-  for (ForkProcess* cur = Fork::ForkProcess::list; cur; cur = cur->next)
-    if (cur->kill_child)
+  
+  for (ForkProcess* cur = Fork::ForkProcess::list; cur != nullptr; cur = cur->next)
+    if (cur->kill_child) {
       delete cur;
+      break;
+    }
 
   while (Fork::ForkProcess::list && wait (nullptr) > 0) {}
 }


### PR DESCRIPTION
Fix of: -Wclass-memaccess -Wuse-after-free -Werror=unused-but-set-variable -Werror=unused-variable -Werror=nonnull for GCC 12. 
This PR is updated https://github.com/malaterre/GDCM/pull/177.