### PR TITLE
Use cmake_minimum_required to set min and policy_max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,7 @@
-cmake_minimum_required(VERSION 3.9.2 FATAL_ERROR) # travis-ci wants 3.9.2
-
 set(GDCM_MAX_VALIDATED_CMAKE_VERSION "3.13.4")
-if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "${GDCM_MAX_VALIDATED_CMAKE_VERSION}")
-  # As of 2018-12-04 GDCM has been validated to build with cmake version 3.13.1 new policies.
-  # Set and use the newest cmake policies that are validated to work
-  set(GDCM_CMAKE_POLICY_VERSION "${CMAKE_VERSION}")
-else()
-  set(GDCM_CMAKE_POLICY_VERSION "${GDCM_MAX_VALIDATED_CMAKE_VERSION}")
-endif()
-cmake_policy(VERSION ${GDCM_CMAKE_POLICY_VERSION})
+
+# Set minimum required version of CMake, and policy version
+cmake_minimum_required(VERSION 3.9.2...${GDCM_MAX_VALIDATED_CMAKE_VERSION} FATAL_ERROR) # travis-ci wants 3.9.2
 
 # GDCM version 3.0.0 will only support C++11 and greater
 if(CMAKE_CXX_STANDARD EQUAL "98" )

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.7...3.13.4)
 
 # Choose behavior based on whether we are building inside the GDCM tree.
 if(GDCM_BINARY_DIR)

--- a/Utilities/gdcmcharls/CMakeLists.txt
+++ b/Utilities/gdcmcharls/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT CHARLS_NAMESPACE)
@@ -11,14 +11,6 @@ string(TOLOWER ${CHARLS_NAMESPACE} CHARLS_LIBRARY_NAME)
 
 project(${CHARLS_NAMESPACE} CXX)
 
-foreach(p
-    CMP0042
-    CMP0063
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 #-----------------------------------------------------------------------------
 # CHARLS version number

--- a/Utilities/gdcmexpat/CMakeLists.txt
+++ b/Utilities/gdcmexpat/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT EXPAT_NAMESPACE)

--- a/Utilities/gdcmjpeg/CMakeLists.txt
+++ b/Utilities/gdcmjpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT JPEG_NAMESPACE)
@@ -17,14 +17,6 @@ string(TOLOWER ${JPEG_NAMESPACE} JPEG_LIBRARY_NAME)
 
 project(${JPEG_NAMESPACE} C)
 
-foreach(p
-    CMP0042
-    CMP0063
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 # Do full dependency headers.
 include_regular_expression("^.*$")

--- a/Utilities/gdcmmd5/CMakeLists.txt
+++ b/Utilities/gdcmmd5/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT MD5_NAMESPACE)

--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -8,23 +8,7 @@
 # e.g.:
 # set(OPENJPEG_NAMESPACE "GDCMOPENJPEG")
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.2)
-endif()
-
-if(COMMAND CMAKE_POLICY)
-  cmake_policy(SET CMP0003 NEW)
-  if (NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
-    cmake_policy(SET CMP0042 NEW)
-  endif()
-
-  foreach(p
-      CMP0042
-      CMP0063
-      )
-    if(POLICY ${p})
-      cmake_policy(SET ${p} NEW)
-    endif()
-  endforeach()
+  cmake_minimum_required(VERSION 2.8.2...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT OPENJPEG_NAMESPACE)

--- a/Utilities/gdcmuuid/CMakeLists.txt
+++ b/Utilities/gdcmuuid/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT UUID_NAMESPACE)

--- a/Utilities/gdcmzlib/CMakeLists.txt
+++ b/Utilities/gdcmzlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT ZLIB_NAMESPACE)

--- a/Utilities/getopt/CMakeLists.txt
+++ b/Utilities/getopt/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
 
 if(NOT GETOPT_NAMESPACE)

--- a/Utilities/socketxx/CMakeLists.txt
+++ b/Utilities/socketxx/CMakeLists.txt
@@ -1,16 +1,6 @@
 if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-  cmake_minimum_required(VERSION 2.8.7)
+  cmake_minimum_required(VERSION 2.8.7...${GDCM_MAX_VALIDATED_CMAKE_VERSION})
 endif()
-
-foreach(p
-    CMP0022
-    CMP0042
-    CMP0063 # CMake 3.3.2
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 # http://www.linuxhacker.at/socketxx
 if(NOT SOCKETXX_NAMESPACE)


### PR DESCRIPTION
CMake version >3.30 produce a deprecated awarning when only, a min argument less that 3.10 is pass to cmake_minimum_required. Using the additional policy_max version range specified the max policy setting at the same time.

Addresses the following warnings on the ITK Dashboards:
CMake Deprecation Warning at Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
