### PR TITLE
ByteValue: safer and more effitient memory usage

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
@@ -22,6 +22,7 @@
 #include <iterator>
 #include <iomanip>
 #include <algorithm>
+#include <cstring>
 
 namespace gdcm_ns
 {


### PR DESCRIPTION
Firstly, the user can initialize a ByteValue object with nullptr and non-zero length which may lead to nullprt dereference. 

Secondly, if the passed length is odd, already initialized "Internal" vector is resized, which most likely causes memory reallocation and copy. Instead, memory can be allocated only once after a proper length calculated. On top of that, "memcpy" might be faster than than  initializing with "Internal(array, array+vlm)".  It safe as Internal is just a vector of chars. 

To sum up, taking into consideration that ByteValue is oftenly used, I believe these changes are worth to be taken.