### PR TITLE
Socket++ fork memory safery improvements

### DIFF
--- a/Utilities/socketxx/socket++/fork.cpp
+++ b/Utilities/socketxx/socket++/fork.cpp
@@ -38,9 +38,13 @@ Fork::KillForks::~KillForks ()
   // First, kill all children whose kill_child flag is set.
   // Second, wait for other children to die.
 {
-  for (ForkProcess* cur = Fork::ForkProcess::list; cur; cur = cur->next)
-    if (cur->kill_child)
+  ForkProcess* cur = Fork::ForkProcess::list;
+  while(cur != nullptr){
+    ForkProcess* next = cur->next; 
+    if(cur->kill_child)
       delete cur;
+    cur = next;  
+  }
 
   while (Fork::ForkProcess::list && wait (nullptr) > 0) {}
 }


### PR DESCRIPTION
Right now an order of operations is:

1. Delete curr.
2. Access curr in "curr = curr->next"
3. Check if new curr is nullptr.

curr->next must be preserved before curr is deleted, what I have done in this PR. The flow now is:

1. If "curr" is nullptr nothing is done, loop is jut skipped (escaped).
2. "next" is preserved.
3. "curr" is deleted by the same condition as before, thus the behaviour should not be changed.
4. The preserve "next" is assigned to "curr"
5. Begin from 1.

