### PR TITLE
gdcmcharls fix nullptr dereferece

### DIFF
--- a/Utilities/gdcmcharls/jpegmarkersegment.cpp
+++ b/Utilities/gdcmcharls/jpegmarkersegment.cpp
@@ -58,7 +58,7 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateJpegFileInterchangeFormat
     content.push_back(static_cast<uint8_t>(params.Ythumbnail));
     if (params.Xthumbnail > 0)
     {
-        if (params.thumbnail)
+        if (!params.thumbnail)
             throw CreateSystemError(ApiResult::InvalidJlsParameters, "params.Xthumbnail is > 0 but params.thumbnail == null_ptr");
 
         content.insert(content.end(), static_cast<uint8_t*>(params.thumbnail),


### PR DESCRIPTION
I know that it is external copypasta code. But GCC12 compile rises -Werror=nonnull warning and it makes sense.
According to an exception message, the exception must be thrown if params.thumbnail is nullptr. Moreover, right now the pointer remains nullptr and it is dereferenced in the very next statment. So, I am tent to believe the current version is mistaken and should be fixed.