### PR TITLE
BUG: Release jpeg2000 resources when error occours

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
@@ -1487,7 +1487,8 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     &image) ? true : false;
   if(!bResult)
   {
-  opj_stream_destroy(cio);
+    opj_destroy_codec(dinfo);
+    opj_stream_destroy(cio);
     return false;
   }
   //image = opj_decode(dinfo, cio);
@@ -1530,6 +1531,8 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
 
   if( !check_comp_valid( image ) )
     {
+    opj_destroy_codec(dinfo);
+    opj_stream_destroy(cio);
     gdcmErrorMacro( "Invalid test failed" );
     return false;
     }
@@ -1551,6 +1554,8 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     }
   else
     {
+    opj_destroy_codec(dinfo);
+    opj_stream_destroy(cio);
     gdcmErrorMacro( "do not handle precision: " << comp->prec );
     return false;
     }
@@ -1603,6 +1608,8 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     }
   else if( image->numcomps == 4 )
     {
+    opj_destroy_codec(dinfo);
+    opj_stream_destroy(cio);
     /* Yes this is legal */
     // http://www.crc.ricoh.com/~gormish/jpeg2000conformance/
     // jpeg2000testimages/Part4TestStreams/codestreams_profile0/p0_06.j2k
@@ -1612,6 +1619,8 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     }
   else
     {
+    opj_destroy_codec(dinfo);
+    opj_stream_destroy(cio);
     // jpeg2000testimages/Part4TestStreams/codestreams_profile0/p0_13.j2k
     gdcmErrorMacro( "Image is " << image->numcomps << " components which is not supported in DICOM" );
     return false;


### PR DESCRIPTION
Repeated attempted reading of DICOM files with unsupported JPEG2000 encoding can results is resource exhaustion. For example threads were not being freed before when errors were encountered.