### PR TITLE
Use exceptions over aborts

### DIFF
--- a/Applications/Cxx/deflate.cxx
+++ b/Applications/Cxx/deflate.cxx
@@ -53,7 +53,7 @@ int inf(FILE *source, FILE *dest)
             strm.avail_out = CHUNK;
             strm.next_out = out;
             ret = inflate(&strm, Z_NO_FLUSH);
-            assert(ret != Z_STREAM_ERROR);  /* state not clobbered */
+            gdcm_assert(ret != Z_STREAM_ERROR);  /* state not clobbered */
             switch (ret) {
             case Z_NEED_DICT:
                 ret = Z_DATA_ERROR;     /* and fall through */

--- a/Applications/Cxx/gdcmanon.cxx
+++ b/Applications/Cxx/gdcmanon.cxx
@@ -424,44 +424,44 @@ int main(int argc, char *argv[])
           {
           //if( option_index == 0 ) /* input */
           //  {
-          //  assert( strcmp(s, "input") == 0 );
-          //  assert( filename.empty() );
+          //  gdcm_assert( strcmp(s, "input") == 0 );
+          //  gdcm_assert( filename.empty() );
           //  filename = optarg;
           //  }
           //else if( option_index == 1 ) /* output */
           //  {
-          //  assert( strcmp(s, "output") == 0 );
-          //  assert( outfilename.empty() );
+          //  gdcm_assert( strcmp(s, "output") == 0 );
+          //  gdcm_assert( outfilename.empty() );
           //  outfilename = optarg;
           //  }
           //else...
           if( option_index == 2 ) /* root-uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
-            assert( root.empty() );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( root.empty() );
             root = optarg;
             }
           else if( option_index == 3 ) /* resources-path */
             {
-            assert( strcmp(s, "resources-path") == 0 );
-            assert( xmlpath.empty() );
+            gdcm_assert( strcmp(s, "resources-path") == 0 );
+            gdcm_assert( xmlpath.empty() );
             xmlpath = optarg;
             }
           //else if( option_index == 6 ) /* key */
           //  {
-          //  assert( strcmp(s, "key") == 0 );
-          //  assert( rsa_path.empty() );
+          //  gdcm_assert( strcmp(s, "key") == 0 );
+          //  gdcm_assert( rsa_path.empty() );
           //  rsa_path = optarg;
           //  }
           //else if( option_index == 7 ) /* certificate */
           //  {
-          //  assert( strcmp(s, "certificate") == 0 );
-          //  assert( cert_path.empty() );
+          //  gdcm_assert( strcmp(s, "certificate") == 0 );
+          //  gdcm_assert( cert_path.empty() );
           //  cert_path = optarg;
           //  }
           else if( option_index == 15 ) /* empty */
             {
-            assert( strcmp(s, "empty") == 0 );
+            gdcm_assert( strcmp(s, "empty") == 0 );
             if( privatetag.ReadFromCommaSeparatedString(optarg) )
               empty_privatetags.push_back( privatetag );
             else if( tag.ReadFromCommaSeparatedString(optarg) )
@@ -474,7 +474,7 @@ int main(int argc, char *argv[])
             }
           else if( option_index == 16 ) /* clear */
             {
-            assert( strcmp(s, "clear") == 0 );
+            gdcm_assert( strcmp(s, "clear") == 0 );
             if( privatetag.ReadFromCommaSeparatedString(optarg) )
               clear_privatetags.push_back( privatetag );
             else if( tag.ReadFromCommaSeparatedString(optarg) )
@@ -487,7 +487,7 @@ int main(int argc, char *argv[])
             }
           else if( option_index == 17 ) /* remove */
             {
-            assert( strcmp(s, "remove") == 0 );
+            gdcm_assert( strcmp(s, "remove") == 0 );
             if( privatetag.ReadFromCommaSeparatedString(optarg) )
               remove_privatetags.push_back( privatetag );
             else if( tag.ReadFromCommaSeparatedString(optarg) )
@@ -500,7 +500,7 @@ int main(int argc, char *argv[])
             }
           else if( option_index == 18 ) /* replace */
             {
-            assert( strcmp(s, "replace") == 0 );
+            gdcm_assert( strcmp(s, "replace") == 0 );
             if( privatetag.ReadFromCommaSeparatedString(optarg) )
               {
               return 1;
@@ -512,13 +512,13 @@ int main(int argc, char *argv[])
               uint16_t dummy;
               char cdummy; // comma
               ss >> std::hex >> dummy;
-              assert( tag.GetGroup() == dummy );
+              gdcm_assert( tag.GetGroup() == dummy );
               ss >> cdummy;
-              assert( cdummy == ',' );
+              gdcm_assert( cdummy == ',' );
               ss >> std::hex >> dummy;
-              assert( tag.GetElement() == dummy );
+              gdcm_assert( tag.GetElement() == dummy );
               ss >> cdummy;
-              assert( cdummy == ',' || cdummy == '=' );
+              gdcm_assert( cdummy == ',' || cdummy == '=' );
               std::string str;
               //ss >> str;
               std::getline(ss, str); // do not skip whitespace
@@ -532,7 +532,7 @@ int main(int argc, char *argv[])
             }
           else if( option_index == 20 ) /* crypto */
             {
-            assert( strcmp(s, "crypto") == 0 );
+            gdcm_assert( strcmp(s, "crypto") == 0 );
             if (strcmp(optarg, "openssl") == 0)
               crypto_lib = gdcm::CryptoFactory::OPENSSL;
             else if (strcmp(optarg, "capi") == 0)
@@ -552,12 +552,12 @@ int main(int argc, char *argv[])
       break;
 
     case 'i':
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 
@@ -566,17 +566,17 @@ int main(int argc, char *argv[])
       break;
 
     case 'k': // key
-      assert( rsa_path.empty() );
+      gdcm_assert( rsa_path.empty() );
       rsa_path = optarg;
       break;
 
     case 'c': // certificate
-      assert( cert_path.empty() );
+      gdcm_assert( cert_path.empty() );
       cert_path = optarg;
       break;
 
     case 'p': // password
-      assert( password.empty() );
+      gdcm_assert( password.empty() );
       password = optarg;
       break;
 

--- a/Applications/Cxx/gdcmclean.cxx
+++ b/Applications/Cxx/gdcmclean.cxx
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]) {
         if (optarg) {
           if (option_index == 3) /* empty */
           {
-            assert(strcmp(s, "empty") == 0);
+            gdcm_assert(strcmp(s, "empty") == 0);
             if (gdcm::VR::IsValid(optarg))
               empty_vrs.push_back(gdcm::VR::GetVRTypeFromFile(optarg));
             else if (privatetag.ReadFromCommaSeparatedString(optarg))
@@ -289,18 +289,18 @@ int main(int argc, char *argv[]) {
               return 1;
             }
           } else {
-            assert(0);
+            gdcm_assert(0);
           }
         }
       } break;
 
       case 'i':
-        assert(filename.empty());
+        gdcm_assert(filename.empty());
         filename = optarg;
         break;
 
       case 'o':
-        assert(outfilename.empty());
+        gdcm_assert(outfilename.empty());
         outfilename = optarg;
         break;
 

--- a/Applications/Cxx/gdcmconv.cxx
+++ b/Applications/Cxx/gdcmconv.cxx
@@ -658,29 +658,29 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 14 ) /* root-uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
-            assert( root.empty() );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( root.empty() );
             root = optarg;
             }
           else if( option_index == 28 ) /* split */
             {
-            assert( strcmp(s, "split") == 0 );
+            gdcm_assert( strcmp(s, "split") == 0 );
             fragmentsize = atoi(optarg);
             }
           else if( option_index == 29 ) /* planar conf*/
             {
-            assert( strcmp(s, "planar-configuration") == 0 );
+            gdcm_assert( strcmp(s, "planar-configuration") == 0 );
             planarconfval = atoi(optarg);
             }
           else if( option_index == 34 ) /* icon minmax*/
             {
-            assert( strcmp(s, "icon-minmax") == 0 );
+            gdcm_assert( strcmp(s, "icon-minmax") == 0 );
             std::stringstream ss;
             ss.str( optarg );
             ss >> iconmin;
@@ -690,33 +690,33 @@ int main (int argc, char *argv[])
             }
           else if( option_index == 40 ) /* photometricinterpretation */
             {
-            assert( strcmp(s, "photometric-interpretation") == 0 );
+            gdcm_assert( strcmp(s, "photometric-interpretation") == 0 );
             photometricinterpretation_str = optarg;
             }
           else if( option_index == 42 ) /* rate */
             {
-            assert( strcmp(s, "rate") == 0 );
+            gdcm_assert( strcmp(s, "rate") == 0 );
             readvector(rates, optarg);
             }
           else if( option_index == 43 ) /* quality */
             {
-            assert( strcmp(s, "quality") == 0 );
+            gdcm_assert( strcmp(s, "quality") == 0 );
             readvector(qualities, optarg);
             }
           else if( option_index == 44 ) /* tile */
             {
-            assert( strcmp(s, "tile") == 0 );
+            gdcm_assert( strcmp(s, "tile") == 0 );
             size_t n = readvector(tilesize, optarg);
-            assert( n == 2 ); (void)n;
+            gdcm_assert( n == 2 ); (void)n;
             }
           else if( option_index == 45 ) /* number of resolution */
             {
-            assert( strcmp(s, "number-resolution") == 0 );
+            gdcm_assert( strcmp(s, "number-resolution") == 0 );
             nresvalue = atoi(optarg);
             }
           else if( option_index == 47 ) /* JPEG-LS error */
             {
-            assert( strcmp(s, "allowed-error") == 0 );
+            gdcm_assert( strcmp(s, "allowed-error") == 0 );
             jpeglserror_value = atoi(optarg);
             }
           //printf (" with arg %s, index = %d", optarg, option_index);
@@ -727,13 +727,13 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
       //printf ("option o with value '%s'\n", optarg);
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 
@@ -1202,7 +1202,7 @@ int main (int argc, char *argv[])
         jpegcodec.SetLossless( false );
         if( quality )
           {
-          assert( qualities.size() == 1 );
+          gdcm_assert( qualities.size() == 1 );
           jpegcodec.SetQuality( static_cast<double>(qualities[0]) );
           }
         change.SetUserCodec( &jpegcodec );
@@ -1286,7 +1286,7 @@ int main (int argc, char *argv[])
         }
       else
         {
-        assert( ts.IsImplicit() );
+        gdcm_assert( ts.IsImplicit() );
         change.SetTransferSyntax( gdcm::TransferSyntax::ImplicitVRLittleEndian );
         if( explicitts )
         change.SetTransferSyntax( gdcm::TransferSyntax::ExplicitVRLittleEndian );
@@ -1405,7 +1405,7 @@ int main (int argc, char *argv[])
       }
     else
       {
-      assert( ts.IsImplicit() );
+      gdcm_assert( ts.IsImplicit() );
       image.SetTransferSyntax( gdcm::TransferSyntax::ImplicitVRLittleEndian );
       }
 
@@ -1424,7 +1424,7 @@ int main (int argc, char *argv[])
 */
 
     unsigned long len = ir.GetBufferLength();
-    //assert( len = ir.GetBufferLength() );
+    //gdcm_assert( len = ir.GetBufferLength() );
     std::vector<char> buffer;
     buffer.resize(len); // black image
 

--- a/Applications/Cxx/gdcmdump.cxx
+++ b/Applications/Cxx/gdcmdump.cxx
@@ -93,12 +93,12 @@ static void printvaluet(std::istream & is, uint32_t numels)
 
 static void printvalue(std::istream &is, uint32_t type, uint32_t numels, uint32_t pos)
 {
-  assert( numels > 0 );
+  gdcm_assert( numels > 0 );
   std::streampos start = is.tellg();
   is.seekg( pos );
   std::cout << "[";
   typedef char (string81)[81]; // 80'th byte == 0
-  assert( sizeof( string81 ) == 81 );
+  gdcm_assert( sizeof( string81 ) == 81 );
   switch( type )
     {
   case TYPE_FLOAT:
@@ -114,7 +114,7 @@ static void printvalue(std::istream &is, uint32_t type, uint32_t numels, uint32_
     printvaluet<uint32_t>(is, numels);
     break;
   default:
-    assert( 0 );
+    gdcm_assert( 0 );
     }
   std::cout << "]";
   std::cout << " # " << numels;
@@ -146,7 +146,7 @@ static void printbinary(std::istream &is, PDFElement const & pdfel )
   uint32_t type = pdfel.gettype();
   uint32_t numels = pdfel.getnumelems();
   //uint32_t dummy = pdfel.getdummy();
-  //assert( dummy == 0 ); (void)dummy;
+  //gdcm_assert( dummy == 0 ); (void)dummy;
   uint32_t offset = pdfel.getoffset();
   uint32_t pos = (uint32_t)(offset + is.tellg() - 4);
   printvalue(is, type, numels, pos);
@@ -165,28 +165,28 @@ static void ProcessSDSDataString( std::istream & is )
 #if 0
   int32_t v1;
   is.read( (char*)&v1,sizeof(v1));
-  assert( v1 == 0x1 );
+  gdcm_assert( v1 == 0x1 );
   uint32_t bla;
   is.read( (char*)&bla, sizeof(bla) );
   char name0[32];
   memset(name0,0,sizeof(name0));
-  assert( bla < sizeof(name0) );
+  gdcm_assert( bla < sizeof(name0) );
   is.read( name0, bla);
   size_t l = strlen(name0);
-  assert( l == bla );
+  gdcm_assert( l == bla );
   std::cerr << "name0:" << name0 << std::endl;
 
   is.read( (char*)&bla, sizeof(bla) );
-  assert( bla == 0x1 );
+  gdcm_assert( bla == 0x1 );
   is.read( (char*)&bla, sizeof(bla) );
   char value[32];
   memset(value,0,sizeof(value));
-  assert( bla < sizeof(value) );
+  gdcm_assert( bla < sizeof(value) );
   is.read( value, bla);
   is.read( (char*)&bla, sizeof(bla) );
-  assert( bla == 0 ); // trailing stuff ?
+  gdcm_assert( bla == 0 ); // trailing stuff ?
   is.read( (char*)&bla, sizeof(bla) );
-  assert( bla == 0 ); // trailing stuff ?
+  gdcm_assert( bla == 0 ); // trailing stuff ?
   const uint32_t cur = (uint32_t)is.tellg();
   std::cerr << "offset:" << cur << std::endl;
 #else
@@ -199,15 +199,15 @@ static void ProcessSDSData( std::istream & is )
   // haven't been able to figure out what was the begin meant for
   is.seekg( 0x20 - 8 );
   uint32_t version = 0;
-  assert( sizeof(uint32_t) == 4 );
+  gdcm_assert( sizeof(uint32_t) == 4 );
   is.read( (char*)&version, sizeof(version) );
-  assert( version == 8 );
+  gdcm_assert( version == 8 );
   uint32_t numel = 0;
   is.read( (char*)&numel, sizeof(numel) );
   for( uint32_t el = 0; el < numel; ++el )
     {
     PDFElement pdfel;
-    assert( sizeof(pdfel) == 50 );
+    gdcm_assert( sizeof(pdfel) == 50 );
     is.read( (char*)&pdfel, 50 );
     if( *pdfel.getname() )
       {
@@ -273,7 +273,7 @@ static int DumpPMS_MRSDS(const gdcm::DataSet & ds)
         else if( s1 == "COILSTATE " )
           ProcessSDSDataString( is );
         else
-          assert(0);
+          gdcm_assert(0);
       } else {
         ProcessSDSData( is );
       }
@@ -530,7 +530,7 @@ static bool ProcessData( const char *buf, size_t len )
 {
   Data2 data2;
   const size_t s = sizeof(data2);
-  assert( len >= s); (void)len;
+  gdcm_assert( len >= s); (void)len;
   // VIMDATA2 is generally 2048 bytes, while s = 1786
   // the end is filled with \0 bytes
   memcpy(&data2, buf, s);
@@ -598,7 +598,7 @@ struct el
     readastring( name, input );
     const char *p = input + 1+  name.size();
     memcpy( &pad, p, sizeof( pad ) );
-    //assert( pad == 1 || pad == 2 || pad == 3 || pad == 6 );
+    //gdcm_assert( pad == 1 || pad == 2 || pad == 3 || pad == 6 );
     values.resize( pad );
     const char *pp = p + sizeof(uint32_t);
     for( uint32_t pidx = 0; pidx < pad; ++pidx )
@@ -683,11 +683,11 @@ struct info
       // postcondition
       uint32_t fixme;
       memcpy( &fixme, in, sizeof(fixme) );
-      assert( fixme == 0x0006981A );
+      gdcm_assert( fixme == 0x0006981A );
       }
     else
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
     return in - m;
     }
@@ -725,7 +725,7 @@ static int DumpEl2_new(const gdcm::DataSet & ds)
   } else {
   uint32_t val0[3];
   memcpy( &val0, begin, sizeof( val0 ) );
-  assert( val0[0] == 0xF22D );
+  gdcm_assert( val0[0] == 0xF22D );
   begin += sizeof( val0 );
 
   // 1A 98 06 00 -> start element
@@ -735,7 +735,7 @@ static int DumpEl2_new(const gdcm::DataSet & ds)
   std::cout << "ELSCINT1 Dumping info from tag " << t01f7_26 << std::endl;
   info i;
   size_t o;
-  assert( val0[1] == 0x1 );
+  gdcm_assert( val0[1] == 0x1 );
   for( uint32_t idx = 0; idx < val0[2]; ++idx )
     {
     o = i.Read( begin );
@@ -1067,7 +1067,7 @@ static int PrintCSABase64Impl(gdcm::CSAHeader &csa, std::string const & csaname 
       {
         ds2.Insert( xde );
       }
-      assert( ss.eof() );
+      gdcm_assert( ss.eof() );
     }
     catch(std::exception &)
     {
@@ -1419,8 +1419,8 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           //printf (" with arg %s", optarg);
@@ -1431,7 +1431,7 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
@@ -1671,7 +1671,7 @@ int main (int argc, char *argv[])
     }
   else
     {
-    assert( gdcm::System::FileExists(filename.c_str()) );
+    gdcm_assert( gdcm::System::FileExists(filename.c_str()) );
     if( printdict )
       {
       res += DoOperation<gdcm::DictPrinter>(filename);

--- a/Applications/Cxx/gdcmgendir.cxx
+++ b/Applications/Cxx/gdcmgendir.cxx
@@ -113,31 +113,31 @@ int main(int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 1 ) /* output */
             {
-            assert( strcmp(s, "output") == 0 );
-            assert( outfilename.empty() );
+            gdcm_assert( strcmp(s, "output") == 0 );
+            gdcm_assert( outfilename.empty() );
             outfilename = optarg;
             }
           else if( option_index == 3 ) /* root-uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
             root = optarg;
             }
           else if( option_index == 4 ) /* resources-path */
             {
-            assert( strcmp(s, "resources-path") == 0 );
-            assert( xmlpath.empty() );
+            gdcm_assert( strcmp(s, "resources-path") == 0 );
+            gdcm_assert( xmlpath.empty() );
             xmlpath = optarg;
             }
           else if( option_index == 5 ) /* descriptor */
             {
-            assert( strcmp(s, "descriptor") == 0 );
-            assert( descriptor_str.empty() );
+            gdcm_assert( strcmp(s, "descriptor") == 0 );
+            gdcm_assert( descriptor_str.empty() );
             descriptor_str = optarg;
             }
           //printf (" with arg %s", optarg);
@@ -148,12 +148,12 @@ int main(int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 

--- a/Applications/Cxx/gdcmimg.cxx
+++ b/Applications/Cxx/gdcmimg.cxx
@@ -346,7 +346,7 @@ static bool PopulateSingeFile( gdcm::PixmapWriter & writer,
 
 static bool Populate( gdcm::PixmapWriter & writer, gdcm::ImageCodec & jpeg, gdcm::Directory::FilenamesType const & filenames, unsigned int ndim = 2, std::streampos const & pos = 0 )
 {
-  assert( !filenames.empty() );
+  gdcm_assert( !filenames.empty() );
   std::vector<std::string>::const_iterator it = filenames.begin();
   bool b = true;
   gdcm::Pixmap &image = writer.GetPixmap();
@@ -509,92 +509,92 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.IsEmpty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.IsEmpty() );
             filename = optarg;
             filenames.emplace_back(filename);
             }
           else if( option_index == 2 ) /* depth */
             {
-            assert( strcmp(s, "depth") == 0 );
+            gdcm_assert( strcmp(s, "depth") == 0 );
             bpp = atoi(optarg);
             }
           else if( option_index == 3 ) /* size */
             {
-            assert( strcmp(s, "size") == 0 );
+            gdcm_assert( strcmp(s, "size") == 0 );
             ndimension = readsize(optarg, size);
             }
           else if( option_index == 4 ) /* region */
             {
-            assert( strcmp(s, "region") == 0 );
+            gdcm_assert( strcmp(s, "region") == 0 );
             readgeometry(optarg, region);
             }
           else if( option_index == 5 ) /* fill */
             {
-            assert( strcmp(s, "fill") == 0 );
+            gdcm_assert( strcmp(s, "fill") == 0 );
             color = atoi(optarg);
             }
           else if( option_index == 6 ) /* study-uid */
             {
-            assert( strcmp(s, "study-uid") == 0 );
+            gdcm_assert( strcmp(s, "study-uid") == 0 );
             study_uid = optarg;
             }
           else if( option_index == 7 ) /* series-uid */
             {
-            assert( strcmp(s, "series-uid") == 0 );
+            gdcm_assert( strcmp(s, "series-uid") == 0 );
             series_uid = optarg;
             }
           else if( option_index == 8 ) /* root-uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
             root = optarg;
             }
           else if( option_index == 9 ) /* sop-class-uid */
             {
-            assert( strcmp(s, "sop-class-uid") == 0 );
+            gdcm_assert( strcmp(s, "sop-class-uid") == 0 );
             sopclass = optarg;
             }
           else if( option_index == 10 ) /* endian */
             {
-            assert( strcmp(s, "endian") == 0 );
+            gdcm_assert( strcmp(s, "endian") == 0 );
             lsb_msb = optarg;
             }
           else if( option_index == 11 ) /* sign */
             {
-            assert( strcmp(s, "sign") == 0 );
+            gdcm_assert( strcmp(s, "sign") == 0 );
             pixelsign = atoi(optarg);
             }
           else if( option_index == 12 ) /* spp */
             {
-            assert( strcmp(s, "spp") == 0 );
+            gdcm_assert( strcmp(s, "spp") == 0 );
             pixelspp = atoi(optarg);
             }
           else if( option_index == 13 ) /* pconf */
             {
-            assert( strcmp(s, "pc") == 0 );
+            gdcm_assert( strcmp(s, "pc") == 0 );
             pconf = atoi(optarg);
             }
           else if( option_index == 14 ) /* pinter */
             {
-            assert( strcmp(s, "pi") == 0 );
+            gdcm_assert( strcmp(s, "pi") == 0 );
             pinter = 1;
             pinterstr = optarg;
             }
           else if( option_index == 15 ) /* pformat */
             {
-            assert( strcmp(s, "pf") == 0 );
+            gdcm_assert( strcmp(s, "pf") == 0 );
             pformat = 1;
             pformatstr = optarg;
             }
           else if( option_index == 16 ) /* start_pos */
             {
-            assert( strcmp(s, "offset") == 0 );
+            gdcm_assert( strcmp(s, "offset") == 0 );
             poffset = 1;
             start_pos = (size_t)std::atoll(optarg);
             }
           else if( option_index == 17 ) /* template */
             {
-            assert( strcmp(s, "template") == 0 );
+            gdcm_assert( strcmp(s, "template") == 0 );
             templated = 1;
             templatefilename = optarg;
             }
@@ -606,14 +606,14 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.IsEmpty() );
+      gdcm_assert( filename.IsEmpty() );
       filename = optarg;
       filenames.emplace_back(filename);
       break;
 
     case 'o':
       //printf ("option o with value '%s'\n", optarg);
-      assert( outfilename.IsEmpty() );
+      gdcm_assert( outfilename.IsEmpty() );
       outfilename = optarg;
       break;
 
@@ -1175,7 +1175,7 @@ int main (int argc, char *argv[])
   if( fill )
     {
     const gdcm::PixelFormat &pixeltype = imageori.GetPixelFormat();
-    assert( imageori.GetNumberOfDimensions() == 2 || imageori.GetNumberOfDimensions() == 3 );
+    gdcm_assert( imageori.GetNumberOfDimensions() == 2 || imageori.GetNumberOfDimensions() == 3 );
     unsigned long len = imageori.GetBufferLength();
     gdcm::SmartPointer<gdcm::Pixmap> image = new gdcm::Pixmap;
     image->SetNumberOfDimensions( 2 ); // good default
@@ -1248,7 +1248,7 @@ int main (int argc, char *argv[])
       }
     else
       {
-      assert( ts.IsImplicit() );
+      gdcm_assert( ts.IsImplicit() );
       image->SetTransferSyntax( gdcm::TransferSyntax::ImplicitVRLittleEndian );
       }
     //imageori.Print( std::cout );

--- a/Applications/Cxx/gdcminfo.cxx
+++ b/Applications/Cxx/gdcminfo.cxx
@@ -678,14 +678,14 @@ int main(int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 3 ) /* resources-path */
             {
-            assert( strcmp(s, "resources-path") == 0 );
-            assert( xmlpath.empty() );
+            gdcm_assert( strcmp(s, "resources-path") == 0 );
+            gdcm_assert( xmlpath.empty() );
             xmlpath = optarg;
             }
           //printf (" with arg %s", optarg);
@@ -696,7 +696,7 @@ int main(int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 

--- a/Applications/Cxx/gdcmoverlay.cxx
+++ b/Applications/Cxx/gdcmoverlay.cxx
@@ -98,8 +98,8 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           printf (" with arg %s", optarg);
@@ -110,7 +110,7 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
@@ -174,7 +174,7 @@ int main (int argc, char *argv[])
     }
   else
     {
-    assert( gdcm::System::FileExists(filename.c_str()) );
+    gdcm_assert( gdcm::System::FileExists(filename.c_str()) );
     if( printdict )
       {
       res += DoOperation<gdcm::DictPrinter>(filename);

--- a/Applications/Cxx/gdcmpap3.cxx
+++ b/Applications/Cxx/gdcmpap3.cxx
@@ -124,9 +124,9 @@ static bool DecompressPapyrus3( int pap3handle, int itemnum, gdcm::TransferSynta
         /* PIXEL DATA */
         theImage = (PapyUShort *)Papy3GetPixelData (fileNb, imageNb, group, ImagePixel);
 
-        //assert( dims[0] == 512 );
-        //assert( dims[1] == 512 );
-        //assert( pf.GetPixelSize() == 2 );
+        //gdcm_assert( dims[0] == 512 );
+        //gdcm_assert( dims[1] == 512 );
+        //gdcm_assert( pf.GetPixelSize() == 2 );
         const size_t imglen = dims[0] * dims[1] * pf.GetPixelSize();
         pixeldata.SetByteValue( (char*)theImage, (uint32_t)imglen );
 
@@ -231,19 +231,19 @@ int main(int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 1 ) /* output */
             {
-            assert( strcmp(s, "output") == 0 );
-            assert( outfilename.empty() );
+            gdcm_assert( strcmp(s, "output") == 0 );
+            gdcm_assert( outfilename.empty() );
             outfilename = optarg;
             }
           else if( option_index == 2 ) /* root-uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
             root = optarg;
             }
           //printf (" with arg %s, index = %d", optarg, option_index);
@@ -254,13 +254,13 @@ int main(int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
       //printf ("option o with value '%s'\n", optarg);
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
           {
           erroriop = true;
           gdcm::DirectionCosines dc( iop_orig.data() );
-          assert( !dc.IsValid() );
+          gdcm_assert( !dc.IsValid() );
             {
             gdcm::Attribute<0x0008,0x0008> imagetype;
             imagetype.Set( w.GetFile().GetDataSet() );
@@ -551,12 +551,12 @@ int main(int argc, char *argv[])
               else if( str == "LOCALIZER" )
                 {
                 static const double fake_axial[] = { 1, 0, 0, 0, 0, 0 };
-                assert( memcmp( iop_orig.data(), fake_axial, 6 * sizeof( double ) ) == 0 ); (void)fake_axial;
+                gdcm_assert( memcmp( iop_orig.data(), fake_axial, 6 * sizeof( double ) ) == 0 ); (void)fake_axial;
                 w.GetFile().GetDataSet().Replace( at_axial.GetAsDataElement() );
                 erroriop = false; // error has been corrected
                 }
               }
-            assert( !erroriop ); // did our heuristic failed ?
+            gdcm_assert( !erroriop ); // did our heuristic failed ?
             }
           }
         if( erroriop )

--- a/Applications/Cxx/gdcmpdf.cxx
+++ b/Applications/Cxx/gdcmpdf.cxx
@@ -251,8 +251,8 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           //printf (" with arg %s", optarg);
@@ -263,7 +263,7 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 

--- a/Applications/Cxx/gdcmraw.cxx
+++ b/Applications/Cxx/gdcmraw.cxx
@@ -134,19 +134,19 @@ int main(int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 2 ) /* tag */
             {
-            assert( strcmp(s, "tag") == 0 );
+            gdcm_assert( strcmp(s, "tag") == 0 );
             rawTag.ReadFromCommaSeparatedString(optarg);
             }
           else if( option_index == 5 ) /* pattern */
             {
-            assert( strcmp(s, "pattern") == 0 );
-            assert( pattern.empty() );
+            gdcm_assert( strcmp(s, "pattern") == 0 );
+            gdcm_assert( pattern.empty() );
             pattern = optarg;
             }
           //printf (" with arg %s", optarg);
@@ -157,13 +157,13 @@ int main(int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
       //printf ("option o with value '%s'\n", optarg);
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 
@@ -176,7 +176,7 @@ int main(int argc, char *argv[])
       break;
 
     case 'p':
-      assert( pattern.empty() );
+      gdcm_assert( pattern.empty() );
       pattern = optarg;
       break;
 

--- a/Applications/Cxx/gdcmscanner.cxx
+++ b/Applications/Cxx/gdcmscanner.cxx
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
       if (optarg)
         {
         const char *s = long_options[option_index].name; (void)s;
-        assert(0);
+        gdcm_assert(0);
         }
       break;
 

--- a/Applications/Cxx/gdcmscu.cxx
+++ b/Applications/Cxx/gdcmscu.cxx
@@ -245,24 +245,24 @@ int main(int argc, char *argv[])
         {
           if( option_index == 0 ) /* input */
           {
-            assert( strcmp(s, "input") == 0 );
+            gdcm_assert( strcmp(s, "input") == 0 );
             filenames.push_back( optarg );
           }
           else if( option_index == 7 ) /* calling aetitle */
           {
-            assert( strcmp(s, "aetitle") == 0 );
-            //assert( callingaetitle.empty() );
+            gdcm_assert( strcmp(s, "aetitle") == 0 );
+            //gdcm_assert( callingaetitle.empty() );
             callingaetitle = optarg;
           }
           else if( option_index == 8 ) /* called aetitle */
           {
-            assert( strcmp(s, "call") == 0 );
-            //assert( callaetitle.empty() );
+            gdcm_assert( strcmp(s, "call") == 0 );
+            //gdcm_assert( callaetitle.empty() );
             callaetitle = optarg;
           }
           else if( option_index == 15 ) /* key */
           {
-            assert( strcmp(s, "key") == 0 );
+            gdcm_assert( strcmp(s, "key") == 0 );
             if( !tag.ReadFromCommaSeparatedString(optarg) )
             {
               std::cerr << "Could not read Tag: " << optarg << std::endl;
@@ -273,13 +273,13 @@ int main(int argc, char *argv[])
             uint16_t dummy;
             char cdummy; // comma
             ss >> std::hex >> dummy;
-            assert( tag.GetGroup() == dummy );
+            gdcm_assert( tag.GetGroup() == dummy );
             ss >> cdummy;
-            assert( cdummy == ',' );
+            gdcm_assert( cdummy == ',' );
             ss >> std::hex >> dummy;
-            assert( tag.GetElement() == dummy );
+            gdcm_assert( tag.GetElement() == dummy );
             ss >> cdummy;
-            assert( cdummy == ',' || cdummy == '=' );
+            gdcm_assert( cdummy == ',' || cdummy == '=' );
             std::string str;
             //ss >> str;
             std::getline(ss, str); // do not skip whitespace
@@ -288,29 +288,29 @@ int main(int argc, char *argv[])
           }
           else if( option_index == 20 ) /* port-scp */
           {
-            assert( strcmp(s, "port-scp") == 0 );
+            gdcm_assert( strcmp(s, "port-scp") == 0 );
             portscpnum = atoi(optarg);
           }
           else if( option_index == 21 ) /* output */
           {
-            assert( strcmp(s, "output") == 0 );
+            gdcm_assert( strcmp(s, "output") == 0 );
             outputdir = optarg;
           }
           else if( option_index == 23 ) /* store-query */
           {
-            assert( strcmp(s, "store-query") == 0 );
+            gdcm_assert( strcmp(s, "store-query") == 0 );
             queryfile = optarg;
           }
           else if( option_index == 29 ) /* log-file */
           {
-            assert( strcmp(s, "log-file") == 0 );
+            gdcm_assert( strcmp(s, "log-file") == 0 );
             logfilename = optarg;
           }
           else
           {
             // If you reach here someone mess-up the index and the argument in
             // the getopt table
-            assert( 0 );
+            gdcm_assert( 0 );
           }
           //printf (" with arg %s", optarg);
         }
@@ -330,13 +330,13 @@ int main(int argc, char *argv[])
         uint16_t dummy;
         char cdummy; // comma
         ss >> std::hex >> dummy;
-        assert( tag.GetGroup() == dummy );
+        gdcm_assert( tag.GetGroup() == dummy );
         ss >> cdummy;
-        assert( cdummy == ',' );
+        gdcm_assert( cdummy == ',' );
         ss >> std::hex >> dummy;
-        assert( tag.GetElement() == dummy );
+        gdcm_assert( tag.GetElement() == dummy );
         ss >> cdummy;
-        assert( cdummy == ',' || cdummy == '=' );
+        gdcm_assert( cdummy == ',' || cdummy == '=' );
         std::string str;
         std::getline(ss, str); // do not skip whitespace
         keys.emplace_back(tag, str );
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
         break;
         
       case 'o':
-        assert( outputdir.empty() );
+        gdcm_assert( outputdir.empty() );
         outputdir = optarg;
         break;
         
@@ -434,7 +434,7 @@ int main(int argc, char *argv[])
       {
       return 1;
       }
-    assert( optind == argc );
+    gdcm_assert( optind == argc );
     }
   
   if( version )
@@ -771,7 +771,7 @@ int main(int argc, char *argv[])
     }
   else
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     return 1;
     }
 

--- a/Applications/Cxx/gdcmstream.cxx
+++ b/Applications/Cxx/gdcmstream.cxx
@@ -108,17 +108,17 @@ static int No_Of_Resolutions(const char *filename)
     // gdcmData/MAROTECH_CT_JP2Lossy.dcm
     //gdcmWarningMacro( "J2K start like JPEG-2000 compressed image data instead of codestream" );
     parameters.decod_format = 1; //JP2_CFMT;
-    //assert(parameters.decod_format == JP2_CFMT);
+    //gdcm_assert(parameters.decod_format == JP2_CFMT);
     }
   else
     {
     /* JPEG-2000 codestream */
     //parameters.decod_format = J2K_CFMT;
-    //assert(parameters.decod_format == J2K_CFMT);
-    assert( 0 );
+    //gdcm_assert(parameters.decod_format == J2K_CFMT);
+    gdcm_assert( 0 );
     }
   parameters.cod_format = 11; // PGX_DFMT;
-  //assert(parameters.cod_format == PGX_DFMT);
+  //gdcm_assert(parameters.cod_format == PGX_DFMT);
 
   /* get a decoder handle */
   dinfo = opj_create_decompress(CODEC_JP2);
@@ -196,17 +196,17 @@ static bool Write_Resolution(gdcm::StreamImageWriter & theStreamWriter, const ch
     // gdcmData/MAROTECH_CT_JP2Lossy.dcm
     //gdcmWarningMacro( "J2K start like JPEG-2000 compressed image data instead of codestream" );
     parameters.decod_format = 1; //JP2_CFMT;
-    //assert(parameters.decod_format == JP2_CFMT);
+    //gdcm_assert(parameters.decod_format == JP2_CFMT);
     }
   else
     {
     /* JPEG-2000 codestream */
     //parameters.decod_format = J2K_CFMT;
-    //assert(parameters.decod_format == J2K_CFMT);
-    assert( 0 );
+    //gdcm_assert(parameters.decod_format == J2K_CFMT);
+    gdcm_assert( 0 );
     }
   parameters.cod_format = 11; // PGX_DFMT;
-  //assert(parameters.cod_format == PGX_DFMT);
+  //gdcm_assert(parameters.cod_format == PGX_DFMT);
 
   /* get a decoder handle */
   dinfo = opj_create_decompress(CODEC_JP2);
@@ -725,7 +725,7 @@ static bool Different_Resolution_From_DICOM( gdcm::StreamImageWriter & theStream
 
 
   gdcm::DataElement row = ds1.GetDataElement( gdcm::Tag(0x0048,0x0006) );
-  assert( row.GetVR() == gdcm::VR::UL );
+  gdcm_assert( row.GetVR() == gdcm::VR::UL );
   ds.Insert(row);
 
   gdcm::DataElement col = ds1.GetDataElement( gdcm::Tag(0x0048,0x0007) );
@@ -831,10 +831,10 @@ static void end_of_WSIFile(std::ostream& of)
   memcpy(&(tmpBuffer2[sizeof(uint16_t)]), &secondTag1, sizeof(uint16_t));
   memcpy(&(tmpBuffer2[2*sizeof(uint16_t)]), &thirdTag1, sizeof(uint32_t));
   //memcpy(&(tmpBuffer2[3*sizeof(uint16_t)]), &fourthTag1, sizeof(uint16_t));
-  assert( of && !of.eof() && of.good() );
+  gdcm_assert( of && !of.eof() && of.good() );
   of.write(tmpBuffer2, theBufferSize1);
   of.flush();
-  assert( of );
+  gdcm_assert( of );
 }
 
 int main (int argc, char *argv[])
@@ -899,44 +899,44 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.IsEmpty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.IsEmpty() );
             filename = optarg;
             }
           //printf (" with arg %s, index = %d", optarg, option_index)
           else if( option_index == 1 ) /* input */
             {
-            assert( strcmp(s, "output") == 0 );
-            assert( outfilename.IsEmpty() );
+            gdcm_assert( strcmp(s, "output") == 0 );
+            gdcm_assert( outfilename.IsEmpty() );
             outfilename = optarg;
             }
           //printf (" with arg %s, index = %d", optarg, option_index);
 
           else if( option_index == 8 ) /* number of resolution */
             {
-            assert( strcmp(s, "resolution") == 0 );
+            gdcm_assert( strcmp(s, "resolution") == 0 );
             nres = atoi(optarg);
             }
 
           else if( option_index == 9 ) /* number of resolution */
             {
-            assert( strcmp(s, "resolution-only") == 0 );
+            gdcm_assert( strcmp(s, "resolution-only") == 0 );
             res = atoi(optarg);
             }
 
           else if( option_index == 10 ) /* tile */
             {
-            assert( strcmp(s, "roi-start") == 0 );
+            gdcm_assert( strcmp(s, "roi-start") == 0 );
             tile = 1;
             unsigned int n = readvector(start, optarg);
-            assert( n == 2 ); (void)n;
+            gdcm_assert( n == 2 ); (void)n;
             }
           else if( option_index == 11 ) /* tile */
             {
-            assert( strcmp(s, "roi-end") == 0 );
+            gdcm_assert( strcmp(s, "roi-end") == 0 );
             tile = 1;
             unsigned int n = readvector(end, optarg);
-            assert( n == 2 ); (void)n;
+            gdcm_assert( n == 2 ); (void)n;
             }
 
           //printf ("\n");
@@ -946,12 +946,12 @@ int main (int argc, char *argv[])
       break;
 
     case 'i':
-      assert( filename.IsEmpty() );
+      gdcm_assert( filename.IsEmpty() );
       filename = optarg;
       break;
 
     case 'o':
-      assert( outfilename.IsEmpty() );
+      gdcm_assert( outfilename.IsEmpty() );
       outfilename = optarg;
       break;
 

--- a/Applications/Cxx/gdcmtar.cxx
+++ b/Applications/Cxx/gdcmtar.cxx
@@ -151,7 +151,7 @@ static frame_diff get_frame_diff( const char* filename )
   skiptags.insert( dummy );
   if ( !reader.ReadUpToTag( dummy, skiptags) )
     {
-    assert(0);
+    gdcm_assert(0);
     }
 
   gdcm::CSAHeader csa;
@@ -165,7 +165,7 @@ static frame_diff get_frame_diff( const char* filename )
   if( ds.FindDataElement( t1 ) )
     {
     csa.LoadFromDataElement( ds.GetDataElement( t1 ) );
-    assert( csa.GetFormat() == gdcm::CSAHeader::SV10
+    gdcm_assert( csa.GetFormat() == gdcm::CSAHeader::SV10
       || csa.GetFormat() == gdcm::CSAHeader::NOMAGIC );
     // SIEMENS / Diffusion
     const CSAElement &bvalue  = csa.GetCSAElementByName( "B_value" );
@@ -174,11 +174,11 @@ static frame_diff get_frame_diff( const char* filename )
     (void)bmatrix;
     const CSAElement &dgd = csa.GetCSAElementByName( "DiffusionGradientDirection" );
     (void)dgd;
-    //assert(0);
+    //gdcm_assert(0);
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
 
   return ret;
@@ -209,7 +209,7 @@ void ProcessAIOP(Scanner const & s, Directory::FilenamesType const & subset, con
       //std::cerr << *file << std::endl;
       mm.insert( std::make_pair(get_frame_diff( file->c_str() ), file->c_str()) );
       }
-    //assert(0);
+    //gdcm_assert(0);
     for( std::multimap<frame_diff, std::string>::const_iterator it = mm.begin();
       it != mm.end(); ++it )
       {
@@ -261,13 +261,13 @@ void ProcessAFrameOfRef(Scanner const & s, Directory::FilenamesType const & subs
     {
     //std::cout << *file << std::endl;
     const char * value = s.GetValue(file->c_str(), gdcm::T4 );
-    assert( value );
+    gdcm_assert( value );
     iopset.insert( value );
     }
   size_t n = iopset.size();
   if ( n == 0 )
     {
-    assert( files.empty() );
+    gdcm_assert( files.empty() );
     return;
     }
 
@@ -418,11 +418,11 @@ static bool ConcatenateImages(Image &im1, Image const &im2)
   else if( de1.GetSequenceOfFragments() )
     {
     SequenceOfFragments *sqf1 = de1.GetSequenceOfFragments();
-    assert( sqf1 );
+    gdcm_assert( sqf1 );
     const DataElement& de2 = im2.GetDataElement();
     const SequenceOfFragments *sqf2 = de2.GetSequenceOfFragments();
-    assert( sqf2 );
-    assert( sqf2->GetNumberOfFragments() == 1 );
+    gdcm_assert( sqf2 );
+    gdcm_assert( sqf2->GetNumberOfFragments() == 1 );
     const Fragment& frag = sqf2->GetFragment(0);
     sqf1->AddFragment(frag);
     }
@@ -441,7 +441,7 @@ static void InsertIfExist( DataSet &enhds, const DataSet &ds, const Tag & t )
 {
   if( ds.FindDataElement( t ) )
     {
-    assert( !enhds.FindDataElement( t ) );
+    gdcm_assert( !enhds.FindDataElement( t ) );
     enhds.Insert( ds.GetDataElement( t ) );
     }
 }
@@ -538,17 +538,17 @@ static int MakeImageEnhanced( std::string const & filename, std::string const &o
     fg.SetPattern( "%04d.dcm" );
     if( !fg.Generate() )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
 
     gdcm::ImageReader reader0;
     reader0.SetFileName( reffile );
     if( !reader0.Read() )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
     gdcm::Image &currentim = reader0.GetImage();
-    assert( currentim.GetNumberOfDimensions( ) == 2 );
+    gdcm_assert( currentim.GetNumberOfDimensions( ) == 2 );
     currentim.SetNumberOfDimensions( 3 );
     size_t count = 0;
 
@@ -559,7 +559,7 @@ static int MakeImageEnhanced( std::string const & filename, std::string const &o
     writer0.GetFile().GetHeader().Clear();
     if( !writer0.Write() )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
     ++file;
     ++count;
@@ -714,7 +714,7 @@ static int MakeImageEnhanced( std::string const & filename, std::string const &o
       reader.SetFileName( file->c_str() );
       if( !reader.Read() )
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       const gdcm::Image &im = reader.GetImage();
 
@@ -725,12 +725,12 @@ static int MakeImageEnhanced( std::string const & filename, std::string const &o
       writer.GetFile().GetHeader().Clear();
       if( !writer.Write() )
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
 
       if( !ConcatenateImages(currentim, im) )
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
 
       // check consistency 
@@ -829,10 +829,10 @@ static bool RemapSharedIntoOld( gdcm::DataSet & ds,
  SequenceOfItems *pffgs,
  unsigned int index )
 {
-  assert( sfgs );
-  assert( pffgs );
+  gdcm_assert( sfgs );
+  gdcm_assert( pffgs );
 
-  assert( sfgs->GetNumberOfItems() == 1 );
+  gdcm_assert( sfgs->GetNumberOfItems() == 1 );
   Item const &item1 = sfgs->GetItem( 1 );
   const DataSet & sfgs_ds = item1.GetNestedDataSet();
 #if 1
@@ -1016,31 +1016,31 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( filename.empty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( filename.empty() );
             filename = optarg;
             }
           else if( option_index == 3 ) /* pattern */
             {
-            assert( strcmp(s, "pattern") == 0 );
-            assert( pattern.empty() );
+            gdcm_assert( strcmp(s, "pattern") == 0 );
+            gdcm_assert( pattern.empty() );
             pattern = optarg;
             }
           else if( option_index == 6 ) /* root uid */
             {
-            assert( strcmp(s, "root-uid") == 0 );
+            gdcm_assert( strcmp(s, "root-uid") == 0 );
             root = optarg;
             }
           else if( option_index == 7 ) /* resourcespath */
             {
-            assert( strcmp(s, "resources-path") == 0 );
-            assert( xmlpath.empty() );
+            gdcm_assert( strcmp(s, "resources-path") == 0 );
+            gdcm_assert( xmlpath.empty() );
             xmlpath = optarg;
             }
           else
             {
             printf (" with arg %s, index = %d", optarg, option_index);
-            assert(0);
+            gdcm_assert(0);
             }
           //printf (" with arg %s, index = %d", optarg, option_index);
           }
@@ -1049,30 +1049,30 @@ int main (int argc, char *argv[])
       break;
 
     case 'i':
-      assert( filename.empty() );
+      gdcm_assert( filename.empty() );
       filename = optarg;
       break;
 
     case 'o':
-      assert( outfilename.empty() );
+      gdcm_assert( outfilename.empty() );
       outfilename = optarg;
       break;
 
     case 'U':
-      //assert( outfilename.empty() );
+      //gdcm_assert( outfilename.empty() );
       //outfilename = optarg;
       //printf ("option unenhance \n");
       unenhance = 1;
       break;
 
     case 'M':
-      //assert( outfilename.empty() );
+      //gdcm_assert( outfilename.empty() );
       //outfilename = optarg;
       mosaic = 1;
       break;
 
     case 'p':
-      assert( pattern.empty() );
+      gdcm_assert( pattern.empty() );
       pattern = optarg;
       break;
 
@@ -1353,7 +1353,7 @@ int main (int argc, char *argv[])
       slice = filter.GetImage();
       slice.SetOrigin( new_origin );
       slice.SetNumberOfDimensions( 2 );
-      assert( slice.GetPixelFormat() == filter.GetImage().GetPixelFormat() );
+      gdcm_assert( slice.GetPixelFormat() == filter.GetImage().GetPixelFormat() );
       slice.SetSpacing(2, filter.GetImage().GetSpacing(2) );
       //slice.Print( std::cout );
       gdcm::DataElement &pd = slice.GetDataElement();
@@ -1422,8 +1422,8 @@ int main (int argc, char *argv[])
       return 1;
     }
     unsigned long slice_len = image.GetBufferLength() / dims[2];
-    assert( slice_len * dims[2] == image.GetBufferLength() );
-    //assert( image.GetBufferLength() == bv->GetLength() );
+    gdcm_assert( slice_len * dims[2] == image.GetBufferLength() );
+    //gdcm_assert( image.GetBufferLength() == bv->GetLength() );
 
     gdcm::FilenameGenerator fg;
     fg.SetNumberOfFilenames( dims[2] );
@@ -1445,24 +1445,24 @@ int main (int argc, char *argv[])
     gdcm::SmartPointer<gdcm::SequenceOfItems> sfgs =
       ds.GetDataElement( gdcm::Tag( 0x5200,0x9229 ) ).GetValueAsSQ();
     ds.Remove( gdcm::Tag( 0x5200,0x9229 ) );
-    assert( ds.FindDataElement( gdcm::Tag( 0x5200,0x9229 ) ) == false );
+    gdcm_assert( ds.FindDataElement( gdcm::Tag( 0x5200,0x9229 ) ) == false );
     // Remove PerFrameFunctionalGroupsSequence
     gdcm::SmartPointer<gdcm::SequenceOfItems> pffgs =
       ds.GetDataElement( gdcm::Tag( 0x5200,0x9230 ) ).GetValueAsSQ();
     ds.Remove( gdcm::Tag( 0x5200,0x9230 ) );
-    assert( ds.FindDataElement( gdcm::Tag( 0x5200,0x9230 ) ) == false );
+    gdcm_assert( ds.FindDataElement( gdcm::Tag( 0x5200,0x9230 ) ) == false );
     ds.Remove( gdcm::Tag( 0x28,0x8) );
     ds.Remove( gdcm::Tag( 0x7fe0,0x0010) );
-    assert( ds.FindDataElement( gdcm::Tag( 0x7fe0,0x0010) ) == false );
+    gdcm_assert( ds.FindDataElement( gdcm::Tag( 0x7fe0,0x0010) ) == false );
     //ds.Remove( gdcm::Tag( 0x0008,0x0012) );
     //ds.Remove( gdcm::Tag( 0x0008,0x0013) );
 
   // reference the old instance:
   // PS 3.3-2009 C.7.6.16.1.3
 #if 0
-  assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1150) ) == false );
-  assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1155) ) == false );
-  assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1160) ) == false );
+  gdcm_assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1150) ) == false );
+  gdcm_assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1155) ) == false );
+  gdcm_assert( ds.FindDataElement( gdcm::Tag(0x0008,0x1160) ) == false );
   oldsopclassuid.SetTag( gdcm::Tag(0x8,0x1150) );
   oldinstanceuid.SetTag( gdcm::Tag(0x8,0x1155) );
   ds.Insert( oldsopclassuid );
@@ -1513,7 +1513,7 @@ int main (int argc, char *argv[])
       //slice = reader.GetImage();
 //      slice.SetOrigin( new_origin );
 //      slice.SetNumberOfDimensions( 2 );
-//      assert( slice.GetPixelFormat() == reader.GetImage().GetPixelFormat() );
+//      gdcm_assert( slice.GetPixelFormat() == reader.GetImage().GetPixelFormat() );
 //      slice.SetSpacing(2, reader.GetImage().GetSpacing(2) );
       //slice.Print( std::cout );
 //      gdcm::DataElement &pd = slice.GetDataElement();
@@ -1538,7 +1538,7 @@ int main (int argc, char *argv[])
     }
   else
     {
-    assert( enhance );
+    gdcm_assert( enhance );
     return MakeImageEnhanced( filename, outfilename );
 #if 0
     std::cerr << "Not implemented" << std::endl;
@@ -1557,7 +1557,7 @@ int main (int argc, char *argv[])
     const gdcm::DataElement &pixeldata = image.GetDataElement();
     const gdcm::ByteValue *bv = pixeldata.GetByteValue();
     unsigned long slice_len = image.GetBufferLength() / dims[2];
-    //assert( image.GetBufferLength() == bv->GetLength() );
+    //gdcm_assert( image.GetBufferLength() == bv->GetLength() );
 
     gdcm::FilenameGenerator fg;
     fg.SetNumberOfFilenames( dims[2] );
@@ -1597,7 +1597,7 @@ int main (int argc, char *argv[])
       slice = reader.GetImage();
       slice.SetOrigin( new_origin );
       slice.SetNumberOfDimensions( 2 );
-      assert( slice.GetPixelFormat() == reader.GetImage().GetPixelFormat() );
+      gdcm_assert( slice.GetPixelFormat() == reader.GetImage().GetPixelFormat() );
       slice.SetSpacing(2, reader.GetImage().GetSpacing(2) );
       //slice.Print( std::cout );
       gdcm::DataElement &pd = slice.GetDataElement();

--- a/Applications/Cxx/gdcmxml.cxx
+++ b/Applications/Cxx/gdcmxml.cxx
@@ -67,7 +67,7 @@ public:
     // Need to store Transfer Syntax for later getData() implementation
     // See Sup118 for details
     const char *tsstring = ts.GetString();
-    assert( tsstring );
+    gdcm_assert( tsstring );
     std::ofstream out2( tsfn.c_str(), std::ios::binary );
     out2.write( tsstring, strlen(tsstring) );
     out2.close();
@@ -112,7 +112,7 @@ static void PrintHelp()
 
 #define CHECK_READER \
   if(ret == -1) \
-    assert(0 && "unable to read");
+    gdcm_assert(0 && "unable to read");
 
 #define READ_NEXT\
   ret = xmlTextReaderRead(reader);\
@@ -172,7 +172,7 @@ static void HandlePN(xmlTextReaderPtr reader,DataElement &de)
   if(CHECK_NAME("DicomAttribute") == 0 && xmlTextReaderNodeType(reader) == 15)
     return;//empty element
   else if(!(CHECK_NAME("PersonName") == 0))
-    assert(0 && "Invalid XML");
+    gdcm_assert(0 && "Invalid XML");
     
   int depth_curr = xmlTextReaderDepth(reader);
   (void)depth_curr;
@@ -330,7 +330,7 @@ static void PopulateDataSet(xmlTextReaderPtr reader,DataSet &DS, int depth, bool
           READ_NEXT \
           name = (const char*)xmlTextReaderConstName(reader); }\
           } \
-        assert(CHECK_NAME("DicomAttribute") == 0);\
+        gdcm_assert(CHECK_NAME("DicomAttribute") == 0);\
         el.SetLength( (count) * vr.GetSizeof() ); \
         int total = 0; \
         while(total < count) \
@@ -355,7 +355,7 @@ static void PopulateDataSet(xmlTextReaderPtr reader,DataSet &DS, int depth, bool
           READ_NEXT \
           char *value_char = (char*)xmlTextReaderConstValue(reader); \
           int nvalue = sscanf(value_char,"%d",&(values[count++]));  \
-          assert( nvalue == 1 ); (void)nvalue; \
+          gdcm_assert( nvalue == 1 ); (void)nvalue; \
           READ_NEXT /*Value ending tag*/ \
           name = (const char*)xmlTextReaderConstName(reader); \
           READ_NEXT \
@@ -478,7 +478,7 @@ static void PopulateDataSet(xmlTextReaderPtr reader,DataSet &DS, int depth, bool
       char *tag_read =(char *)xmlTextReaderGetAttribute(reader,(const unsigned char*)"tag");
       Tag t;
       if(!t.ReadFromContinuousString((const char *)tag_read))
-        assert(0 && "Invalid Tag!");
+        gdcm_assert(0 && "Invalid Tag!");
       
       /* Reading VR */
       char vr_read[3] = "";
@@ -542,10 +542,10 @@ static void PopulateDataSet(xmlTextReaderPtr reader,DataSet &DS, int depth, bool
           int depth_UN=xmlTextReaderDepth(reader);
           while(!(CHECK_NAME("DicomAttribute") == 0 && xmlTextReaderNodeType(reader) == 15 && (depth_UN-1)  == xmlTextReaderDepth(reader)))
             {READ_NEXT}
-          //assert(0 && "UN not Handled yet");
+          //gdcm_assert(0 && "UN not Handled yet");
           }break;          
         default:
-          assert(0 && "Unknown VR");  
+          gdcm_assert(0 && "Unknown VR");
         };
       
       /*Modify de before insert*/
@@ -571,28 +571,28 @@ static void HandleSequence(SequenceOfItems *sqi, xmlTextReaderPtr reader,int dep
       {
       //at Item
       READ_NEXT  
-      //assert(0 && "Hi1");
+      //gdcm_assert(0 && "Hi1");
       //at DicomAtt
       if(   CHECK_NAME("DicomAttribute") == 0  &&  xmlTextReaderDepth(reader) == (depth + 1) && xmlTextReaderNodeType(reader) == 1)
         {
         //start of an item
         //Create Nested DataSet
-        //assert(0 && "Hi2");
+        //gdcm_assert(0 && "Hi2");
         Item *item = new Item();
         DataSet *NestedDS = new DataSet() ;
         PopulateDataSet(reader,*NestedDS,xmlTextReaderDepth(reader),true);
         item->SetNestedDataSet(*NestedDS);
         sqi->AddItem(*item);
-        //assert(0 && "Hi3");
+        //gdcm_assert(0 && "Hi3");
         
         }        
       else
-        assert("Empty Item or Invalid XML");
+        gdcm_assert("Empty Item or Invalid XML");
       
       READ_NEXT    
       }
     else
-      assert("Expected Item");  
+      gdcm_assert("Expected Item");
     }
 }
 
@@ -737,8 +737,8 @@ int main (int argc, char *argv[])
           {
           if( option_index == 0 ) /* input */
             {
-            assert( strcmp(s, "input") == 0 );
-            assert( file1.IsEmpty() );
+            gdcm_assert( strcmp(s, "input") == 0 );
+            gdcm_assert( file1.IsEmpty() );
             file1 = optarg;
             }
           }
@@ -747,12 +747,12 @@ int main (int argc, char *argv[])
 
     case 'i':
       //printf ("option i with value '%s'\n", optarg);
-      assert( file1.IsEmpty() );
+      gdcm_assert( file1.IsEmpty() );
       file1 = optarg;
       break;
 
     case 'o':
-      assert( file2.IsEmpty() );
+      gdcm_assert( file2.IsEmpty() );
       file2 = optarg;
       break;
 

--- a/Examples/Cxx/CStoreQtProgress.cxx
+++ b/Examples/Cxx/CStoreQtProgress.cxx
@@ -59,7 +59,7 @@ public:
   void ShowIteration()
     {
     index++;
-    assert( index <= nfiles );
+    gdcm_assert( index <= nfiles );
     // update refprogess (we are moving to the next file)
     refprogress = progress;
     }

--- a/Examples/Cxx/CheckBigEndianBug.cxx
+++ b/Examples/Cxx/CheckBigEndianBug.cxx
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
   char *buffer2 = new char[s2];
   is2.read(buffer2, s2);
 
-  assert( s1 == s2 );
+  gdcm_assert( s1 == s2 );
   if( memcmp(buffer1, buffer2, s1 ) == 0 )
     {
     std::cout << "memcmp succeed ! File are bit identical" << std::endl;

--- a/Examples/Cxx/DiscriminateVolume.cxx
+++ b/Examples/Cxx/DiscriminateVolume.cxx
@@ -100,13 +100,13 @@ void ProcessAFrameOfRef(Scanner const & s, Directory::FilenamesType const & subs
     {
     //std::cout << *file << std::endl;
     const char * value = s.GetValue(file->c_str(), gdcm::t4 );
-    assert( value );
+    gdcm_assert( value );
     iopset.insert( value );
     }
   size_t n = iopset.size();
   if ( n == 0 )
     {
-    assert( files.empty() );
+    gdcm_assert( files.empty() );
     return;
     }
 

--- a/Examples/Cxx/DumpADAC.cxx
+++ b/Examples/Cxx/DumpADAC.cxx
@@ -247,16 +247,16 @@ bool DumpADAC( std::istream & is )
   magic[6] = 0;
   is.read( magic, 6);
 //  std::cout << magic << " ";
-  assert( strcmp( magic, "adac01" ) == 0 );
+  gdcm_assert( strcmp( magic, "adac01" ) == 0 );
   int c = is.get();
-  assert( c == 0 ); (void)c;
+  gdcm_assert( c == 0 ); (void)c;
   c = is.get();
-  assert( c == 'X' );
+  gdcm_assert( c == 'X' );
 
   uint16_t v;
   v = readint16(is);
 //  std::cout << v << std::endl;
-  assert( v == 512 ); (void)v; // ??
+  gdcm_assert( v == 512 ); (void)v; // ??
 
   int nel = 87;
   for (int i = 0; i <= nel; ++i )
@@ -292,7 +292,7 @@ bool DumpADAC( std::istream & is )
     else if( e.v2 == 0x100 )
       {
       mult = diff / 2;
-      assert( diff == 2 * mult );
+      gdcm_assert( diff == 2 * mult );
       for ( int ii = 0; ii < mult; ++ii )
         {
         if ( ii ) os << "\\";
@@ -302,19 +302,19 @@ bool DumpADAC( std::istream & is )
       }
     else if( e.v2 == 0x200 )
       {
-      assert( diff == 4 );
+      gdcm_assert( diff == 4 );
       uint32_t val = readint32(is);
       os << "" << std::dec << val << "";
       }
     else if( e.v2 == 0x300 )
       {
-      assert( diff == 4 );
+      gdcm_assert( diff == 4 );
       float val = readfloat32(is);
       os << "" << std::dec << val << "";
       }
     else
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
     os << std::endl;
     }

--- a/Examples/Cxx/DumpExamCard.cxx
+++ b/Examples/Cxx/DumpExamCard.cxx
@@ -61,7 +61,7 @@ static const char *PDFStrings[] = { // Keep me ordered please
 
 static bool isvalidpdfstring( const char *pdfstring )
 {
-  assert( pdfstring );
+  gdcm_assert( pdfstring );
   static const size_t n = sizeof( PDFStrings ) / sizeof( *PDFStrings );
   static const char **begin = PDFStrings;
   static const char **end = begin + n;
@@ -99,7 +99,7 @@ static const char *gettypenamefromtype( int i)
     ret = "enum";
     break;
     }
-  assert( ret );
+  gdcm_assert( ret );
   return ret;
 }
 
@@ -137,20 +137,20 @@ struct header
       numparams = 0;
       uint32_t bla;
       is.read( (char*)&bla, sizeof(bla) );
-      assert( bla == 0x2 || bla == 0x3 );
+      gdcm_assert( bla == 0x2 || bla == 0x3 );
       nstrings = 1;
       numparams = 1;
     } else {
       // indirect
       is.read( (char*)&nints,sizeof(nints));
       is.read( (char*)&v3,sizeof(v3));
-      assert( v3 == 0 ); // looks like this is always 0
+      gdcm_assert( v3 == 0 ); // looks like this is always 0
       is.read( (char*)&v4,sizeof(v4));
       is.read( (char*)&nfloats,sizeof(nfloats));
       is.read( (char*)&v6,sizeof(v6));
       is.read( (char*)&nstrings,sizeof(nstrings));
       is.read( (char*)&v8,sizeof(v8));
-      assert( v8 == 8 );
+      gdcm_assert( v8 == 8 );
       is.read( (char*)&numparams,sizeof(numparams));
     }
     }
@@ -191,10 +191,10 @@ struct param
     is.read( (char*)&bla, sizeof(bla) );
     char name0[32];
     memset(name0,0,sizeof(name0));
-    assert( bla < sizeof(name0) );
+    gdcm_assert( bla < sizeof(name0) );
     is.read( name0, bla);
     size_t l = strlen(name0);
-    assert( l == bla ); (void)l;
+    gdcm_assert( l == bla ); (void)l;
     char * ptr = strdup( name0 );
     v4.ptr = ptr;
     type = param_string;
@@ -206,22 +206,22 @@ struct param
     is.read( (char*)&bla, sizeof(bla) );
     char name0[32];
     memset(name0,0,sizeof(name0));
-    assert( bla < sizeof(name0) );
+    gdcm_assert( bla < sizeof(name0) );
     is.read( name0, bla);
     size_t l = strlen(name0);
-    assert( l == bla ); (void)l;
+    gdcm_assert( l == bla ); (void)l;
     memcpy( this->name, name0, bla );
     is.read( (char*)&bla, sizeof(bla) );
-    assert( bla == 0x1 );
+    gdcm_assert( bla == 0x1 );
     is.read( (char*)&bla, sizeof(bla) );
     char value[32];
     memset(value,0,sizeof(value));
-    assert( bla < sizeof(value) );
+    gdcm_assert( bla < sizeof(value) );
     is.read( value, bla);
     is.read( (char*)&bla, sizeof(bla) );
-    assert( bla == 0 ); // trailing stuff ?
+    gdcm_assert( bla == 0 ); // trailing stuff ?
     is.read( (char*)&bla, sizeof(bla) );
-    assert( bla == 0 ); // trailing stuff ?
+    gdcm_assert( bla == 0 ); // trailing stuff ?
     const uint32_t cur = (uint32_t)is.tellg();
     std::cerr << "offset:" << cur << std::endl;
     if( cur == 65 )
@@ -231,7 +231,7 @@ struct param
     else if( cur == 122 )
       is.read( (char*)&bla, 2 );
     else
-      assert(0);
+      gdcm_assert(0);
     type = param_string;
     dim = 1;
     // FIXME: store the value in v4 for now:
@@ -244,17 +244,17 @@ struct param
     is.read( name, 32 + 1);
     // This is always the same issue the string can contains garbage from previous run,
     // we need to print only until the first \0 character:
-    assert( strlen( name ) <= 32 );
+    gdcm_assert( strlen( name ) <= 32 );
     is.read( (char*)&boolean,1);
-    assert( boolean == 0 || boolean == 1 || boolean == 0x69 ); // some kind of bool, or digital trash ?
+    gdcm_assert( boolean == 0 || boolean == 1 || boolean == 0x69 ); // some kind of bool, or digital trash ?
     is.read( (char*)&type, sizeof( type ) );
-    assert( gettypenamefromtype( type ) );
+    gdcm_assert( gettypenamefromtype( type ) );
     is.read( (char*)&dim, sizeof( dim ) ); // number of elements
     is.read( (char*)&v4.val, sizeof( v4.val ) );
-    //assert( v4.val == 0 ); // always 0 ? sometimes not...
+    //gdcm_assert( v4.val == 0 ); // always 0 ? sometimes not...
     const uint32_t cur = (uint32_t)is.tellg();
     is.read( (char*)&offset, sizeof( offset ) );
-    assert( offset != 0 );
+    gdcm_assert( offset != 0 );
     offset += cur;
     }
 
@@ -411,7 +411,7 @@ Wotsit ?
 
   if( s0 == "ExamCardBlob" )
     {
-    assert( de1.IsEmpty() );
+    gdcm_assert( de1.IsEmpty() );
 
     std::string fn = gdcm::LOComp::Trim( s0.c_str() ); // remove trailing space
     fn += ".xml";
@@ -464,13 +464,13 @@ Wotsit ?
       {
 
       std::istringstream is;
-      assert( bv->GetLength() == (size_t)dlen.GetValue() || bv->GetLength() == (size_t)(dlen.GetValue() + 1) );
+      gdcm_assert( bv->GetLength() == (size_t)dlen.GetValue() || bv->GetLength() == (size_t)(dlen.GetValue() + 1) );
       std::string dup( bv->GetPointer(), dlen.GetValue() /*bv->GetLength()*/ );
       is.str( dup );
 
       header h;
       h.read( is );
-      //assert( is.peek() && is.eof() );
+      //gdcm_assert( is.peek() && is.eof() );
 #if 1
       static int c = 0;
       std::string fn0 = gdcm::LOComp::Trim( s1.c_str() ); // remove trailing space
@@ -504,12 +504,12 @@ Wotsit ?
             }
           else
             {
-            assert(0);
+            gdcm_assert(0);
             }
           params.push_back( p );
         }
       } else {
-        assert( is.tellg() == std::streampos(0x20) );
+        gdcm_assert( is.tellg() == std::streampos(0x20) );
         is.seekg( 0x20 );
 
         param p;
@@ -523,7 +523,7 @@ Wotsit ?
 
       std::string fn = gdcm::LOComp::Trim( s0.c_str() ); // remove trailing space
       bool b1 = isvalidpdfstring( fn.c_str() );
-      assert( b1 ); (void)b1;
+      gdcm_assert( b1 ); (void)b1;
       fn += ".csv";
       //fn += ".xml";
       std::ofstream csv( fn.c_str() );
@@ -557,9 +557,9 @@ Wotsit ?
       std::cout << "nints:" << nints << std::endl;
       std::cout << "nstrings:" << nstrings << std::endl;
 #endif
-      assert( h.getnints() >= nints );
-      assert( h.getnfloats() >= nfloats );
-      assert( h.getnstrings() >= nstrings);
+      gdcm_assert( h.getnints() >= nints );
+      gdcm_assert( h.getnfloats() >= nfloats );
+      gdcm_assert( h.getnstrings() >= nstrings);
 
       for( uint32_t i = 0; i < h.getnparams(); ++i )
         {
@@ -585,7 +585,7 @@ Wotsit ?
 
       const char *beg = bv->GetPointer();
       const char *end = beg + bv->GetLength();
-      assert( *beg == 0 );
+      gdcm_assert( *beg == 0 );
       const char *p = beg + 1; // skip first \0
       size_t prev = 0;
       for( ; p != end; ++p )
@@ -631,7 +631,7 @@ Wotsit ?
       }
     }
   // else -> ret == false
-  assert( ret );
+  gdcm_assert( ret );
 
   return ret;
 }

--- a/Examples/Cxx/DumpGEMSMovieGroup.cxx
+++ b/Examples/Cxx/DumpGEMSMovieGroup.cxx
@@ -30,8 +30,8 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
   // prepare names mapping:
   typedef VRToType<VR::UL>::Type UL;
   std::map< UL, std::string > names;
-  assert( sqi_names );
-  assert( sqi_values );
+  gdcm_assert( sqi_names );
+  gdcm_assert( sqi_values );
   SequenceOfItems::SizeType s = sqi_names->GetNumberOfItems();
   PrivateTag tindex(0x7fe1,0x71,"GEMS_Ultrasound_MovieGroup_001");
   PrivateTag tname (0x7fe1,0x72,"GEMS_Ultrasound_MovieGroup_001");
@@ -43,14 +43,14 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
     if( !ds.FindDataElement( tindex )
       || !ds.FindDataElement( tname ) )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       return false;
       }
     const DataElement & index = ds.GetDataElement( tindex );
     const DataElement & name = ds.GetDataElement( tname );
     if( index.IsEmpty() || name.IsEmpty() )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       return false;
       }
     gdcm::Element<VR::UL, VM::VM1> el1;
@@ -63,7 +63,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
     }
 
   SequenceOfItems::SizeType s2 = sqi_values->GetNumberOfItems();
-  assert( s2 <= s );
+  gdcm_assert( s2 <= s );
   PrivateTag tindex2(0x7fe1,0x48,"GEMS_Ultrasound_MovieGroup_001");
   for( SequenceOfItems::SizeType i = 1; i <= s2; ++i )
     {
@@ -71,13 +71,13 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
     const DataSet & ds = item.GetNestedDataSet();
     if( !ds.FindDataElement( tindex2 ) )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       return false;
       }
     const DataElement & index2 = ds.GetDataElement( tindex2 );
     if( index2.IsEmpty() )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       return false;
       }
     gdcm::Element<VR::FD, VM::VM1_2> el1;
@@ -139,7 +139,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       const DataElement & value = ds.GetDataElement( tvalueul );
       gdcm::Element<VR::UL,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
-      assert( el2.GetLength() == 1 );
+      gdcm_assert( el2.GetLength() == 1 );
       std::cout << el2.GetValue() << std::endl;
       }
     else if( ds.FindDataElement( tvalueob ) )
@@ -163,7 +163,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       gdcm::Element<VR::SL,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
       el2.Print( std::cout );
-      assert( el2.GetLength() == 4 );
+      gdcm_assert( el2.GetLength() == 4 );
       std::cout << std::endl;
       }
     else if( ds.FindDataElement( tvaluesl3 ) )
@@ -172,7 +172,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       gdcm::Element<VR::SL,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
       el2.Print( std::cout );
-//      assert( el2.GetLength() == 4 );
+//      gdcm_assert( el2.GetLength() == 4 );
       std::cout << std::endl;
       }
     else if( ds.FindDataElement( tvaluefd ) )
@@ -181,7 +181,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       gdcm::Element<VR::FD,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
       el2.Print( std::cout );
-//      assert( el2.GetLength() == 4 || el2.GetLength() == 3 || el2.GetLength() == 8 );
+//      gdcm_assert( el2.GetLength() == 4 || el2.GetLength() == 3 || el2.GetLength() == 8 );
       std::cout << std::endl;
       }
     else if( ds.FindDataElement( tvaluefloat2 ) )
@@ -190,7 +190,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       gdcm::Element<VR::FD,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
       el2.Print( std::cout );
-      assert( el2.GetLength() == 2 );
+      gdcm_assert( el2.GetLength() == 2 );
       std::cout << std::endl;
       }
     else if( ds.FindDataElement( tvaluefd1 ) )
@@ -199,14 +199,14 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
       gdcm::Element<VR::FD,VM::VM1_n> el2;
       el2.SetFromDataElement( value );
       el2.Print( std::cout );
-      assert( el2.GetLength() == 4 );
+      gdcm_assert( el2.GetLength() == 4 );
       std::cout << std::endl;
       }
     else
       {
       std::cout << "(no value)" << std::endl;
 //      std::cout << ds << std::endl;
-      assert( ds.Size() == 2 );
+      gdcm_assert( ds.Size() == 2 );
       }
     }
   return true;
@@ -227,7 +227,7 @@ gdcm::SequenceOfItems *sqi_names, std::string const & indent )
 {
   if( !ds.FindDataElement( privtag1 ) )
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     return false;
     }
   const gdcm::DataElement& values10name = ds.GetDataElement( privtag1 );
@@ -255,7 +255,7 @@ bool print73( gdcm::DataSet const & ds10, gdcm::SequenceOfItems *sqi_dict, std::
     {
     gdcm::Item &item_73 = sqi_values73->GetItem(i3);
     gdcm::DataSet &ds73 = item_73.GetNestedDataSet();
-    assert( ds73.Size() == 3 );
+    gdcm_assert( ds73.Size() == 3 );
 
     const gdcm::PrivateTag tseq_values74name(0x7fe1,0x74,"GEMS_Ultrasound_MovieGroup_001");
     const gdcm::PrivateTag tseq_values75(0x7fe1,0x75,"GEMS_Ultrasound_MovieGroup_001");
@@ -278,23 +278,23 @@ bool print36( gdcm::DataSet const & ds10, gdcm::SequenceOfItems *sqi_dict, std::
   gdcm::SmartPointer<gdcm::SequenceOfItems> sqi_values36 = seq_values36.GetValueAsSQ();
 
   size_t ni3 = sqi_values36->GetNumberOfItems();
-  assert( ni3 >= 1 );
+  gdcm_assert( ni3 >= 1 );
   for( size_t i3 = 1; i3 <= ni3; ++i3 )
     {
     gdcm::Item &item_36 = sqi_values36->GetItem(i3);
     gdcm::DataSet &ds36 = item_36.GetNestedDataSet();
-    assert( ds36.Size() == 4 );
+    gdcm_assert( ds36.Size() == 4 );
 
     // (7fe1,1037) UL 47  # 4,1 US MovieGroup Number of Frames
     // (7fe1,1043) OB 40\00\1c\c4\67\2f\0b\11\40         # 376,1 ?
     // (7fe1,1060) OB 4e\4e\49\4f\4e\47\46\43\2a         # 4562714,1 US MovieGroup Image Data
     //
     const gdcm::PrivateTag timagedata(0x7fe1,0x60,"GEMS_Ultrasound_MovieGroup_001");
-    assert( ds36.FindDataElement( timagedata ) );
+    gdcm_assert( ds36.FindDataElement( timagedata ) );
     gdcm::DataElement const & imagedata = ds36.GetDataElement( timagedata );
 
       const gdcm::ByteValue * bv = imagedata.GetByteValue();
-  assert( bv );
+  gdcm_assert( bv );
       static int c = 0;
       std::stringstream ss;
       ss << "/tmp/debug";
@@ -325,7 +325,7 @@ bool print83( gdcm::DataSet const & ds10, gdcm::SequenceOfItems *sqi_dict, std::
     {
     gdcm::Item &item_83 = sqi_values83->GetItem(i3);
     gdcm::DataSet &ds83 = item_83.GetNestedDataSet();
-    assert( ds83.Size() == 3 );
+    gdcm_assert( ds83.Size() == 3 );
 
     const gdcm::PrivateTag tseq_values84name(0x7fe1,0x84,"GEMS_Ultrasound_MovieGroup_001");
     const gdcm::PrivateTag tseq_values85(0x7fe1,0x85,"GEMS_Ultrasound_MovieGroup_001");
@@ -341,19 +341,19 @@ gdcm::SequenceOfItems *sqi_dict, std::string const & indent )
   (void)indent;
   if( !subds.FindDataElement( privtag0 ) )
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     return false;
     }
   const gdcm::DataElement& seq_values10 = subds.GetDataElement( privtag0 );
   gdcm::SmartPointer<gdcm::SequenceOfItems> sqi_values10 = seq_values10.GetValueAsSQ();
 
   size_t ni1 = sqi_values10->GetNumberOfItems();
-//  assert( ni1 == 1 );
+//  gdcm_assert( ni1 == 1 );
   for( size_t i1 = 1; i1 <= ni1; ++i1 )
     {
     gdcm::Item &item_10 = sqi_values10->GetItem(i1);
     gdcm::DataSet &ds10 = item_10.GetNestedDataSet();
-    assert( ds10.Size() == 2 + 3 );
+    gdcm_assert( ds10.Size() == 2 + 3 );
     // (7fe1,0010)
     // (7fe1,1012)
     // (7fe1,1018)
@@ -366,20 +366,20 @@ gdcm::SequenceOfItems *sqi_dict, std::string const & indent )
     const gdcm::PrivateTag tseq_values20(0x7fe1,0x20,"GEMS_Ultrasound_MovieGroup_001");
     if( !ds10.FindDataElement( tseq_values20 ) )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       return false;
       }
     const gdcm::DataElement& seq_values20 = ds10.GetDataElement( tseq_values20 );
     gdcm::SmartPointer<gdcm::SequenceOfItems> sqi_values20 = seq_values20.GetValueAsSQ();
 
     size_t ni2 = sqi_values20->GetNumberOfItems();
-    //assert( ni == 1 );
+    //gdcm_assert( ni == 1 );
     for( size_t i2 = 1; i2 <= ni2; ++i2 )
       {
       gdcm::Item &item_20 = sqi_values20->GetItem(i2);
       gdcm::DataSet &ds20 = item_20.GetNestedDataSet();
       size_t count = ds20.Size(); (void)count;
-      assert( ds20.Size() == 2 + 3 || ds20.Size() == 2 + 2 );
+      gdcm_assert( ds20.Size() == 2 + 3 || ds20.Size() == 2 + 2 );
       // (7fe1,0010)
       // (7fe1,1024)
       // (7fe1,1026)
@@ -418,7 +418,7 @@ int main(int argc, char *argv[])
   const DataElement& seq = ds.GetDataElement( tseq );
 
   SmartPointer<SequenceOfItems> sqi = seq.GetValueAsSQ();
-  assert( sqi->GetNumberOfItems() == 1 );
+  gdcm_assert( sqi->GetNumberOfItems() == 1 );
 
   Item &item = sqi->GetItem(1);
   DataSet &subds = item.GetNestedDataSet();
@@ -442,7 +442,7 @@ int main(int argc, char *argv[])
   std::cout << el.GetValue() << std::endl;
 }
   size_t count = subds.Size(); (void)count;
-  assert( subds.Size() == 3 + 2 + 1 || subds.Size() == 3 + 2 + 2);
+  gdcm_assert( subds.Size() == 3 + 2 + 1 || subds.Size() == 3 + 2 + 2);
 
 //  (7fe1,0010) # 30,1 Private Creator
 //  (7fe1,1002) # 8,1 US MovieGroup Value 0008 Name

--- a/Examples/Cxx/DumpImageHeaderInfo.cxx
+++ b/Examples/Cxx/DumpImageHeaderInfo.cxx
@@ -46,7 +46,7 @@ std::istream & element::read( std::istream & is )
     return is;
     }
   //os << magic << std::endl;
-  assert( magic == ref ); (void)ref;
+  gdcm_assert( magic == ref ); (void)ref;
 
   uint32_t l;
   is.read( (char*)&l, sizeof(l) );
@@ -127,7 +127,7 @@ static bool DumpImageHeaderInfo( std::istream & is, size_t reflen )
     {
     }
   //size_t pos = is.tellg();
-  //assert( pos == reflen );
+  //gdcm_assert( pos == reflen );
   (void)reflen;
 
   return true;

--- a/Examples/Cxx/DumpPhilipsECHO.cxx
+++ b/Examples/Cxx/DumpPhilipsECHO.cxx
@@ -83,11 +83,11 @@ static bool ProcessDeflate( const char *outfilename, const int nslices, const
 
   std::streamoff totalsize;
   is.read( (char*)&totalsize, sizeof( totalsize ));
-  assert( totalsize == len );
+  gdcm_assert( totalsize == len );
 
   uint32_t nframes;
   is.read( (char*)&nframes, sizeof( nframes ));
-  assert( nframes == (uint32_t)nslices );
+  gdcm_assert( nframes == (uint32_t)nslices );
 
   std::vector< std::streamoff > offsets;
   offsets.reserve( nframes );
@@ -113,7 +113,7 @@ static bool ProcessDeflate( const char *outfilename, const int nslices, const
   ss << ".raw";
   std::ofstream os( ss.str().c_str(), std::ios::binary );
 
-  assert( buf_size >= size[0] * size[1] );
+  gdcm_assert( buf_size >= size[0] * size[1] );
   outbuf.resize( buf_size );
 
   hframe header;
@@ -122,15 +122,15 @@ static bool ProcessDeflate( const char *outfilename, const int nslices, const
     {
     is.read( (char*)&header, sizeof( header ));
 
-    assert( header == crcheaders[r] );
-    assert( header.val1[0] == 2000 );
-    assert( header.val1[1] == 3 );
-    assert( header.val2[0] == 1 );
-    assert( header.val2[1] == 1280 );
+    gdcm_assert( header == crcheaders[r] );
+    gdcm_assert( header.val1[0] == 2000 );
+    gdcm_assert( header.val1[1] == 3 );
+    gdcm_assert( header.val2[0] == 1 );
+    gdcm_assert( header.val2[1] == 1280 );
 
     uLongf destLen = buf_size; // >= 608,427
     Bytef *dest = (Bytef*)outbuf.data();
-    assert( is.tellg() == offsets[r] + 16 );
+    gdcm_assert( is.tellg() == offsets[r] + 16 );
     const Bytef *source = (const Bytef*)buf + offsets[r] + 16;
     uLong sourceLen;
     if( r + 1 == nframes )
@@ -139,9 +139,9 @@ static bool ProcessDeflate( const char *outfilename, const int nslices, const
       sourceLen = (uLong)offsets[r+1] - (uLong)offsets[r] - 16;
     // FIXME: in-memory decompression:
     int ret = uncompress (dest, &destLen, source, sourceLen);
-    assert( ret == Z_OK ); (void)ret;
-    assert( destLen >= (uLongf)size[0] * size[1] ); // 16bytes padding ?
-    assert( header.imgsize == (uint32_t)size[0] * size[1] );
+    gdcm_assert( ret == Z_OK ); (void)ret;
+    gdcm_assert( destLen >= (uLongf)size[0] * size[1] ); // 16bytes padding ?
+    gdcm_assert( header.imgsize == (uint32_t)size[0] * size[1] );
     //os.write( &outbuf[0], outbuf.size() );
     os.write( outbuf.data(), size[0] * size[1] );
 
@@ -149,7 +149,7 @@ static bool ProcessDeflate( const char *outfilename, const int nslices, const
     is.seekg( sourceLen, std::ios::cur );
     }
   os.close();
-  assert( is.tellg() == totalsize );
+  gdcm_assert( is.tellg() == totalsize );
 
   return true;
 }
@@ -184,11 +184,11 @@ static bool ProcessNone( const char *outfilename, const int nslices, const
 
   std::streampos totalsize;
   is.read( (char*)&totalsize, sizeof( totalsize ));
-  assert( totalsize == len );
+  gdcm_assert( totalsize == len );
 
   uint32_t nframes;
   is.read( (char*)&nframes, sizeof( nframes ));
-  assert( nframes == (uint32_t)nslices );
+  gdcm_assert( nframes == (uint32_t)nslices );
 
   std::vector< uint32_t > offsets;
   offsets.reserve( nframes );
@@ -225,12 +225,12 @@ static bool ProcessNone( const char *outfilename, const int nslices, const
          << " " << header.val2[1]
          << " " << header.imgsize << std::endl;
 #endif
-    assert( header == crcheaders[r] );
+    gdcm_assert( header == crcheaders[r] );
 
     is.read( buffer, buf_size - 16 );
     os.write( buffer, header.imgsize );
     }
-  assert( is.tellg() == totalsize );
+  gdcm_assert( is.tellg() == totalsize );
   os.close();
 
   return true;
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
   const DataElement& seq1 = ds1.GetDataElement( tseq1 );
 
   SmartPointer<SequenceOfItems> sqi1 = seq1.GetValueAsSQ();
-  assert( sqi1->GetNumberOfItems() >= 1 );
+  gdcm_assert( sqi1->GetNumberOfItems() >= 1 );
 
   const size_t nitems = sqi1->GetNumberOfItems();
   for( size_t item = 1; item < nitems; ++item )
@@ -322,10 +322,10 @@ int main(int argc, char *argv[])
     const DataElement& seq2 = ds2.GetDataElement( tseq2 );
 
     SmartPointer<SequenceOfItems> sqi2 = seq2.GetValueAsSQ();
-    assert( sqi2->GetNumberOfItems() >= 1 );
+    gdcm_assert( sqi2->GetNumberOfItems() >= 1 );
 
     // FIXME: what if not in first Item ?
-    assert( sqi2->GetNumberOfItems() == 1 );
+    gdcm_assert( sqi2->GetNumberOfItems() == 1 );
     Item &item2 = sqi2->GetItem(1);
     DataSet &ds3 = item2.GetNestedDataSet();
 
@@ -344,7 +344,7 @@ int main(int argc, char *argv[])
     Element<VR::IS,VM::VM1> elnslices;
     elnslices.SetFromDataElement( nslices );
     const int nslicesref = elnslices.GetValue();
-    assert( nslicesref >= 0 );
+    gdcm_assert( nslicesref >= 0 );
     // (200d,3011)  IS  6  259648
     const PrivateTag tzalloc(0x200d,0x3011,"Philips US Imaging DD 033");
     if( !ds3.FindDataElement( tzalloc ) ) return 1;
@@ -352,7 +352,7 @@ int main(int argc, char *argv[])
     Element<VR::IS,VM::VM1> elzalloc;
     elzalloc.SetFromDataElement( zalloc );
     const int zallocref = elzalloc.GetValue();
-    assert( zallocref >= 0 );
+    gdcm_assert( zallocref >= 0 );
     // (200d,3021)  IS  2  0
     const PrivateTag tzero(0x200d,0x3021,"Philips US Imaging DD 033");
     if( !ds3.FindDataElement( tzero ) ) return 1;
@@ -360,7 +360,7 @@ int main(int argc, char *argv[])
     Element<VR::IS,VM::VM1> elzero;
     elzero.SetFromDataElement( zero );
     const int zerocref = elzero.GetValue();
-    assert( zerocref == 0 ); (void)zerocref;
+    gdcm_assert( zerocref == 0 ); (void)zerocref;
 
     // (200d,3cf3) OB
     const PrivateTag tdeflate(0x200d,0x3cf3,"Philips US Imaging DD 045");
@@ -377,12 +377,12 @@ int main(int argc, char *argv[])
     std::string outfile = std::string( bvdatatype->GetPointer(), bvdatatype->GetLength() );
     outfile = LOComp::Trim( outfile.c_str() );
     const char *outfilename = outfile.c_str();
-    assert( is_valid(outfilename) );
+    gdcm_assert( is_valid(outfilename) );
     if( bv2 )
       {
-      assert( bv3 );
-      assert( zallocref > 0 );
-      assert( nslicesref > 0 );
+      gdcm_assert( bv3 );
+      gdcm_assert( zallocref > 0 );
+      gdcm_assert( nslicesref > 0 );
       std::cout << ds2 << std::endl;
 
       if( strncmp(bv->GetPointer(), "ZLib", 4) == 0 )

--- a/Examples/Cxx/DumpSiemensBase64.cxx
+++ b/Examples/Cxx/DumpSiemensBase64.cxx
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
       {
         ds2.Insert( xde );
       }
-      assert( ss.eof() );
+      gdcm_assert( ss.eof() );
     }
     catch(std::exception &)
     {

--- a/Examples/Cxx/ELSCINT1WaveToText.cxx
+++ b/Examples/Cxx/ELSCINT1WaveToText.cxx
@@ -102,7 +102,7 @@ int main(int argc, char *argv [])
   const gdcm::DataElement& wave = ds.GetDataElement( twave );
   if ( wave.IsEmpty() ) return 1;
   const gdcm::ByteValue * bv = wave.GetByteValue();
-  assert( bv );
+  gdcm_assert( bv );
 
   std::ofstream os( outfilename, std::ios::binary );
   // Dump that to a CSV file:

--- a/Examples/Cxx/ExtractIconFromFile.cxx
+++ b/Examples/Cxx/ExtractIconFromFile.cxx
@@ -29,7 +29,7 @@ bool WriteIconAsPNM(const char* filename, const gdcm::IconImage& icon)
   pnm.SetLUT( icon.GetLUT() );
   const gdcm::DataElement& in = icon.GetDataElement();
   bool b = pnm.Write( filename, in );
-  assert( b );
+  gdcm_assert(b);
   return b;
 }
 
@@ -65,7 +65,7 @@ int main(int argc, char *argv [])
       {
       const gdcm::DataElement& in = icon.GetDataElement();
       const gdcm::ByteValue *bv = in.GetByteValue();
-      assert( bv );
+      gdcm_assert( bv );
       std::ofstream out( "icon.jpg", std::ios::binary );
       out.write( bv->GetPointer(), bv->GetLength() );
       out.close();
@@ -73,7 +73,7 @@ int main(int argc, char *argv [])
     }
   else
     {
-    assert( iif.GetNumberOfIconImages() == 0 );
+    gdcm_assert( iif.GetNumberOfIconImages() == 0 );
     std::cerr << "No Icon Found anywhere in file" << std::endl;
 
     const gdcm::Image &img = reader.GetImage();

--- a/Examples/Cxx/Extracting_All_Resolution.cxx
+++ b/Examples/Cxx/Extracting_All_Resolution.cxx
@@ -100,17 +100,17 @@ bool Write_Resolution(gdcm::StreamImageWriter & theStreamWriter, const char *fil
     // gdcmData/MAROTECH_CT_JP2Lossy.dcm
     //gdcmWarningMacro( "J2K start like JPEG-2000 compressed image data instead of codestream" );
     parameters.decod_format = 1; //JP2_CFMT;
-    //assert(parameters.decod_format == JP2_CFMT);
+    //gdcm_assert(parameters.decod_format == JP2_CFMT);
     }
   else
     {
     /* JPEG-2000 codestream */
     //parameters.decod_format = J2K_CFMT;
-    //assert(parameters.decod_format == J2K_CFMT);
-    assert( 0 );
+    //gdcm_assert(parameters.decod_format == J2K_CFMT);
+    gdcm_assert( 0 );
     }
   parameters.cod_format = 11; // PGX_DFMT;
-  //assert(parameters.cod_format == PGX_DFMT);
+  //gdcm_assert(parameters.cod_format == PGX_DFMT);
 
   /* get a decoder handle */
     dinfo = opj_create_decompress(CODEC_JP2);
@@ -447,10 +447,10 @@ int main(int argc, char *argv[])
  memcpy(&(tmpBuffer2[sizeof(uint16_t)]), &secondTag1, sizeof(uint16_t));
  memcpy(&(tmpBuffer2[2*sizeof(uint16_t)]), &thirdTag1, sizeof(uint32_t));
  //memcpy(&(tmpBuffer2[3*sizeof(uint16_t)]), &fourthTag1, sizeof(uint16_t));
- assert( of && !of.eof() && of.good() );
+ gdcm_assert( of && !of.eof() && of.good() );
  of.write(tmpBuffer2, theBufferSize1);
  of.flush();
- assert( of );
+ gdcm_assert( of );
 
 
 

--- a/Examples/Cxx/Fake_Image_Using_Stream_Image_Writer.cxx
+++ b/Examples/Cxx/Fake_Image_Using_Stream_Image_Writer.cxx
@@ -222,10 +222,10 @@ if (!theStreamWriter.WriteImageInformation()){
  memcpy(&(tmpBuffer2[sizeof(uint16_t)]), &secondTag1, sizeof(uint16_t));
  memcpy(&(tmpBuffer2[2*sizeof(uint16_t)]), &thirdTag1, sizeof(uint32_t));
  //memcpy(&(tmpBuffer2[3*sizeof(uint16_t)]), &fourthTag1, sizeof(uint16_t));
- assert( of && !of.eof() && of.good() );
+ gdcm_assert( of && !of.eof() && of.good() );
  of.write(tmpBuffer2, theBufferSize1);
  of.flush();
- assert( of );
+ gdcm_assert( of );
 
 
   return 0;

--- a/Examples/Cxx/GenAllVR.cxx
+++ b/Examples/Cxx/GenAllVR.cxx
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
     Tag t = FindTagFromVR( pubdict, vr );
     if( vr != VR::UN && vr != VR::SQ )
       {
-      assert( t != Tag(0xffff,0xffff) );
+      gdcm_assert( t != Tag(0xffff,0xffff) );
       gdcm::DataElement de( t );
       std::generate_n(ss, len, rnd_gen());
       de.SetVR( vr );

--- a/Examples/Cxx/GenFakeIdentifyFile.cxx
+++ b/Examples/Cxx/GenFakeIdentifyFile.cxx
@@ -84,7 +84,7 @@ gdcm::DataElement CreateFakeElement(gdcm::Tag const &tag, bool toremove)
     it.SetVLToUndefined();
     gdcm::DataSet &nds = it.GetNestedDataSet();
     // Insert sequence into data set
-    assert(de.GetVR() == gdcm::VR::SQ );
+    gdcm_assert(de.GetVR() == gdcm::VR::SQ );
     gdcm::SmartPointer<gdcm::SequenceOfItems> sq = new gdcm::SequenceOfItems();
     sq->SetLengthToUndefined();
     de.SetValue(*sq);

--- a/Examples/Cxx/GenSeqs.cxx
+++ b/Examples/Cxx/GenSeqs.cxx
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 
   //const unsigned int nitems = 1000;
   const unsigned int ptr_len = 42; /*94967296 / nitems; */
-  //assert( ptr_len == 42949672 );
+  //gdcm_assert( ptr_len == 42949672 );
   char *ptr = new char[ptr_len];
   memset(ptr,0,ptr_len);
 

--- a/Examples/Cxx/GetSubSequenceData.cxx
+++ b/Examples/Cxx/GetSubSequenceData.cxx
@@ -44,7 +44,7 @@ static bool processgroup(Item & item3, std::string const & outfilename)
   const DataElement& seq6 = subds3.GetDataElement( tseq6 );
   SmartPointer<SequenceOfItems> sqi6 = seq6.GetValueAsSQ();
   size_t ni6= sqi6->GetNumberOfItems();
-  assert( sqi6->GetNumberOfItems() >= 1 );
+  gdcm_assert( sqi6->GetNumberOfItems() >= 1 );
   const PrivateTag tseq7(0x7fe1,0x86,"GEMS_Ultrasound_MovieGroup_001");
   int dimx = 0, dimy = 0;
   for( size_t i6 = 1; i6 <= ni6; ++i6 )
@@ -70,7 +70,7 @@ static bool processgroup(Item & item3, std::string const & outfilename)
 
   SmartPointer<SequenceOfItems> sqi4 = seq3.GetValueAsSQ();
   size_t ni4= sqi4->GetNumberOfItems();
-  assert( sqi4->GetNumberOfItems() >= 1 );
+  gdcm_assert( sqi4->GetNumberOfItems() >= 1 );
   const PrivateTag tseq8(0x7fe1,0x37,"GEMS_Ultrasound_MovieGroup_001");
   const PrivateTag tseq4(0x7fe1,0x43,"GEMS_Ultrasound_MovieGroup_001");
   const PrivateTag tseq5(0x7fe1,0x60,"GEMS_Ultrasound_MovieGroup_001");
@@ -102,7 +102,7 @@ static bool processgroup(Item & item3, std::string const & outfilename)
     el0.SetFromDataElement( seq4 );
     std::cout << "TimeStamp (" << el0.GetLength() << "): ";
     // Seems like the 3D volumes is split into chunks of max 100 frames...
-    assert( ldimz.GetValue() == el0.GetLength() );
+    gdcm_assert( ldimz.GetValue() == el0.GetLength() );
     for( unsigned long i = 0; i < el0.GetLength(); ++i ) {
       if(i) std::cout << ",";
       std::cout << el0.GetValue(i);
@@ -141,7 +141,7 @@ static bool processgroup(Item & item3, std::string const & outfilename)
   (void)l1;
   size_t l2 = im->GetBufferLength();
   (void)l2;
-  assert( im->GetBufferLength() == imbuffer.size() );
+  gdcm_assert( im->GetBufferLength() == imbuffer.size() );
   im->SetPhotometricInterpretation( gdcm::PhotometricInterpretation::MONOCHROME2 );
 
   im->SetDataElement( fakedata );
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
   const DataElement& seq = ds.GetDataElement( tseq );
 
   SmartPointer<SequenceOfItems> sqi = seq.GetValueAsSQ();
-  assert( sqi->GetNumberOfItems() == 1 );
+  gdcm_assert( sqi->GetNumberOfItems() == 1 );
   Item &item = sqi->GetItem(1);
   DataSet &subds = item.GetNestedDataSet();
 
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
   const DataElement& seq1 = subds.GetDataElement( tseq1 );
 
   SmartPointer<SequenceOfItems> sqi2 = seq1.GetValueAsSQ();
-  assert( sqi2->GetNumberOfItems() == 1 );
+  gdcm_assert( sqi2->GetNumberOfItems() == 1 );
   //int n = sqi2->GetNumberOfItems();
   int index = 1;
   Item &item2 = sqi2->GetItem(index);
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
 
   SmartPointer<SequenceOfItems> sqi3 = seq2.GetValueAsSQ();
   size_t ni3 = sqi3->GetNumberOfItems(); (void)ni3;
-  assert( sqi3->GetNumberOfItems() >= 1 );
+  gdcm_assert( sqi3->GetNumberOfItems() >= 1 );
   std::cout << "#Groups = " << sqi3->GetNumberOfItems() << std::endl;
   for( SequenceOfItems::SizeType i = 1; i <= sqi3->GetNumberOfItems(); ++i) {
     Item &item3 = sqi3->GetItem(i);

--- a/Examples/Cxx/LargeVRDSExplicit.cxx
+++ b/Examples/Cxx/LargeVRDSExplicit.cxx
@@ -43,7 +43,7 @@ bool interpolate(const double * pts, size_t npts, std::vector<double> &out )
       {
       if( j != npts - 1 )
         {
-        assert( 3*j+5 < 3*npts );
+        gdcm_assert( 3*j+5 < 3*npts );
         const double midpointx = (pts[3*j+0] + pts[3*j+3]) / 2;
         const double midpointy = (pts[3*j+1] + pts[3*j+4]) / 2;
         const double midpointz = (pts[3*j+2] + pts[3*j+5]) / 2;
@@ -54,13 +54,13 @@ bool interpolate(const double * pts, size_t npts, std::vector<double> &out )
       }
     else
       {
-      assert( j < npts );
+      gdcm_assert( j < npts );
       out.push_back( pts[3*j+0] );
       out.push_back( pts[3*j+1] );
       out.push_back( pts[3*j+2] );
       }
     }
-  assert( out.size() == 2 * npts * 3 - 3 );
+  gdcm_assert( out.size() == 2 * npts * 3 - 3 );
   return true;
 }
 
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
     out = out2;
     out2.clear();
     }
-  assert( out.size() % 3 == 0 );
+  gdcm_assert( out.size() % 3 == 0 );
 
   gdcm::Attribute<0x3006,0x0050> at_interpolate;
   at_interpolate.SetNumberOfValues( (unsigned int)(out.size() / 3) );
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
   nestedds2.Replace( at_interpolate.GetAsDataElement() );
   nestedds2.Replace( ncontourpoints.GetAsDataElement() );
 
-  //assert(0);
+  //gdcm_assert(0);
 
   // Let's take item one and subdivide it
 

--- a/Examples/Cxx/ReadAndPrintAttributes.cxx
+++ b/Examples/Cxx/ReadAndPrintAttributes.cxx
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 
     // Let's assume for a moment we knew the tag number:
     Attribute<0x3004,0x000e> at;
-    assert( at.GetTag() == tDoseGridScaling );
+    gdcm_assert( at.GetTag() == tDoseGridScaling );
     at.SetFromDataSet( ds );
     // For the sake of long term maintenance, we will not write
     // that this particular attribute is stored as a double. What if

--- a/Examples/Cxx/StreamImageReaderTest.cxx
+++ b/Examples/Cxx/StreamImageReaderTest.cxx
@@ -271,10 +271,10 @@ int main(int argc, char *argv[])
   memcpy(&(tmpBuffer2[sizeof(uint16_t)]), &secondTag1, sizeof(uint16_t));
   memcpy(&(tmpBuffer2[2*sizeof(uint16_t)]), &thirdTag1, sizeof(uint32_t));
   //memcpy(&(tmpBuffer2[3*sizeof(uint16_t)]), &fourthTag1, sizeof(uint16_t));
-  assert( of && !of.eof() && of.good() );
+  gdcm_assert( of && !of.eof() && of.good() );
   of.write(tmpBuffer2, theBufferSize1);
   of.flush();
-  assert( of );
+  gdcm_assert( of );
 
   return 0;
 }

--- a/Examples/Cxx/VolumeSorter.cxx
+++ b/Examples/Cxx/VolumeSorter.cxx
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
   const gdcm::Scanner::ValuesType &values = s.GetValues();
   nvalues = values.size();
   std::cout << "There are " << nvalues << " different type of values" << std::endl;
-  assert( nfiles2 % nvalues == 0 );
+  gdcm_assert( nfiles2 % nvalues == 0 );
   std::cout << "Series is composed of " << (nfiles/nvalues) << " different 3D volumes" << std::endl;
 }
 

--- a/Examples/Cxx/pmsct_rgb1.cxx
+++ b/Examples/Cxx/pmsct_rgb1.cxx
@@ -42,7 +42,7 @@ void delta_decode(const unsigned char *data_in, size_t data_size,
   const size_t outputlen = 3 * plane_size;
   new_stream.resize( outputlen );
 
-  assert( data_size != outputlen );
+  gdcm_assert( data_size != outputlen );
   if( data_size == outputlen )
     {
     return;
@@ -79,7 +79,7 @@ void delta_decode(const unsigned char *data_in, size_t data_size,
     {
     // next byte:
     byte b = *src++;
-    assert( src < data_in + data_size );
+    gdcm_assert( src < data_in + data_size );
     // mode selection:
     switch ( b )
       {

--- a/Examples/Cxx/rle2img.cxx
+++ b/Examples/Cxx/rle2img.cxx
@@ -55,7 +55,7 @@ void delta_decode(const char *inbuffer, size_t length, std::vector<unsigned shor
     if( inbuffer[i] == (char)0xa5 )
       {
       //unsigned char repeat = (unsigned char)inbuffer[i+1] + 1;
-      //assert( (unsigned char)inbuffer[i+1] != 255 );
+      //gdcm_assert( (unsigned char)inbuffer[i+1] != 255 );
       int repeat = (unsigned char)inbuffer[i+1] + 1;
       char value = inbuffer[i+2];
       while(repeat)
@@ -90,7 +90,7 @@ void delta_decode(const char *inbuffer, size_t length, std::vector<unsigned shor
       output.push_back( value );
       delta = value;
       }
-    //assert( output[output.size()-1] == ref[output.size()-1] );
+    //gdcm_assert( output[output.size()-1] == ref[output.size()-1] );
     }
 
   if ( output.size() % 2 )

--- a/Examples/PHP/hello_world.php
+++ b/Examples/PHP/hello_world.php
@@ -73,7 +73,7 @@ if( $ds->FindDataElement( $tDoseGridScaling ) )
 
   // Let's assume for a moment we knew the tag number:
   $at=new Tag(0x3004,0x000e);
-  assert( $at.GetTag() == $tDoseGridScaling );
+  gdcm_assert( $at.GetTag() == $tDoseGridScaling );
   $at->SetFromDataSet( $ds );
   // For the sake of long term maintenance, we will not write
   // that this particular attribute is stored as a double. What if

--- a/Source/Common/gdcmASN1.cxx
+++ b/Source/Common/gdcmASN1.cxx
@@ -73,7 +73,7 @@ bool ASN1::ParseDump(const char *array, size_t length)
   BIO *out=NULL;
 
   out=BIO_new(BIO_s_file());
-  assert( out );
+  gdcm_assert( out );
   BIO_set_fp(out,stdout,BIO_NOCLOSE|BIO_FP_TEXT);
   if (!ASN1_parse_dump(out,(const unsigned char*)array,length,indent,dump) )
     {

--- a/Source/Common/gdcmBoxRegion.cxx
+++ b/Source/Common/gdcmBoxRegion.cxx
@@ -67,7 +67,7 @@ Region *BoxRegion::Clone() const
 
 bool BoxRegion::Empty() const
 {
-  assert( 0 );
+  gdcm_assert( 0 );
   return false;
 }
 
@@ -146,14 +146,14 @@ BoxRegion BoxRegion::BoundingBox(BoxRegion const & b1, BoxRegion const & b2 )
 
 BoxRegion::BoxRegion(const BoxRegion& b)
 {
-  assert( b.Internals );
+  gdcm_assert( b.Internals );
   Internals = new BoxRegionInternals;
   *Internals = *b.Internals;
 }
 
 void BoxRegion::operator=(const BoxRegion& b)
 {
-  assert( b.Internals );
+  gdcm_assert( b.Internals );
   *Internals = *b.Internals;
 }
 

--- a/Source/Common/gdcmCAPICryptographicMessageSyntax.cxx
+++ b/Source/Common/gdcmCAPICryptographicMessageSyntax.cxx
@@ -313,7 +313,7 @@ bool CAPICryptographicMessageSyntax::Decrypt(char *output, size_t &outlen, const
   keyBlob.header.reserved = 0;
   keyBlob.header.aiKeyAlg = GetAlgIdByObjId(cekAlg->pszObjId);
   keyBlob.cbKeySize = cekLen;
-  assert(cekLen <= 32);
+  gdcm_assert(cekLen <= 32);
   memcpy(keyBlob.rgbKeyData, cek, cekLen);
 
   if (!CryptImportKey(hProv, (unsigned char*)&keyBlob, sizeof(keyBlob), 0, 0, &hCEK))
@@ -480,7 +480,7 @@ void CAPICryptographicMessageSyntax::ReverseBytes(unsigned char* data, DWORD len
 
 bool CAPICryptographicMessageSyntax::LoadFile(const char * filename, unsigned char* & buffer, DWORD & bufLen)
 {
-  assert( !buffer );
+  gdcm_assert( !buffer );
   FILE * f = fopen(filename, "rb");
   if (f == NULL)
     {

--- a/Source/Common/gdcmCryptoFactory.cxx
+++ b/Source/Common/gdcmCryptoFactory.cxx
@@ -61,7 +61,7 @@ CryptoFactory* CryptoFactory::GetFactoryInstance(CryptoLib id)
     gdcmErrorMacro( "No crypto factory registered with id " << (int)id );
     return nullptr;
     }
-  assert(it->second);
+  gdcm_assert(it->second);
   return it->second;
 }
 

--- a/Source/Common/gdcmDirectory.cxx
+++ b/Source/Common/gdcmDirectory.cxx
@@ -68,7 +68,7 @@ unsigned int Directory::Explore(FilenameType const &name, bool recursive)
   if ('\\' == dirName[dirName.size() - 1])
     dirName = dirName.substr(0, dirName.size() - 1);
   if ('/' != dirName[dirName.size() - 1]) dirName.push_back('/');
-  assert( '/' == dirName[dirName.size()-1] );
+  gdcm_assert( '/' == dirName[dirName.size()-1] );
   const std::wstring firstfile = dirName+L"*";
   HANDLE hFile = FindFirstFileW(firstfile.c_str(), &fileData);
 
@@ -106,7 +106,7 @@ unsigned int Directory::Explore(FilenameType const &name, bool recursive)
 #else
   std::string fileName;
   std::string dirName = name;
-  // assert( System::FileIsDirectory( dirName ) );
+  // gdcm_assert( System::FileIsDirectory( dirName ) );
   Directories.push_back(dirName);
   // Real POSIX implementation: scandir is a BSD extension only, and doesn't
   // work on debian for example
@@ -127,7 +127,7 @@ unsigned int Directory::Explore(FilenameType const &name, bool recursive)
   struct stat buf;
   dirent *d;
   if ('/' != dirName[dirName.size()-1]) dirName.push_back('/');
-  assert( '/' == dirName[dirName.size()-1] );
+  gdcm_assert( '/' == dirName[dirName.size()-1] );
   for (d = readdir(dir); d; d = readdir(dir))
     {
     fileName = dirName + d->d_name;
@@ -152,7 +152,7 @@ unsigned int Directory::Explore(FilenameType const &name, bool recursive)
         || strcmp( d->d_name, ".." ) == 0
         || d->d_name[0] == '.' ) // discard any hidden dir
         continue;
-      assert( d->d_name[0] != '.' ); // hidden directory ??
+      gdcm_assert( d->d_name[0] != '.' ); // hidden directory ??
       if ( recursive )
         {
         nFiles += Explore( fileName, recursive);

--- a/Source/Common/gdcmDirectory.h
+++ b/Source/Common/gdcmDirectory.h
@@ -56,7 +56,7 @@ public :
 
   /// Set/Get the file names within the directory
   FilenamesType const &GetFilenames() const {
-    assert( !(Toplevel.empty()) && "Need to call Explore first" );
+    gdcm_assert( !(Toplevel.empty()) && "Need to call Explore first" );
     return Filenames; }
 
   /// Return the Directories traversed

--- a/Source/Common/gdcmException.h
+++ b/Source/Common/gdcmException.h
@@ -31,6 +31,8 @@
 # endif
 #endif
 
+#define gdcm_forced_assert(cond) assert(cond)
+
 namespace gdcm
 {
 
@@ -54,9 +56,9 @@ class Exception : public std::exception
                                  const unsigned int lineNumber,
                                  const char* const func)
   {
-    assert(desc != nullptr);
-    assert(file != nullptr);
-    assert(func != nullptr);
+    gdcm_forced_assert(desc != nullptr);
+    gdcm_forced_assert(file != nullptr);
+    gdcm_forced_assert(func != nullptr);
     std::ostringstream oswhat;
     oswhat << file << ":" << lineNumber << " (" << func << "):\n";
     oswhat << desc;
@@ -97,6 +99,17 @@ private:
 };
 
 } // end namespace gdcm
+
+// Always defined
+#define gdcm_assert(cond) \
+  if (!(cond)) throw gdcm::Exception("An invalid logic behavior occurred" #cond, __FILE__ , __LINE__)
+
+/* Asserts that should only exist in debug builds. */
+#ifndef NDEBUG // checks in debug builds and elision in release builds (like assert)
+#define gdcm_debug_assert(cond) gdcm_assert(cond)
+#else
+#define gdcm_debug_assert(cond) ((void)0)
+#endif
 
 // Undo warning suppression.
 #if defined(__clang__) && defined(__has_warning)

--- a/Source/Common/gdcmFilename.cxx
+++ b/Source/Common/gdcmFilename.cxx
@@ -52,7 +52,7 @@ const char *Filename::GetPath()
 const char *Filename::GetName()
 {
   std::string filename = FileName;
-  assert( !filename.empty() );
+  gdcm_assert( !filename.empty() );
 #if defined(_WIN32)
   std::string::size_type slash_pos = filename.find_last_of("/\\");
 #else
@@ -69,7 +69,7 @@ const char *Filename::GetName()
 const char *Filename::ToWindowsSlashes()
 {
   Conversion = FileName;
-  //assert( !Conversion.empty() );
+  //gdcm_assert( !Conversion.empty() );
   for (std::string::iterator it = Conversion.begin(); it != Conversion.end(); ++it )
     {
     if( *it == '/' )
@@ -86,13 +86,13 @@ const char *Filename::ToUnixSlashes()
 {
   Conversion = FileName;
   //std::string::size_type s = Conversion.find("\\");
-  //assert( s == std::string::npos );
-  assert( !Conversion.empty() );
+  //gdcm_assert( s == std::string::npos );
+  gdcm_assert( !Conversion.empty() );
   for (std::string::iterator it = Conversion.begin(); it != Conversion.end(); ++it )
     {
     if( *it == '\\' )
       {
-      assert( it+1 == Conversion.end() || *(it+1) != ' ' ); // is it an escaped space ?
+      gdcm_assert( it+1 == Conversion.end() || *(it+1) != ' ' ); // is it an escaped space ?
       *it = '/';
       }
     }

--- a/Source/Common/gdcmFilenameGenerator.cxx
+++ b/Source/Common/gdcmFilenameGenerator.cxx
@@ -92,7 +92,7 @@ bool FilenameGenerator::Generate()
     for( SizeType i = 0; i < numfiles && success; ++i)
       {
       int res = snprintf( internal, internal_len, Pattern.c_str(), i );
-      assert( res >= 0 );
+      gdcm_assert( res >= 0 );
       success = (SizeType)res < internal_len;
       if( Pattern.empty() )
         {
@@ -102,7 +102,7 @@ bool FilenameGenerator::Generate()
         {
         Filenames[i] = Prefix + internal;
         }
-      //assert( Filenames[i].size() == res ); // upon success only
+      //gdcm_assert( Filenames[i].size() == res ); // upon success only
       }
     delete[] internal;
     if( !success )

--- a/Source/Common/gdcmFilenameGenerator.h
+++ b/Source/Common/gdcmFilenameGenerator.h
@@ -62,7 +62,7 @@ public:
   const char * GetFilename(SizeType n) const;
 
   /// Return all filenames
-  FilenamesType const & GetFilenames() const { assert( !Pattern.empty() ); return Filenames; }
+  FilenamesType const & GetFilenames() const { gdcm_assert( !Pattern.empty() ); return Filenames; }
 
 private:
   FilenameType Pattern;

--- a/Source/Common/gdcmObject.h
+++ b/Source/Common/gdcmObject.h
@@ -55,7 +55,7 @@ public:
   virtual ~Object() {
     // If your debugger reach here it means you are doing something silly
     // like using SmartPointer on object allocated on the stack (vs heap)
-    assert(ReferenceCount == 0);
+    gdcm_forced_assert(ReferenceCount == 0);
     }
 
   // http://www.parashift.com/c++-faq-lite/freestore-mgmt.html#faq-16.24
@@ -71,10 +71,10 @@ protected:
   // For the purpose of the invasive SmartPointer implementation
   void Register() {
     ReferenceCount++;
-    assert( ReferenceCount > 0 );
+    gdcm_assert( ReferenceCount > 0 );
   }
   void UnRegister() {
-    assert( ReferenceCount > 0 );
+    gdcm_assert( ReferenceCount > 0 );
     ReferenceCount--;
     if(!ReferenceCount)
       {

--- a/Source/Common/gdcmOpenSSLCryptographicMessageSyntax.cxx
+++ b/Source/Common/gdcmOpenSSLCryptographicMessageSyntax.cxx
@@ -56,7 +56,7 @@ CryptographicMessageSyntax::CipherTypes OpenSSLCryptographicMessageSyntax::GetCi
 
 bool OpenSSLCryptographicMessageSyntax::SetPassword(const char * pass, size_t passLen)
 {
-  assert(pass);
+  gdcm_assert(pass);
 
   if (password)
     {
@@ -281,7 +281,7 @@ bool OpenSSLCryptographicMessageSyntax::ParseKeyFile( const char *keyfile)
 
 bool OpenSSLCryptographicMessageSyntax::ParseCertificateFile( const char *keyfile)
 {
-  assert( recips );
+  gdcm_assert( recips );
   ::X509 *x509 = NULL;
 
   ::BIO *in;

--- a/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx
+++ b/Source/Common/gdcmOpenSSLP7CryptographicMessageSyntax.cxx
@@ -446,7 +446,7 @@ bool OpenSSLP7CryptographicMessageSyntax::ParseCertificateFile( const char *keyf
 {
 #ifdef GDCM_USE_SYSTEM_OPENSSL
   STACK_OF(X509) *recips = Internals->GetRecipients();
-  assert( recips );
+  gdcm_assert( recips );
   ::X509 *x509 = NULL;
 
   ::BIO *in;

--- a/Source/Common/gdcmSmartPointer.h
+++ b/Source/Common/gdcmSmartPointer.h
@@ -60,7 +60,7 @@ public:
 
   ObjectType& operator * () const
     {
-    assert( Pointer );
+    gdcm_assert( Pointer );
     return *Pointer; 
     }
 

--- a/Source/Common/gdcmSwapCode.cxx
+++ b/Source/Common/gdcmSwapCode.cxx
@@ -47,9 +47,9 @@ int SwapCode::GetIndex(SwapCode const & sc)
     idx = 4;
     break;
   default:
-    assert(0 && "Should not happen" );
+    gdcm_assert(0 && "Should not happen" );
     }
-  assert( idx < 5 );
+  gdcm_assert( idx < 5 );
   return idx;
 }
 

--- a/Source/Common/gdcmSwapper.txx
+++ b/Source/Common/gdcmSwapper.txx
@@ -148,7 +148,7 @@ namespace gdcm
         SwapperNoOp::SwapArray<uint32_t>((uint32_t*)array,n);
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
       }
     }
 
@@ -160,7 +160,7 @@ namespace gdcm
         SwapperNoOp::SwapArray<uint64_t>((uint64_t*)array,n);
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
       }
     }
 
@@ -224,7 +224,7 @@ namespace gdcm
         SwapperDoOp::SwapArray<uint32_t>((uint32_t*)array,n);
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
       }
     }
 
@@ -236,7 +236,7 @@ namespace gdcm
         SwapperDoOp::SwapArray<uint64_t>((uint64_t*)array,n);
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
       }
     }
 

--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -212,7 +212,7 @@ bool System::FileExists(const char* filename)
     }
   else
     {
-    //assert( !FileIsDirectory(filename) );
+    //gdcm_assert( !FileIsDirectory(filename) );
     return true;
     }
 }
@@ -437,7 +437,7 @@ bool System::DeleteDirectory(const char *source)
         out = prefix + (out.c_str() + 2);
       } else {
         // regular C:\ style path:
-        assert(out[1] == ':');
+        gdcm_assert(out[1] == ':');
         const std::wstring prefix = LR"(\\?\)";
         out = prefix + out.c_str();
       }
@@ -613,7 +613,7 @@ inline int getlastdigit(unsigned char *data, unsigned long size)
     data[i] = (unsigned char)(extended / 10);
     carry = extended % 10;
     }
-  assert( carry >= 0 && carry < 10 );
+  gdcm_assert( carry >= 0 && carry < 10 );
   return carry;
 }
 
@@ -689,7 +689,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
        (other than the declaration) is a bug. Thus, the following is purely of
        historic interest.
 */
-  assert( tz == 0 );
+  gdcm_assert( tz == 0 );
   FILETIME ft;
   unsigned __int64 tmpres = 0;
   //static int tzflag;
@@ -818,7 +818,7 @@ const char *System::GetTimezoneOffsetFromUTC()
   time_t t = time(nullptr);
   struct tm *tmp = localtime(&t);
   size_t l = strftime(outstr, sizeof(outstr), "%z", tmp);
-  assert( l == 5 ); (void)l;
+  gdcm_assert( l == 5 ); (void)l;
   buffer = outstr;
   return buffer.c_str();
 }
@@ -846,7 +846,7 @@ bool System::FormatDateTime(char date[22], time_t timep, long milliseconds)
     }
   // Format the date and time, down to a single second.
   size_t ret = strftime (tmp, sizeof (tmp), "%Y%m%d%H%M%S", ptm);
-  assert( ret == 14 );
+  gdcm_assert( ret == 14 );
   if( ret == 0 || ret >= maxsize )
     {
     return false;
@@ -911,7 +911,7 @@ bool System::GetCurrentDateTime(char date[22])
   // "59"), SS = Second (range "00" - "60").
   // FFFFFF = Fractional Second contains a fractional part of a second as small
   // as 1 millionth of a second (range 000000 - 999999).
-  assert( tv.tv_usec >= 0 && tv.tv_usec < 1000000 );
+  gdcm_assert( tv.tv_usec >= 0 && tv.tv_usec < 1000000 );
   milliseconds = tv.tv_usec;
 
   return FormatDateTime(date, timep, milliseconds);
@@ -925,7 +925,7 @@ int System::StrNCaseCmp(const char *s1, const char *s2, size_t n)
   return _strnicmp(s1,s2,n);
 #else // default implementation
 #error
-  assert( n ); // TODO
+  gdcm_assert( n ); // TODO
   while (--n && *s1 && (tolower(*s1) == tolower(*s2)))
     {
     s1++;
@@ -1051,7 +1051,7 @@ struct CharsetAliasType
 
 static const char *CharsetAliasToName(const char *alias)
 {
-  assert( alias );
+  gdcm_assert( alias );
   //gdcmDebugMacro( alias );
   // http://msdn.microsoft.com/en-us/library/windows/desktop/dd317756(v=vs.85).aspx
   // 1252 windows-1252  ANSI Latin 1; Western European (Windows)

--- a/Source/Common/gdcmTerminal.cxx
+++ b/Source/Common/gdcmTerminal.cxx
@@ -84,7 +84,7 @@ public:
   std::string textcolor() const {
     char command[16];
     int n = snprintf(command, sizeof(command), "%c[%d;%d;%dm", 0x1B, attribute, fgcolor + 30, bgcolor + 40);
-    assert( n < 16 ); (void)n;
+    gdcm_assert( n < 16 ); (void)n;
     return command;
   }
   void set_attributes(int color) {

--- a/Source/Common/gdcmTesting.cxx
+++ b/Source/Common/gdcmTesting.cxx
@@ -79,7 +79,7 @@ const char * const * Testing::GetMediaStorageDataFile(unsigned int file)
 {
   if( file < Testing::GetNumberOfMediaStorageDataFiles() ) return gdcmMediaStorageDataFiles[file];
   // else return the {0x0, 0x0} sentinel:
-  assert( *gdcmMediaStorageDataFiles[ Testing::GetNumberOfMediaStorageDataFiles() ] == nullptr );
+  gdcm_assert( *gdcmMediaStorageDataFiles[ Testing::GetNumberOfMediaStorageDataFiles() ] == nullptr );
   return gdcmMediaStorageDataFiles[ Testing::GetNumberOfMediaStorageDataFiles() ];
 }
 const char * Testing::GetMediaStorageFromFile(const char *filepath)
@@ -99,7 +99,7 @@ const char * Testing::GetMediaStorageFromFile(const char *filepath)
     p = mediastorages[i][0];
     }
   // \postcondition always valid (before sentinel)
-  assert( i <= GetNumberOfMediaStorageDataFiles() );
+  gdcm_assert( i <= GetNumberOfMediaStorageDataFiles() );
   return mediastorages[i][1];
 }
 
@@ -119,7 +119,7 @@ const char * const * Testing::GetMD5DataImage(unsigned int file)
 {
   if( file < Testing::GetNumberOfMD5DataImages() ) return gdcmMD5DataImages[file];
   // else return the {0x0, 0x0} sentinel:
-  assert( *gdcmMD5DataImages[ Testing::GetNumberOfMD5DataImages() ] == nullptr );
+  gdcm_assert( *gdcmMD5DataImages[ Testing::GetNumberOfMD5DataImages() ] == nullptr );
   return gdcmMD5DataImages[ Testing::GetNumberOfMD5DataImages() ];
 }
 
@@ -141,7 +141,7 @@ const char * Testing::GetMD5FromFile(const char *filepath)
     p = md5s[i][1];
     }
   // \postcondition always valid (before sentinel)
-  assert( i <= GetNumberOfMD5DataImages() );
+  gdcm_assert( i <= GetNumberOfMD5DataImages() );
   return md5s[i][0];
 }
 
@@ -471,7 +471,7 @@ int Testing::GetLossyFlagFromFile(const char *filename)
     std::cerr << "Error: No ref table for: " << filename << std::endl;
     return -1;
     }
-  assert( pfiles->filename ); // need to update ref table
+  gdcm_assert( pfiles->filename ); // need to update ref table
   return pfiles->lossyflag;
 }
 

--- a/Source/Common/gdcmTrace.cxx
+++ b/Source/Common/gdcmTrace.cxx
@@ -36,7 +36,7 @@ void Trace::SetStreamToFile( const char *filename )
   if( !filename ) return;
   if( UseStreamToFile )
     {
-    assert( FileStream );
+    gdcm_assert( FileStream );
     FileStream->close();
     FileStream = nullptr;
     UseStreamToFile = false;
@@ -45,7 +45,7 @@ void Trace::SetStreamToFile( const char *filename )
   if( !out ) return;
   out->open( filename );
   if( !out->good() ) return;
-  assert( !FileStream && !UseStreamToFile );
+  gdcm_assert( !FileStream && !UseStreamToFile );
   FileStream = out;
   UseStreamToFile = true;
   DebugStream   = FileStream;
@@ -58,7 +58,7 @@ void Trace::SetStream(std::ostream &os)
   if( !os.good() ) return;
   if( UseStreamToFile )
     {
-    assert( FileStream );
+    gdcm_assert( FileStream );
     FileStream->close();
     FileStream = nullptr;
     UseStreamToFile = false;
@@ -114,7 +114,7 @@ Trace::~Trace()
 {
   if( UseStreamToFile )
     {
-    assert( FileStream );
+    gdcm_forced_assert( FileStream );
     FileStream->close();
     FileStream = nullptr;
     }

--- a/Source/Common/zipstreamimpl.hpp
+++ b/Source/Common/zipstreamimpl.hpp
@@ -272,7 +272,7 @@ bool basic_zip_streambuf<charT, traits>::zip_to_stream(
             {
                 // copy to the beginning of the stream
 				std::streamsize theDiff = written_byte_size-remainder;
-				//assert(theDiff > 0 && theDiff < std::numeric_limits<unsigned int>::max());
+				//gdcm_assert(theDiff > 0 && theDiff < std::numeric_limits<unsigned int>::max());
                 memcpy(&_output_buffer[0],
                        &_output_buffer[(unsigned int)theDiff],
                        remainder);
@@ -511,7 +511,7 @@ basic_unzip_streambuf<charT, traits>::fill_input_buffer()
         // Ok so we reached the end of file, since we did not read no header
         // we have to explicitly tell zlib the compress stream ends, therefore
         // we add an extra \0 character...it may not always be needed...
-        assert( nbytesread < (std::streamsize)(_input_buffer.size() / sizeof(char_type)) );
+        gdcm_assert( nbytesread < (std::streamsize)(_input_buffer.size() / sizeof(char_type)) );
         _input_buffer[ (unsigned int)nbytesread ] = 0;
         ++nbytesread;
         }

--- a/Source/DataDictionary/gdcmCSAHeaderDict.h
+++ b/Source/DataDictionary/gdcmCSAHeaderDict.h
@@ -40,7 +40,7 @@ public:
   //static CSAHeaderDictEntry GroupLengthCSAHeaderDictEntry; // = CSAHeaderDictEntry("Group Length",VR::UL,VM::VM1);
 
   CSAHeaderDict():CSAHeaderDictInternal() {
-    assert( CSAHeaderDictInternal.empty() );
+    gdcm_assert( CSAHeaderDictInternal.empty() );
   }
   CSAHeaderDict &operator=(const CSAHeaderDict &_val) = delete;
   CSAHeaderDict(const CSAHeaderDict &_val) = delete;
@@ -57,7 +57,7 @@ public:
     MapCSAHeaderDictEntry::size_type s = CSAHeaderDictInternal.size();
 #endif
     CSAHeaderDictInternal.insert( de );
-    assert( s < CSAHeaderDictInternal.size() );
+    gdcm_assert( s < CSAHeaderDictInternal.size() );
     }
 
   const CSAHeaderDictEntry &GetCSAHeaderDictEntry(const char *name) const

--- a/Source/DataDictionary/gdcmDefaultDicts.cxx
+++ b/Source/DataDictionary/gdcmDefaultDicts.cxx
@@ -13882,7 +13882,7 @@ void Dict::LoadDefault()
    {
       Tag t(n.group, n.element);
       DictEntry e( n.name, n.keyword, n.vr, n.vm, n.ret );
-      assert( DictEntry::CheckKeywordAgainstName(n.name, n.keyword) );
+      gdcm_assert( DictEntry::CheckKeywordAgainstName(n.name, n.keyword) );
       AddDictEntry( t, e );
       n = DICOMV3DataDict[++i];
    }

--- a/Source/DataDictionary/gdcmDict.h
+++ b/Source/DataDictionary/gdcmDict.h
@@ -50,7 +50,7 @@ public:
   //static DictEntry GroupLengthDictEntry; // = DictEntry("Group Length",VR::UL,VM::VM1);
 
   Dict():DictInternal() {
-    assert( DictInternal.empty() );
+    gdcm_assert( DictInternal.empty() );
   }
   Dict &operator=(const Dict &_val) = delete;
   Dict(const Dict &_val) = delete;
@@ -69,7 +69,7 @@ public:
 #endif
     DictInternal.insert(
       MapDictEntry::value_type(tag, de));
-    assert( s < DictInternal.size() );
+    gdcm_assert( s < DictInternal.size() );
     }
 
   const DictEntry &GetDictEntry(const Tag &tag) const
@@ -92,13 +92,13 @@ public:
         && tag != Tag(0x40,0xa125)
       )
         {
-        assert( 0 && "Impossible" );
+        gdcm_assert( 0 && "Impossible" );
         }
 #endif
       it = DictInternal.find( Tag(0xffff,0xffff) );
       return it->second;
       }
-    assert( DictInternal.count(tag) == 1 );
+    gdcm_assert( DictInternal.count(tag) == 1 );
     return it->second;
     }
 
@@ -111,7 +111,7 @@ public:
       {
       return nullptr;
       }
-    assert( DictInternal.count(tag) == 1 );
+    gdcm_assert( DictInternal.count(tag) == 1 );
     return it->second.GetKeyword();
     }
 
@@ -145,7 +145,7 @@ public:
       it = DictInternal.find( tag );
       return it->second;
       }
-    assert( DictInternal.count(tag) == 1 );
+    gdcm_assert( DictInternal.count(tag) == 1 );
     return it->second;
     }
 
@@ -178,7 +178,7 @@ public:
       it = DictInternal.find( tag );
       return it->second;
       }
-    assert( DictInternal.count(tag) == 1 );
+    gdcm_assert( DictInternal.count(tag) == 1 );
     return it->second;
     }
 
@@ -234,23 +234,23 @@ public:
       {
       MapDictEntry::iterator it =
         DictInternal.find(tag);
-      assert( it != DictInternal.end() );
+      gdcm_assert( it != DictInternal.end() );
       DictEntry &duplicate = it->second;
-      assert( de.GetVR() == VR::UN || duplicate.GetVR() == VR::UN );
-      assert( de.GetVR() != duplicate.GetVR() );
+      gdcm_assert( de.GetVR() == VR::UN || duplicate.GetVR() == VR::UN );
+      gdcm_assert( de.GetVR() != duplicate.GetVR() );
       if( duplicate.GetVR() == VR::UN )
         {
-        assert( de.GetVR() != VR::UN );
+        gdcm_assert( de.GetVR() != VR::UN );
         duplicate.SetVR( de.GetVR() );
         duplicate.SetVM( de.GetVM() );
-        assert( GetDictEntry(tag).GetVR() != VR::UN );
-        assert( GetDictEntry(tag).GetVR() == de.GetVR() );
-        assert( GetDictEntry(tag).GetVM() == de.GetVM() );
+        gdcm_assert( GetDictEntry(tag).GetVR() != VR::UN );
+        gdcm_assert( GetDictEntry(tag).GetVR() == de.GetVR() );
+        gdcm_assert( GetDictEntry(tag).GetVM() == de.GetVM() );
         }
       return;
       }
 #endif
-    assert( s < DictInternal.size() /*&& std::cout << tag << "," << de << std::endl*/ );
+    gdcm_assert( s < DictInternal.size() /*&& std::cout << tag << "," << de << std::endl*/ );
     }
   /// Remove entry 'tag'. Return true on success (element was found
   /// and remove). return false if element was not found.
@@ -258,7 +258,7 @@ public:
     {
     MapDictEntry::size_type s =
       DictInternal.erase(tag);
-    assert( s == 1 || s == 0 );
+    gdcm_assert( s == 1 || s == 0 );
     return s == 1;
     }
   bool FindDictEntry(const PrivateTag &tag) const
@@ -278,12 +278,12 @@ public:
       DictInternal.find(tag);
     if (it == DictInternal.end())
       {
-      //assert( 0 && "Impossible" );
+      //gdcm_assert( 0 && "Impossible" );
       it = DictInternal.find( PrivateTag(0xffff,0xffff,"GDCM Private Sentinel" ) );
       assert (it != DictInternal.end());
       return it->second;
       }
-    assert( DictInternal.count(tag) == 1 );
+    gdcm_assert( DictInternal.count(tag) == 1 );
     return it->second;
     }
 

--- a/Source/DataDictionary/gdcmDictConverter.cxx
+++ b/Source/DataDictionary/gdcmDictConverter.cxx
@@ -153,7 +153,7 @@ void DictConverter::Convert()
           }
         }
       else
-        assert(0);
+        gdcm_assert(0);
       }
     else if ( line[7] == 'x' && line[8] == 'x' )
       {
@@ -179,7 +179,7 @@ void DictConverter::Convert()
           }
         }
       else
-        assert(0);
+        gdcm_assert(0);
       }
     else
       {
@@ -206,7 +206,7 @@ bool DictConverter::ReadVR(const char *raw, VR::VRType &type)
     ++i;
   std::string vm(raw, raw+i-1);
   type = VR::GetVRType(vm.c_str());
-  assert( type != VR::VR_END );
+  gdcm_assert( type != VR::VR_END );
   return true;
 }
 
@@ -214,9 +214,9 @@ bool DictConverter::ReadVM(const char *raw, VM::VMType &type)
 {
   char vm[8];
   int r = sscanf(raw, "%s", vm);
-  assert( r == 1 );
+  gdcm_assert( r == 1 );
   type = VM::GetVMType(vm);
-  assert( type != VM::VM_END );
+  gdcm_assert( type != VM::VM_END );
   return true;
 }
 
@@ -224,11 +224,11 @@ bool DictConverter::Readuint16(const char *raw, uint16_t &ov)
 {
   unsigned int v;
   int r = sscanf(raw, "%04x", &v);
-  assert( r == 1 && "Wrong Value read for uint16");
+  gdcm_assert( r == 1 && "Wrong Value read for uint16");
   char sv[4+1];
   r = snprintf(sv, sizeof(sv), "%04x", v);
-  assert( r == 4 && "Wrong Value printed for uint16");
-  assert( strncmp(raw, sv, 4) == 0 );
+  gdcm_assert( r == 4 && "Wrong Value printed for uint16");
+  gdcm_assert( strncmp(raw, sv, 4) == 0 );
   ov = v;
   return true;
 }
@@ -302,7 +302,7 @@ bool DictConverter::ConvertToXML(const char *raw, std::string &cxx)
   VR::VRType vr;
   VM::VMType vm;
   Readuint16(raw, group);
-  assert( !(group%2) );
+  gdcm_assert( !(group%2) );
   Readuint16(raw+5, element);
   ReadVR(raw+10, vr);
   int len = 11+strlen(VR::GetVRString(vr));
@@ -331,7 +331,7 @@ bool DictConverter::ConvertToCXX(const char *raw, std::string &cxx)
   VR::VRType vr;
   VM::VMType vm;
   Readuint16(raw, group);
-  //assert( !(group%2) );
+  //gdcm_assert( !(group%2) );
   //
   Readuint16(raw+5, element);
   ReadVR(raw+10, vr);

--- a/Source/DataDictionary/gdcmDicts.cxx
+++ b/Source/DataDictionary/gdcmDicts.cxx
@@ -55,12 +55,12 @@ const DictEntry &Dicts::GetDictEntry(const Tag& tag, const char *owner) const
     }
   else if( tag.IsPublic() )
     {
-    assert( owner == nullptr );
+    gdcm_assert( owner == nullptr );
     return PublicDict.GetDictEntry(tag);
     }
   else
     {
-    assert( tag.IsPrivate() );
+    gdcm_assert( tag.IsPrivate() );
     if( owner && *owner )
       {
       size_t len = strlen(owner); (void)len;
@@ -78,10 +78,10 @@ const DictEntry &Dicts::GetDictEntry(const Tag& tag, const char *owner) const
         }
       else if( tag.IsPrivateCreator() )
         {
-        assert( !tag.IsIllegal() );
-        assert( tag.GetElement() ); // Not a group length !
-        assert( tag.IsPrivate() );
-        assert( owner == nullptr );
+        gdcm_assert( !tag.IsIllegal() );
+        gdcm_assert( tag.GetElement() ); // Not a group length !
+        gdcm_assert( tag.IsPrivate() );
+        gdcm_assert( owner == nullptr );
         static const DictEntry Dummy("Private Creator", "PrivateCreator", VR::LO, VM::VM1, false);
         return Dummy;
         }
@@ -109,7 +109,7 @@ const char *Dicts::GetConstructorString(ConstructorType type)
 
 const Dict &Dicts::GetPublicDict() const
 {
-  //assert( PublicType < PublicDicts.size() );
+  //gdcm_assert( PublicType < PublicDicts.size() );
   return PublicDict; //[PublicType];
 }
 

--- a/Source/DataDictionary/gdcmGlobal.cxx
+++ b/Source/DataDictionary/gdcmGlobal.cxx
@@ -44,7 +44,7 @@ public:
   // - on some system where it make sense the path where the Resource should be located
   void LoadDefaultPaths()
     {
-    assert( ResourcePaths.empty() );
+    gdcm_assert( ResourcePaths.empty() );
     const char filename2[] = GDCM_CMAKE_INSTALL_PREFIX "/" GDCM_INSTALL_DATA_DIR "/XML/";
     ResourcePaths.emplace_back(filename2 );
     const char filename3[] = GDCM_CMAKE_INSTALL_PREFIX " " GDCM_API_VERSION "/" GDCM_INSTALL_DATA_DIR "/XML/";
@@ -76,14 +76,14 @@ Global::Global()
 {
   if(++GlobalCount == 1)
     {
-    assert( Internals == nullptr ); // paranoid
+    gdcm_assert( Internals == nullptr ); // paranoid
     Internals = new GlobalInternal;
-    assert( Internals->GlobalDicts.IsEmpty() );
+    gdcm_assert( Internals->GlobalDicts.IsEmpty() );
     // Fill in with default values now !
     // at startup time is safer as later call might be from different thread
     // thus initialization of std::map would be all skrew up
     Internals->GlobalDicts.LoadDefaults();
-    assert( Internals->GlobalDefs.IsEmpty() );
+    gdcm_assert( Internals->GlobalDefs.IsEmpty() );
     // Same goes for GlobalDefs:
     //Internals->GlobalDefs.LoadDefaults();
     Internals->LoadDefaultPaths();
@@ -102,7 +102,7 @@ Global::~Global()
 
 bool Global::LoadResourcesFiles()
 {
-  assert( Internals != nullptr ); // paranoid
+  gdcm_assert( Internals != nullptr ); // paranoid
   const char *filename = Locate( "Part3.xml" );
   if( filename )
     {
@@ -171,19 +171,19 @@ const char *Global::Locate(const char *resfile) const
 
 Dicts const &Global::GetDicts() const
 {
-  assert( !Internals->GlobalDicts.IsEmpty() );
+  gdcm_assert( !Internals->GlobalDicts.IsEmpty() );
   return Internals->GlobalDicts;
 }
 
 Dicts &Global::GetDicts()
 {
-  assert( !Internals->GlobalDicts.IsEmpty() );
+  gdcm_assert( !Internals->GlobalDicts.IsEmpty() );
   return Internals->GlobalDicts;
 }
 
 Defs const &Global::GetDefs() const
 {
-  assert( !Internals->GlobalDefs.IsEmpty() );
+  gdcm_assert( !Internals->GlobalDefs.IsEmpty() );
   return Internals->GlobalDefs;
 }
 

--- a/Source/DataDictionary/gdcmGroupDict.cxx
+++ b/Source/DataDictionary/gdcmGroupDict.cxx
@@ -18,13 +18,13 @@ namespace gdcm
 
 std::string const &GroupDict::GetAbbreviation(uint16_t num) const
 {
-  assert(num < Abbreviations.size());
+  gdcm_assert(num < Abbreviations.size());
   return Abbreviations[num];
 }
 
 std::string const &GroupDict::GetName(uint16_t num) const
 {
-  assert(num < Names.size());
+  gdcm_assert(num < Names.size());
   return Names[num];
 }
 

--- a/Source/DataDictionary/gdcmGroupDict.h
+++ b/Source/DataDictionary/gdcmGroupDict.h
@@ -41,7 +41,7 @@ public:
 
   size_t Size() const
     {
-    assert( Names.size() == Abbreviations.size() );
+    gdcm_assert( Names.size() == Abbreviations.size() );
     return Names.size(); }
 
   std::string const &GetAbbreviation(uint16_t num) const;

--- a/Source/DataDictionary/gdcmPrivateDefaultDicts.cxx
+++ b/Source/DataDictionary/gdcmPrivateDefaultDicts.cxx
@@ -11999,7 +11999,7 @@ void Dict::LoadDefault()
    {
    if( n.group % 2 == 0 )
      {
-     assert( n.owner == 0 );
+     gdcm_assert( n.owner == 0 );
      Tag t(n.group, n.element);
      DictEntry e( n.name, n.vr, n.vm, n.ret );
      AddDictEntry( t, e );
@@ -12017,10 +12017,10 @@ void PrivateDict::LoadDefault()
    {
 //   if( n.group % 2 != 0 )
      {
-     assert( n.owner != nullptr );
-     assert( n.name );
-     assert( n.group % 2 != 0 || n.group == 0xffff );
-     assert( n.element <= 0xff || n.element == 0xffff );
+     gdcm_assert( n.owner != nullptr );
+     gdcm_assert( n.name );
+     gdcm_assert( n.group % 2 != 0 || n.group == 0xffff );
+     gdcm_assert( n.element <= 0xff || n.element == 0xffff );
      PrivateTag t(n.group, n.element,n.owner);
      DictEntry e( n.name, "", n.vr, n.vm, n.ret );
      AddDictEntry( t, e );

--- a/Source/DataDictionary/gdcmSOPClassUIDToIOD.cxx
+++ b/Source/DataDictionary/gdcmSOPClassUIDToIOD.cxx
@@ -135,7 +135,7 @@ namespace gdcm
 unsigned int SOPClassUIDToIOD::GetNumberOfSOPClassToIOD()
 {
   static const unsigned int n = sizeof( SOPClassUIDToIODStrings ) / sizeof( *SOPClassUIDToIODStrings );
-  assert( n > 0 );
+  gdcm_assert( n > 0 );
   return n - 1;
 }
 
@@ -188,7 +188,7 @@ SOPClassUIDToIOD::SOPClassUIDToIODType& SOPClassUIDToIOD::GetSOPClassUIDToIOD(un
   if( i < SOPClassUIDToIOD::GetNumberOfSOPClassToIOD() )
     return SOPClassUIDToIODStrings[i];
   // else return the {0x0, 0x0} sentinel:
-  assert( *SOPClassUIDToIODStrings[ SOPClassUIDToIOD::GetNumberOfSOPClassToIOD() ] == nullptr );
+  gdcm_assert( *SOPClassUIDToIODStrings[ SOPClassUIDToIOD::GetNumberOfSOPClassToIOD() ] == nullptr );
   return SOPClassUIDToIODStrings[ SOPClassUIDToIOD::GetNumberOfSOPClassToIOD() ];
 
 }
@@ -209,7 +209,7 @@ const char *SOPClassUIDToIOD::GetSOPClassUIDFromIOD(const char *iod)
     p = sopclassuidtoiods[i][1];
     }
   // \postcondition always valid (before sentinel)
-  assert( i <= GetNumberOfSOPClassToIOD() );
+  gdcm_assert( i <= GetNumberOfSOPClassToIOD() );
   return sopclassuidtoiods[i][0];
 }
 
@@ -229,7 +229,7 @@ const char *SOPClassUIDToIOD::GetIODFromSOPClassUID(const char *sopclassuid)
     p = sopclassuidtoiods[i][0];
     }
   // \postcondition always valid (before sentinel)
-  assert( i <= GetNumberOfSOPClassToIOD() );
+  gdcm_assert( i <= GetNumberOfSOPClassToIOD() );
   return sopclassuidtoiods[i][1];
 }
 

--- a/Source/DataDictionary/gdcmUIDs.cxx
+++ b/Source/DataDictionary/gdcmUIDs.cxx
@@ -511,8 +511,8 @@ const char * const * UIDs::GetTransferSyntaxString(unsigned int ts)
 {
   if( ts > 0 && ts <= UIDs::GetNumberOfTransferSyntaxStrings() ) return TransferSyntaxStrings[ts];
   // else return the {0x0, 0x0} sentinel (begin or end)
-  assert( *TransferSyntaxStrings[ UIDs::GetNumberOfTransferSyntaxStrings() + 1 ] == nullptr );
-  assert( *TransferSyntaxStrings[ 0 ] == nullptr );
+  gdcm_assert( *TransferSyntaxStrings[ UIDs::GetNumberOfTransferSyntaxStrings() + 1 ] == nullptr );
+  gdcm_assert( *TransferSyntaxStrings[ 0 ] == nullptr );
   return TransferSyntaxStrings[ UIDs::GetNumberOfTransferSyntaxStrings() + 1 ];
 }
 
@@ -553,11 +553,11 @@ bool UIDs::SetFromUID(const char *str)
   if( p )
     {
     TSField = TSType(i);
-    assert( TSField != (TSType)0 );
+    gdcm_assert( TSField != (TSType)0 );
     return true;
     }
 
-  assert( TSField == (TSType)0 );
+  gdcm_assert( TSField == (TSType)0 );
   return false;
 }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmAttribute.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmAttribute.h
@@ -125,7 +125,7 @@ public:
 
   // copy:
   //ArrayType GetValue(unsigned int idx = 0) {
-  //  assert( idx < GetNumberOfValues() );
+  //  gdcm_assert( idx < GetNumberOfValues() );
   //  return Internal[idx];
   //}
   //ArrayType operator[] (unsigned int idx) {
@@ -152,7 +152,7 @@ public:
     }
 
   ArrayType &GetValue(unsigned int idx = 0) {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     return Internal[idx];
   }
   ArrayType & operator[] (unsigned int idx) {
@@ -160,18 +160,18 @@ public:
   }
   // const reference
   ArrayType const &GetValue(unsigned int idx = 0) const {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     return Internal[idx];
   }
   ArrayType const & operator[] (unsigned int idx) const {
     return GetValue(idx);
   }
   void SetValue(ArrayType v, unsigned int idx = 0) {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     Internal[idx] = v;
   }
   void SetValues(const ArrayType* array, unsigned int numel = VMType ) {
-    assert( array && numel && numel == GetNumberOfValues() );
+    gdcm_assert( array && numel && numel == GetNumberOfValues() );
     // std::copy is smarted than a memcpy, and will call memcpy when POD type
     std::copy(array, array+numel, Internal);
   }
@@ -187,7 +187,7 @@ public:
     EncodingImplementation<VRToEncoding<TVR>::Mode>::Write(Internal,
       GetNumberOfValues(),os);
     ret.SetVR( GetVR() );
-    assert( ret.GetVR() != VR::SQ );
+    gdcm_assert( ret.GetVR() != VR::SQ );
     if( (VR::VRType)VRToEncoding<TVR>::Mode == VR::VRASCII )
       {
       if( GetVR() != VR::UI )
@@ -205,9 +205,9 @@ public:
 
   void SetFromDataElement(DataElement const &de) {
     // This is kind of hackish but since I do not generate other element than the first one: 0x6000 I should be ok:
-    assert( Tag(Group,Element) == de.GetTag() || Group == 0x6000 || Group == 0x5000 );
-    assert( GetVR() != VR::INVALID );
-    assert( GetVR().Compatible( de.GetVR() ) || de.GetVR() == VR::INVALID ); // In case of VR::INVALID cannot use the & operator
+    gdcm_assert( Tag(Group,Element) == de.GetTag() || Group == 0x6000 || Group == 0x5000 );
+    gdcm_assert( GetVR() != VR::INVALID );
+    gdcm_assert( GetVR().Compatible( de.GetVR() ) || de.GetVR() == VR::INVALID ); // In case of VR::INVALID cannot use the & operator
     if( de.IsEmpty() ) return;
     const ByteValue *bv = de.GetByteValue();
 #ifdef GDCM_WORDS_BIGENDIAN
@@ -236,7 +236,7 @@ public:
 protected:
   void SetByteValueNoSwap(const ByteValue *bv) {
     if( !bv ) return; // That would be bad...
-    assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
+    gdcm_assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
     //if( VRToEncoding<TVR>::Mode == VR::VRBINARY )
     //  {
     //  // always do a copy !
@@ -253,7 +253,7 @@ protected:
   }
   void SetByteValue(const ByteValue *bv) {
     if( !bv ) return; // That would be bad...
-    assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
+    gdcm_assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
     //if( VRToEncoding<TVR>::Mode == VR::VRBINARY )
     //  {
     //  // always do a copy !
@@ -274,7 +274,7 @@ protected:
     const uint16_t cref[] = { Group, Element };
     uint16_t c[2];
     _is.read((char*)&c, sizeof(c));
-    assert( c[0] == cref[0] && c[1] == cref[1] );
+    gdcm_assert( c[0] == cref[0] && c[1] == cref[1] );
     char vr[2];
     _is.read(vr, 2); // Check consistency ?
     const uint32_t lref = GetLength() * sizeof( typename VRToType<TVR>::Type );
@@ -357,7 +357,7 @@ public:
   }
   // copy:
   //ArrayType GetValue(unsigned int idx = 0) {
-  //  assert( idx < GetNumberOfValues() );
+  //  gdcm_assert( idx < GetNumberOfValues() );
   //  return Internal[idx];
   //}
   //ArrayType operator[] (unsigned int idx) {
@@ -384,7 +384,7 @@ public:
     }
 
   ArrayType &GetValue() {
-//    assert( idx < GetNumberOfValues() );
+//    gdcm_assert( idx < GetNumberOfValues() );
     return Internal;
   }
 //  ArrayType & operator[] (unsigned int idx) {
@@ -392,18 +392,18 @@ public:
 //  }
   // const reference
   ArrayType const &GetValue() const {
-    //assert( idx < GetNumberOfValues() );
+    //gdcm_assert( idx < GetNumberOfValues() );
     return Internal;
   }
   //ArrayType const & operator[] () const {
   //  return GetValue();
   //}
   void SetValue(ArrayType v) {
-//    assert( idx < GetNumberOfValues() );
+//    gdcm_assert( idx < GetNumberOfValues() );
     Internal = v;
   }
 /*  void SetValues(const ArrayType* array, unsigned int numel = VMType ) {
-    assert( array && numel && numel == GetNumberOfValues() );
+    gdcm_assert( array && numel && numel == GetNumberOfValues() );
     // std::copy is smarted than a memcpy, and will call memcpy when POD type
     std::copy(array, array+numel, Internal);
   }
@@ -422,7 +422,7 @@ public:
     EncodingImplementation<VRToEncoding<TVR>::Mode>::Write(&Internal,
       GetNumberOfValues(),os);
     ret.SetVR( GetVR() );
-    assert( ret.GetVR() != VR::SQ );
+    gdcm_assert( ret.GetVR() != VR::SQ );
     if( (VR::VRType)VRToEncoding<TVR>::Mode == VR::VRASCII )
       {
       if( GetVR() != VR::UI )
@@ -440,9 +440,9 @@ public:
 
   void SetFromDataElement(DataElement const &de) {
     // This is kind of hackish but since I do not generate other element than the first one: 0x6000 I should be ok:
-    assert( Tag(Group,Element) == de.GetTag() || Group == 0x6000 || Group == 0x5000 );
-    assert( GetVR() != VR::INVALID );
-    assert( GetVR().Compatible( de.GetVR() ) || de.GetVR() == VR::INVALID ); // In case of VR::INVALID cannot use the & operator
+    gdcm_assert( Tag(Group,Element) == de.GetTag() || Group == 0x6000 || Group == 0x5000 );
+    gdcm_assert( GetVR() != VR::INVALID );
+    gdcm_assert( GetVR().Compatible( de.GetVR() ) || de.GetVR() == VR::INVALID ); // In case of VR::INVALID cannot use the & operator
     if( de.IsEmpty() ) return;
     const ByteValue *bv = de.GetByteValue();
 #ifdef GDCM_WORDS_BIGENDIAN
@@ -471,7 +471,7 @@ public:
 protected:
   void SetByteValueNoSwap(const ByteValue *bv) {
     if( !bv ) return; // That would be bad...
-    assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
+    gdcm_assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
     //if( VRToEncoding<TVR>::Mode == VR::VRBINARY )
     //  {
     //  // always do a copy !
@@ -488,7 +488,7 @@ protected:
   }
   void SetByteValue(const ByteValue *bv) {
     if( !bv ) return; // That would be bad...
-    assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
+    gdcm_assert( bv->GetPointer() && bv->GetLength() ); // [123]C element can be empty
     //if( VRToEncoding<TVR>::Mode == VR::VRBINARY )
     //  {
     //  // always do a copy !
@@ -509,7 +509,7 @@ protected:
     const uint16_t cref[] = { Group, Element };
     uint16_t c[2];
     _is.read((char*)&c, sizeof(c));
-    assert( c[0] == cref[0] && c[1] == cref[1] );
+    gdcm_assert( c[0] == cref[0] && c[1] == cref[1] );
     char vr[2];
     _is.read(vr, 2); // Check consistency ?
     const uint32_t lref = GetLength() * sizeof( typename VRToType<TVR>::Type );
@@ -598,7 +598,7 @@ public:
       os << "," << Internal[i];
     }
   ArrayType &GetValue(unsigned int idx = 0) {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     return Internal[idx];
   }
   ArrayType &operator[] (unsigned int idx) {
@@ -606,14 +606,14 @@ public:
   }
   // const reference
   ArrayType const &GetValue(unsigned int idx = 0) const {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     return Internal[idx];
   }
   ArrayType const & operator[] (unsigned int idx) const {
     return GetValue(idx);
   }
   void SetValue(unsigned int idx, ArrayType v) {
-    assert( idx < GetNumberOfValues() );
+    gdcm_assert( idx < GetNumberOfValues() );
     Internal[idx] = v;
   }
   void SetValue(ArrayType v) { SetValue(0, v); }
@@ -628,7 +628,7 @@ public:
       }
     Own = own;
     Length = numel;
-    assert( Internal == nullptr );
+    gdcm_assert( Internal == nullptr );
     if( own ) // make a copy:
       {
       Internal = new ArrayType[numel];
@@ -640,7 +640,7 @@ public:
       Internal = const_cast<ArrayType*>(array);
       }
     // postcondition
-    assert( numel == GetNumberOfValues() );
+    gdcm_assert( numel == GetNumberOfValues() );
     }
 
   DataElement GetAsDataElement() const {
@@ -662,17 +662,17 @@ public:
         }
       }
     ret.SetVR( GetVR() );
-    assert( ret.GetVR() != VR::SQ );
+    gdcm_assert( ret.GetVR() != VR::SQ );
     VL::Type osStrSize = (VL::Type) os.str().size();
     ret.SetByteValue( os.str().c_str(), osStrSize);
     return ret;
   }
   void SetFromDataElement(DataElement const &de) {
     // This is kind of hackish but since I do not generate other element than the first one: 0x6000 I should be ok:
-    assert( GetTag() == de.GetTag() || GetTag().GetGroup() == 0x6000
+    gdcm_assert( GetTag() == de.GetTag() || GetTag().GetGroup() == 0x6000
       || GetTag().GetGroup() == 0x5000 );
-    assert( GetVR().Compatible( de.GetVR() ) ); // In case of VR::INVALID cannot use the & operator
-    assert( !de.IsEmpty() );
+    gdcm_assert( GetVR().Compatible( de.GetVR() ) ); // In case of VR::INVALID cannot use the & operator
+    gdcm_assert( !de.IsEmpty() );
     const ByteValue *bv = de.GetByteValue();
     SetByteValue(bv);
   }
@@ -688,7 +688,7 @@ public:
   }
 protected:
   void SetByteValue(const ByteValue *bv) {
-    assert( bv ); // FIXME
+    gdcm_assert( bv ); // FIXME
     std::stringstream ss;
     std::string s = std::string( bv->GetPointer(), bv->GetLength() );
     Length = bv->GetLength(); // HACK FIXME
@@ -787,7 +787,7 @@ public:
     Internal[i] = sarray.substr(pos1, pos2-pos1);
     // Shouldn't we do the contrary, since we know how many separators
     // (and default behavior is to discard anything after the VM declared
-    assert( GetLength()-1 == i );
+    gdcm_assert( GetLength()-1 == i );
     }
 
   unsigned long GetLength() const {
@@ -840,7 +840,7 @@ public:
     if( len ) {
       if( len > Length ) {
         // perform realloc
-        assert( (len / size) * size == len );
+        gdcm_assert( (len / size) * size == len );
         ArrayType *internal = new ArrayType[len / size];
         memcpy(internal, Internal, Length * size);
         delete[] Internal;
@@ -862,13 +862,13 @@ public:
       // TODO rewrite this stupid code:
       Length = len;
       //Internal = array;
-      assert(0);
+      gdcm_assert(0);
       }
   }
   // Implementation of Print is common to all Mode (ASCII/Binary)
   void Print(std::ostream &_os) const {
-    assert( Length );
-    assert( Internal );
+    gdcm_assert( Length );
+    gdcm_assert( Internal );
     _os << Internal[0]; // VM is at least guarantee to be one
     const unsigned long length = GetLength() < 25 ? GetLength() : 25;
     for(unsigned long i=1; i<length; ++i)

--- a/Source/DataStructureAndEncodingDefinition/gdcmBasicOffsetTable.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmBasicOffsetTable.h
@@ -33,8 +33,8 @@ public:
 
 /*
   VL GetLength() const {
-    assert( !ValueLengthField.IsUndefined() );
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueLengthField.IsUndefined() );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + ValueLengthField.GetLength()
       + ValueLengthField;
   }
@@ -46,10 +46,10 @@ public:
     const Tag itemStart(0xfffe, 0xe000);
     if( !TagField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
-    //assert( TagField == itemStart );
+    //gdcm_assert( TagField == itemStart );
     if( TagField != itemStart )
       {
       // Bug_Siemens_PrivateIconNoItem.dcm
@@ -61,7 +61,7 @@ public:
       }
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     // Self
@@ -83,24 +83,24 @@ public:
     const Tag seqDelItem(0xfffe,0xe0dd);
     if( !TagField.Write<TSwap>(os) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
-    assert( TagField == itemStart );
+    gdcm_assert( TagField == itemStart );
     if( !ValueLengthField.Write<TSwap>(os) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
     if( ValueLengthField )
       {
       // Self
       const ByteValue *bv = GetByteValue();
-      assert( bv );
-      assert( bv->GetLength() == ValueLengthField );
+      gdcm_assert( bv );
+      gdcm_assert( bv->GetLength() == ValueLengthField );
       if( !bv->Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }
@@ -115,7 +115,7 @@ inline std::ostream &operator<<(std::ostream &os, const BasicOffsetTable &val)
   if( val.ValueField )
     {
     const ByteValue *bv = val.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     os << *bv;
     }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmByteBuffer.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteBuffer.h
@@ -82,7 +82,7 @@ public:
         Start = /*buffer =*/ newBuf;
         }
       }
-    assert( (int)Internal.capacity() >= len );
+    gdcm_assert( (int)Internal.capacity() >= len );
     return End;
     }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmByteSwapFilter.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteSwapFilter.cxx
@@ -36,7 +36,7 @@ bool ByteSwapFilter::ByteSwap()
     {
     const DataElement &de = *it;
     VR const & vr = de.GetVR();
-    //assert( vr & VR::VRASCII || vr & VR::VRBINARY );
+    //gdcm_assert( vr & VR::VRASCII || vr & VR::VRBINARY );
     ByteValue *bv = const_cast<ByteValue*>(de.GetByteValue());
     gdcm::SmartPointer<gdcm::SequenceOfItems> si = de.GetValueAsSQ();
     if( de.IsEmpty() )
@@ -44,15 +44,15 @@ bool ByteSwapFilter::ByteSwap()
       }
     else if( bv && !si )
       {
-      assert( !si );
+      gdcm_assert( !si );
       // ASCII do not need byte swap
       if( vr & VR::VRBINARY /*&& de.GetTag().IsPrivate()*/ )
         {
-        //assert( de.GetTag().IsPrivate() );
+        //gdcm_assert( de.GetTag().IsPrivate() );
         switch(vr)
           {
         case VR::AT:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::FL:
           // FIXME: Technically FL should not be byte-swapped...
@@ -60,22 +60,22 @@ bool ByteSwapFilter::ByteSwap()
           SwapperDoOp::SwapArray((uint32_t*)bv->GetVoidPointer(), bv->GetLength() / sizeof(uint32_t) );
           break;
         case VR::FD:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::OB:
           // I think we are fine, unless this is one of those OB_OW thingy
           break;
         case VR::OF:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::OW:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::SL:
           SwapperDoOp::SwapArray((uint32_t*)bv->GetVoidPointer(), bv->GetLength() / sizeof(uint32_t) );
           break;
         case VR::SQ:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::SS:
           SwapperDoOp::SwapArray((uint16_t*)bv->GetVoidPointer(), bv->GetLength() / sizeof(uint16_t) );
@@ -84,16 +84,16 @@ bool ByteSwapFilter::ByteSwap()
           SwapperDoOp::SwapArray((uint32_t*)bv->GetVoidPointer(), bv->GetLength() / sizeof(uint32_t) );
           break;
         case VR::UN:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         case VR::US:
           SwapperDoOp::SwapArray((uint16_t*)bv->GetVoidPointer(), bv->GetLength() / sizeof(uint16_t) );
           break;
         case VR::UT:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           break;
         default:
-          assert( 0 && "Should not happen" );
+          gdcm_assert( 0 && "Should not happen" );
           }
         }
       }
@@ -116,11 +116,11 @@ bool ByteSwapFilter::ByteSwap()
     else if( const SequenceOfFragments *sf = de.GetSequenceOfFragments() )
       {
       (void)sf;
-      assert( 0 && "Should not happen" );
+      gdcm_assert( 0 && "Should not happen" );
       }
     else
       {
-      assert( 0 && "error" );
+      gdcm_assert( 0 && "error" );
       }
 
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmByteValue.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteValue.cxx
@@ -64,7 +64,7 @@ namespace gdcm_ns
       }
     // I cannot check IsPrintable some file contains \2 or \0 in a VR::LO element
     // See: acr_image_with_non_printable_in_0051_1010.acr
-    //assert( IsPrintable(length) );
+    //gdcm_assert( IsPrintable(length) );
     std::vector<char>::const_iterator it = Internal.begin();
     for(; it != Internal.begin()+length; ++it)
       {
@@ -156,7 +156,7 @@ namespace gdcm_ns
         else
           {
           //in the rare case there are more ^ characters
-          assert("Name components exceeded");
+          gdcm_assert("Name components exceeded");
           }
         }
       else if ( c == '=' )
@@ -201,7 +201,7 @@ namespace gdcm_ns
           }
         else
           {
-          assert("Impossible - only 3 names allowed");
+          gdcm_assert("Impossible - only 3 names allowed");
           }
         count2=1;
         }
@@ -325,7 +325,7 @@ namespace gdcm_ns
     Internal.insert( Internal.end(), bv.Internal.begin(), bv.Internal.end());
     Length += bv.Length;
     // post condition
-    assert( Internal.size() % 2 == 0 && Internal.size() == Length );
+    gdcm_assert( Internal.size() % 2 == 0 && Internal.size() == Length );
     }
    
 } // end namespace gdcm_ns

--- a/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmByteValue.h
@@ -52,7 +52,7 @@ public:
   ByteValue(std::vector<char> &v):Internal(v),Length((uint32_t)v.size()) {}
   //ByteValue(std::ostringstream const &os) {
   //  (void)os;
-  //   assert(0); // TODO
+  //   gdcm_assert(0); // TODO
   //}
   ~ByteValue() override {
     Internal.clear();
@@ -66,13 +66,13 @@ public:
 
   // Either from Element Number (== 0x0000)
   void PrintGroupLength(std::ostream &os) {
-    assert( Length == 2 );
+    gdcm_assert( Length == 2 );
     (void)os;
   }
 
   bool IsEmpty() const {
 #if 0
-    if( Internal.empty() ) assert( Length == 0 );
+    if( Internal.empty() ) gdcm_assert( Length == 0 );
     return Internal.empty();
 #else
   return Length == 0;
@@ -132,8 +132,8 @@ public:
   bool GetBuffer(char *buffer, unsigned long length) const;
   bool WriteBuffer(std::ostream &os) const {
     if( Length ) {
-      //assert( Internal.size() <= Length );
-      assert( !(Internal.size() % 2) );
+      //gdcm_assert( Internal.size() <= Length );
+      gdcm_assert( !(Internal.size() % 2) );
       os.write(&Internal[0], Internal.size() );
       }
     return true;
@@ -150,7 +150,7 @@ public:
       if( readvalues )
         {
         is.read(&Internal[0], Length);
-        assert( Internal.size() == Length || Internal.size() == Length + 1 );
+        gdcm_assert( Internal.size() == Length || Internal.size() == Length + 1 );
         TSwap::SwapArray((TType*)GetVoidPointer(), Internal.size() / sizeof(TType) );
         }
       else
@@ -169,7 +169,7 @@ public:
 
   template <typename TSwap, typename TType>
   std::ostream const &Write(std::ostream &os) const {
-    assert( !(Internal.size() % 2) );
+    gdcm_assert( !(Internal.size() % 2) );
     if( !Internal.empty() ) {
       //os.write(&Internal[0], Internal.size());
       std::vector<char> copy = Internal;
@@ -191,7 +191,7 @@ public:
    *         UNICODE or character set...
    */
   bool IsPrintable(VL length) const {
-    assert( length <= Length );
+    gdcm_assert( length <= Length );
     for(unsigned int i=0; i<length; i++)
       {
       if ( i == (length-1) && Internal[i] == '\0') continue;

--- a/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL CP246ExplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -37,18 +37,18 @@ VL CP246ExplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & VR::OB_OW );
+      gdcm_assert( VRField & VR::OB_OW );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
-    assert(0);
+    gdcm_assert(0);
   return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + 2*VRField.GetLength() + ValueLengthField;
     }
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.txx
@@ -44,17 +44,17 @@ std::istream &CP246ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !is.eof() ) // FIXME This should not be needed
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       }
     return is;
     }
-  assert( TagField != Tag(0xfffe,0xe0dd) );
+  gdcm_assert( TagField != Tag(0xfffe,0xe0dd) );
   const Tag itemDelItem(0xfffe,0xe00d);
   if( TagField == itemDelItem )
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( ValueLengthField != 0 )
@@ -72,20 +72,20 @@ std::istream &CP246ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !VRField.Read(is) )
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       return is;
       }
     }
   catch( std::exception & )
     {
     // gdcm-MR-PHILIPS-16-Multi-Seq.dcm
-    // assert( TagField == Tag(0xfffe, 0xe000) );
+    // gdcm_assert( TagField == Tag(0xfffe, 0xe000) );
     // -> For some reason VR is written as {44,0} well I guess this is a VR...
     // Technically there is a second bug, dcmtk assume other things when reading this tag,
     // so I need to change this tag too, if I ever want dcmtk to read this file. oh well
     // 0019004_Baseline_IMG1.dcm
     // -> VR is garbage also...
-    // assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
+    // gdcm_assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
     gdcmWarningMacro( "Assuming 16 bits VR for Tag=" <<
       TagField << " in order to read a buggy DICOM file." );
     VRField = VR::INVALID;
@@ -95,7 +95,7 @@ std::istream &CP246ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     }
@@ -128,11 +128,11 @@ std::istream &CP246ExplicitDataElement::ReadValue(std::istream &is, bool readval
 
   //std::cerr << "exp cur tag=" << TagField << " VR=" << VRField << " VL=" << ValueLengthField << std::endl;
   // Read the Value
-  //assert( ValueField == 0 );
+  //gdcm_assert( ValueField == 0 );
   if( VRField == VR::SQ )
     {
     // Check whether or not this is an undefined length sequence
-    assert( TagField != Tag(0x7fe0,0x0010) );
+    gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new SequenceOfItems;
     }
   else if( ValueLengthField.IsUndefined() )
@@ -143,14 +143,14 @@ std::istream &CP246ExplicitDataElement::ReadValue(std::istream &is, bool readval
       // Enhanced_MR_Image_Storage_PixelSpacingNotIn_0028_0030.dcm (illegal)
       // vs
       // undefined_length_un_vr.dcm
-      assert( TagField != Tag(0x7fe0,0x0010) );
+      gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
       ValueField = new SequenceOfItems;
       ValueField->SetLength(ValueLengthField); // perform realloc
       try
         {
         if( !ValueIO<CP246ExplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) ) // non cp246
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       catch( std::exception &)
@@ -167,14 +167,14 @@ std::istream &CP246ExplicitDataElement::ReadValue(std::istream &is, bool readval
     else
       {
       // Ok this is Pixel Data fragmented...
-      assert( TagField == Tag(0x7fe0,0x0010) );
-      assert( VRField & VR::OB_OW );
+      gdcm_assert( TagField == Tag(0x7fe0,0x0010) );
+      gdcm_assert( VRField & VR::OB_OW );
       ValueField = new SequenceOfFragments;
       }
     }
   else
     {
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
     }
   // We have the length we should be able to read the value
@@ -191,12 +191,12 @@ std::istream &CP246ExplicitDataElement::ReadValue(std::istream &is, bool readval
   )
     {
     gdcmWarningMacro( "ByteSwaping Private SQ: " << TagField );
-    assert( VRField == VR::SQ );
+    gdcm_assert( VRField == VR::SQ );
     try
       {
       if( !ValueIO<CP246ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         }
       }
     catch( std::exception & )

--- a/Source/DataStructureAndEncodingDefinition/gdcmCSAElement.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmCSAElement.h
@@ -61,7 +61,7 @@ public:
   Value const &GetValue() const { return *DataField; }
   Value &GetValue() { return *DataField; }
   void SetValue(Value const & vl) {
-    //assert( DataField == 0 );
+    //gdcm_assert( DataField == 0 );
     DataField = vl;
   }
   /// Check if CSA Element is empty
@@ -131,7 +131,7 @@ inline std::ostream& operator<<(std::ostream &os, const CSAElement &val)
     {
     //val.DataField->Print( os << "'" );
     const ByteValue * bv = dynamic_cast<ByteValue*>(&*val.DataField);
-    assert( bv );
+    gdcm_assert( bv );
     const char * p = bv->GetPointer();
     std::string str(p, p + bv->GetLength() );
     if( val.ValueMultiplicityField == VM::VM1 )

--- a/Source/DataStructureAndEncodingDefinition/gdcmCSAHeader.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmCSAHeader.cxx
@@ -911,16 +911,16 @@ bool check_mapping(uint32_t syngodt, const char *vr)
   static const unsigned int max = sizeof(mapping) / sizeof(equ);
   const equ *p = mapping;
   if( syngodt > mapping[max-1].syngodt ) return false;
-  assert( syngodt <= mapping[max-1].syngodt );
+  gdcm_assert( syngodt <= mapping[max-1].syngodt );
   while(p->syngodt < syngodt )
     {
     //std::cout << "mapping:" << p->vr << std::endl;
     ++p;
     }
-  assert( p->syngodt == syngodt ); // or else need to update mapping
+  gdcm_assert( p->syngodt == syngodt ); // or else need to update mapping
   const char* lvr = p->vr;
   int check = strcmp(vr, lvr) == 0;
-  assert( check ); (void)check;
+  gdcm_assert( check ); (void)check;
   return true;
 }
 
@@ -978,9 +978,9 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
   gdcmDebugMacro( "found type" );
 
   const ByteValue *bv = de.GetByteValue();
-  assert( bv );
+  gdcm_assert( bv );
   const char *p = bv->GetPointer();
-  assert( p );
+  gdcm_assert( p );
   std::string s( bv->GetPointer(), bv->GetLength() );
   std::stringstream ss;
   ss.str( s );
@@ -1035,10 +1035,10 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
           {
           ds.InsertDataElement( xde ); // Cannot use Insert since Group = 0x0 (< 0x8)
           //VR refvr = GetVRFromDataSetFormatDict( xde.GetTag() );
-          //assert( xde.GetVR() == refvr );
+          //gdcm_assert( xde.GetVR() == refvr );
           }
         //std::cout << ds << std::endl;
-        assert( ss.eof() );
+        gdcm_assert( ss.eof() );
         }
       catch(std::exception &)
         {
@@ -1049,7 +1049,7 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
       }
     else
       {
-      //assert(0);
+      //gdcm_assert(0);
       ss.seekg( 0, std::ios::beg );
       // No magic number for this one:
       // SIEMENS_Sonata-16-MONO2-Value_Multiplicity.dcm
@@ -1060,10 +1060,10 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
     {
     // NEW FORMAT !
     ss.read(signature, 4);
-    assert( strcmp( signature, "\4\3\2\1" ) == 0 );
+    gdcm_assert( strcmp( signature, "\4\3\2\1" ) == 0 );
     InternalType = SV10;
     }
-  assert( InternalType != UNKNOWN );
+  gdcm_assert( InternalType != UNKNOWN );
   gdcmDebugMacro( "Found Type: " << (int)InternalType );
 
   uint32_t n;
@@ -1077,7 +1077,7 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
     gdcmErrorMacro( "Must be a new format. Giving up" );
     return false;
     }
-  assert( unused == 77 ); // 'M' character...
+  gdcm_assert( unused == 77 ); // 'M' character...
 
   for(uint32_t i = 0; i < n; ++i)
     {
@@ -1094,7 +1094,7 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
     ss.read((char*)&vm, sizeof(vm));
     SwapperNoOp::SwapArray(&vm,1);
     csael.SetVM( VM::GetVMTypeFromLength(vm,1) );
-    //assert( csael.GetVM() != VM::VM0 );
+    //gdcm_assert( csael.GetVM() != VM::VM0 );
     //std::cout << "VM " << vm <<  ", ";
     char vr[4];
     ss.read(vr, 4);
@@ -1104,7 +1104,7 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
       gdcmErrorMacro( "Garbage data. Stopping CSA parsing." );
       return false;
     }
-    assert( /*vr[3] == 0 &&*/ vr[2] == 0 );
+    gdcm_assert( /*vr[3] == 0 &&*/ vr[2] == 0 );
     csael.SetVR( VR::GetVRTypeFromFile(vr) );
     //std::cout << "VR " << vr << ", ";
     uint32_t syngodt;
@@ -1122,13 +1122,13 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
     ss.read((char*)&nitems, sizeof(nitems));
     SwapperNoOp::SwapArray(&nitems,1);
     csael.SetNoOfItems( nitems );
-    if( InternalType == SV10) { assert( nitems % 6 == 0 );}
+    if( InternalType == SV10) { gdcm_assert( nitems % 6 == 0 );}
     //std::cout << "NoOfItems " << nitems << ", ";
     uint32_t xx;
     ss.read((char*)&xx, sizeof(xx));
     SwapperNoOp::SwapArray(&xx,1);
     //std::cout << "xx=" << xx<< std::endl;
-    assert( xx == 77 || xx == 205 );
+    gdcm_assert( xx == 77 || xx == 205 );
 
     //std::cout << "Data ";
     std::ostringstream os;
@@ -1138,10 +1138,10 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
       ss.read((char*)&item_xx, 4*sizeof(uint32_t));
       SwapperNoOp::SwapArray(item_xx,4);
       if( item_xx[2] != 77 && item_xx[2] != 205 ) return false;
-      assert( item_xx[2] == 77 || item_xx[2] == 205 );
+      gdcm_assert( item_xx[2] == 77 || item_xx[2] == 205 );
       uint32_t len = item_xx[1]; // 2nd element
       if( item_xx[0] != item_xx[1] || item_xx[1] != item_xx[3] ) return false;
-      assert( item_xx[0] == item_xx[1] && item_xx[1] == item_xx[3] );
+      gdcm_assert( item_xx[0] == item_xx[1] && item_xx[1] == item_xx[3] );
       if( len )
         {
         char *val = new char[len+1];
@@ -1164,7 +1164,7 @@ bool CSAHeader::LoadFromDataElement(DataElement const &de)
         for(uint32_t d= 0; d < dummy_len; ++d)
           {
           // dummy[d]  is zero in the NEW format
-          //assert( dummy[d] == 0 );
+          //gdcm_assert( dummy[d] == 0 );
           //for the old format there appears to be some garbage:
           if( dummy[d] )
             {
@@ -1216,7 +1216,7 @@ const CSAElement &CSAHeader::GetCSAElementByName(const char *name)
     for(; it != InternalCSADataSet.end(); ++it)
       {
       const char *itname = it->GetName();
-      assert( itname );
+      gdcm_assert( itname );
       if( strcmp(name, itname) == 0 )
         {
         return *it;
@@ -1234,7 +1234,7 @@ bool CSAHeader::FindCSAElementByName(const char *name)
     for(; it != InternalCSADataSet.end(); ++it)
       {
       const char *itname = it->GetName();
-      assert( itname );
+      gdcm_assert( itname );
       if( strcmp(name, itname) == 0 )
         {
         return true;

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataElement.cxx
@@ -23,13 +23,13 @@
 namespace gdcm_ns
 {
   void DataElement::SetVLToUndefined() {
-    assert( VRField == VR::SQ || VRField == VR::INVALID
+    gdcm_assert( VRField == VR::SQ || VRField == VR::INVALID
       || (VRField == VR::UN /*&& IsUndefinedLength()*/ ) );
     SequenceOfItems *sqi = dynamic_cast<SequenceOfItems*>(ValueField.GetPointer());
     if( sqi )
       {
       sqi->SetLengthToUndefined();
-      assert( GetValueAsSQ()->IsUndefinedLength() );
+      gdcm_assert( GetValueAsSQ()->IsUndefinedLength() );
       }
     ValueLengthField.SetToUndefined();
   }
@@ -61,7 +61,7 @@ namespace gdcm_ns
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(ValueField.GetPointer());
     if( sq ) // all set !
       {
-      //assert( GetVR() == VR::SQ );
+      //gdcm_assert( GetVR() == VR::SQ );
       SmartPointer<SequenceOfItems> sqi = sq;
       return sqi;
       }
@@ -72,7 +72,7 @@ namespace gdcm_ns
         if( GetVR() == VR::INVALID )
           {
           const ByteValue *bv = GetByteValue();
-          assert( bv );
+          gdcm_assert( bv );
           SequenceOfItems *sqi = new SequenceOfItems;
           sqi->SetLength( bv->GetLength() );
           std::string s( bv->GetPointer(), bv->GetLength() );
@@ -111,9 +111,9 @@ namespace gdcm_ns
           }
         else if  ( GetVR() == VR::UN ) // cp 246, IVRLE SQ
           {
-          assert( GetVR() == VR::UN ); // cp 246, IVRLE SQ
+          gdcm_assert( GetVR() == VR::UN ); // cp 246, IVRLE SQ
           const ByteValue *bv = GetByteValue();
-          assert( bv );
+          gdcm_assert( bv );
           SequenceOfItems *sqi = new SequenceOfItems;
           sqi->SetLength( bv->GetLength() );
           std::string s( bv->GetPointer(), bv->GetLength() );
@@ -168,7 +168,7 @@ namespace gdcm_ns
         else if  ( GetVR() & VR::OB_OW ) // pre-dicom 1993 ?
           {
           const ByteValue *bv = GetByteValue();
-          assert( bv );
+          gdcm_assert( bv );
           SequenceOfItems *sqi = new SequenceOfItems;
           sqi->SetLength( bv->GetLength() );
           std::string s( bv->GetPointer(), bv->GetLength() );
@@ -189,8 +189,8 @@ namespace gdcm_ns
           }
         else
           {
-          assert( GetVR().IsVRFile() );
-          assert( GetByteValue() );
+          gdcm_assert( GetVR().IsVRFile() );
+          gdcm_assert( GetByteValue() );
           return nullptr;
           }
         }

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataElement.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataElement.h
@@ -98,7 +98,7 @@ public:
   }
   /// \warning you need to set the ValueLengthField explicitly
   void SetValue(Value const & vl) {
-    //assert( ValueField == 0 );
+    //gdcm_assert( ValueField == 0 );
     ValueField = vl;
     ValueLengthField = vl.GetLength();
   }

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.cxx
@@ -28,7 +28,7 @@ std::string DataSet::GetPrivateCreator(const Tag &t) const
   if( t.IsPrivate() && !t.IsGroupLength() && !t.IsPrivateCreator() && !t.IsIllegal() )
     {
     Tag pc = t.GetPrivateCreator();
-    assert( pc.GetElement() );
+    gdcm_assert( pc.GetElement() );
       {
       const DataElement r(pc);
       ConstIterator it = DES.find(r);
@@ -40,7 +40,7 @@ std::string DataSet::GetPrivateCreator(const Tag &t) const
       const DataElement &de = *it;
       if( de.IsEmpty() ) return "";
       const ByteValue *bv = de.GetByteValue();
-      assert( bv );
+      gdcm_assert( bv );
       std::string owner = std::string(bv->GetPointer(),bv->GetLength()).c_str();
       // There should not be any trailing space character...
       // TODO: tmp.erase(tmp.find_last_not_of(' ') + 1);
@@ -49,7 +49,7 @@ std::string DataSet::GetPrivateCreator(const Tag &t) const
         // osirix/AbdominalCT/36382443
         owner.erase(owner.size()-1,1);
         }
-      assert( owner.empty() || owner[owner.size()-1] != ' ' );
+      gdcm_assert( owner.empty() || owner[owner.size()-1] != ' ' );
       return owner;
       }
     }
@@ -67,17 +67,17 @@ PrivateTag DataSet::GetPrivateTag(const Tag &t) const
 Tag DataSet::ComputeDataElement(const PrivateTag & t) const
 {
   //gdcmDebugMacro( "Entering ComputeDataElement" );
-  //assert( t.IsPrivateCreator() ); // No this is wrong to do the assert: eg. (0x07a1,0x000a,"ELSCINT1")
+  //gdcm_assert( t.IsPrivateCreator() ); // No this is wrong to do the assert: eg. (0x07a1,0x000a,"ELSCINT1")
   // is valid because we have not yet done the mapping, so 0xa < 0x10 fails but might not later on
   const Tag start(t.GetGroup(), 0x0010 ); // First possible private creator (0x0 -> 0x9 are reserved...)
   const DataElement r(start);
   ConstIterator it = DES.lower_bound(r);
   const char *refowner = t.GetOwner();
-  assert( refowner );
+  gdcm_assert( refowner );
   bool found = false;
   while( it != DES.end() && it->GetTag().GetGroup() == t.GetGroup() && it->GetTag().GetElement() < 0x100 )
     {
-    //assert( it->GetTag().GetOwner() );
+    //gdcm_assert( it->GetTag().GetOwner() );
     const ByteValue * bv = it->GetByteValue();
     if( bv )
       {
@@ -85,7 +85,7 @@ Tag DataSet::ComputeDataElement(const PrivateTag & t) const
       std::string tmp(bv->GetPointer(),bv->GetLength());
       // trim trailing whitespaces:
       tmp.erase(tmp.find_last_not_of(' ') + 1);
-      assert( tmp.empty() || tmp[ tmp.size() - 1 ] != ' ' ); // FIXME
+      gdcm_assert( tmp.empty() || tmp[ tmp.size() - 1 ] != ' ' ); // FIXME
       if( System::StrCaseCmp( tmp.c_str(), refowner ) == 0 )
         {
         // found !
@@ -135,7 +135,7 @@ MediaStorage DataSet::GetMediaStorage() const
   std::string ts;
     {
     const ByteValue *bv = de.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     if( bv->GetPointer() && bv->GetLength() )
       {
       // Pad string with a \0

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
@@ -69,7 +69,7 @@ public:
   DataElementSet &GetDES() { return DES; }
   void Clear() {
     DES.clear();
-    assert( DES.empty() );
+    gdcm_assert( DES.empty() );
   }
 
   SizeType Size() const {
@@ -79,7 +79,7 @@ public:
   void Print(std::ostream &os, std::string const &indent = "") const {
     // CT_Phillips_JPEG2K_Decompr_Problem.dcm has a SQ of length == 0
     //int s = DES.size();
-    //assert( s );
+    //gdcm_assert( s );
     //std::copy(DES.begin(), DES.end(),
     //  std::ostream_iterator<DataElement>(os, "\n"));
     ConstIterator it = DES.begin();
@@ -92,15 +92,15 @@ public:
   template <typename TDE>
   unsigned int ComputeGroupLength(Tag const &tag) const
     {
-    assert( tag.GetElement() == 0x0 );
+    gdcm_assert( tag.GetElement() == 0x0 );
     const DataElement r(tag);
     ConstIterator it = DES.find(r);
     unsigned int res = 0;
     for( ++it; it != DES.end()
       && it->GetTag().GetGroup() == tag.GetGroup(); ++it)
       {
-      assert( it->GetTag().GetElement() != 0x0 );
-      assert( it->GetTag().GetGroup() == tag.GetGroup() );
+      gdcm_assert( it->GetTag().GetElement() != 0x0 );
+      gdcm_assert( it->GetTag().GetGroup() == tag.GetGroup() );
       res += it->GetLength<TDE>();
       }
     return res;
@@ -109,13 +109,13 @@ public:
   template <typename TDE>
   VL GetLength() const {
     if( DES.empty() ) return 0;
-    assert( !DES.empty() );
+    gdcm_assert( !DES.empty() );
     VL ll = 0;
-    assert( ll == 0 );
+    gdcm_assert( ll == 0 );
     ConstIterator it = DES.begin();
     for( ; it != DES.end(); ++it)
       {
-      assert( !(it->GetLength<TDE>().IsUndefined()) );
+      gdcm_assert( !(it->GetLength<TDE>().IsUndefined()) );
       if ( it->GetTag() != Tag(0xfffe,0xe00d) )
         {
         ll += it->GetLength<TDE>();
@@ -171,7 +171,7 @@ public:
   /// Completely remove a dataelement from the dataset
   SizeType Remove(const Tag& tag) {
     DataElementSet::size_type count = DES.erase(tag);
-    assert( count == 0 || count == 1 );
+    gdcm_assert( count == 0 || count == 1 );
     return count;
   }
 
@@ -283,7 +283,7 @@ protected:
 #else
     DES.insert(de);
 #endif
-    assert( de.IsEmpty() || de.GetVL() == de.GetValue().GetLength() );
+    gdcm_assert( de.IsEmpty() || de.GetVL() == de.GetValue().GetLength() );
     }
 
 protected:

--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.txx
@@ -26,7 +26,7 @@ namespace gdcm_ns
   std::istream &DataSet::ReadNested(std::istream &is) {
     DataElement de;
     const Tag itemDelItem(0xfffe,0xe00d);
-    assert( de.GetTag() != itemDelItem ); // precondition before while loop
+    gdcm_assert( de.GetTag() != itemDelItem ); // precondition before while loop
     try
       {
       while( de.Read<TDE,TSwap>(is) && de.GetTag() != itemDelItem  ) // Keep that order please !
@@ -51,7 +51,7 @@ namespace gdcm_ns
         throw pe;
         }
       }
-    assert( de.GetTag() == itemDelItem );
+    gdcm_assert( de.GetTag() == itemDelItem );
     return is;
   }
 
@@ -79,14 +79,14 @@ namespace gdcm_ns
         }
       else
         {
-        assert( is.good() );
+        gdcm_assert( is.good() );
         if( de.GetTag() != t )
           is.seekg( de.GetVL(), std::ios::cur );
         }
       // tag was found, we can exit the loop:
       if ( t <= de.GetTag() )
         {
-        assert( is.good() );
+        gdcm_assert( is.good() );
         break;
         }
       }
@@ -106,14 +106,14 @@ namespace gdcm_ns
         }
       else
         {
-        assert( is.good() );
+        gdcm_assert( is.good() );
         if( de.GetTag() != t )
           is.seekg( de.GetVL(), std::ios::cur );
         }
       // tag was found, we can exit the loop:
       if ( t <= de.GetTag() )
         {
-        assert( is.good() );
+        gdcm_assert( is.good() );
         break;
         }
       }
@@ -171,7 +171,7 @@ namespace gdcm_ns
           }
         }
       }
-    assert( inputStream.good() );
+    gdcm_assert( inputStream.good() );
     return inputStream;
     }
 
@@ -179,11 +179,11 @@ namespace gdcm_ns
   std::istream &DataSet::ReadSelectedPrivateTags(std::istream &inputStream, const std::set<PrivateTag> & selectedPTags, bool readvalues) {
     if ( ! (selectedPTags.empty() || inputStream.fail()) )
       {
-      assert( selectedPTags.size() == 1 );
+      gdcm_assert( selectedPTags.size() == 1 );
       const PrivateTag refPTag = *(selectedPTags.rbegin());
       PrivateTag nextPTag = refPTag;
       nextPTag.SetElement( (uint16_t)(nextPTag.GetElement() + 0x1) );
-      assert( nextPTag.GetElement() & 0x00ff ); // no wrap please
+      gdcm_assert( nextPTag.GetElement() & 0x00ff ); // no wrap please
       Tag maxTag;
       maxTag.SetPrivateCreator( nextPTag );
       DataElement dataElem;
@@ -299,11 +299,11 @@ namespace gdcm_ns
     (void)length;
     if ( ! (selectedPTags.empty() || inputStream.fail()) )
       {
-      assert( selectedPTags.size() == 1 );
+      gdcm_assert( selectedPTags.size() == 1 );
       const PrivateTag refPTag = *(selectedPTags.rbegin());
       PrivateTag nextPTag = refPTag;
       nextPTag.SetElement( (uint16_t)(nextPTag.GetElement() + 0x1) );
-      assert( nextPTag.GetElement() ); // no wrap please
+      gdcm_assert( nextPTag.GetElement() ); // no wrap please
       Tag maxTag;
       maxTag.SetPrivateCreator( nextPTag );
       DataElement dataElem;
@@ -367,16 +367,16 @@ namespace gdcm_ns
         {
         //std::cout << "Nested: " << de << std::endl;
 #ifndef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
-        assert( de.GetTag() != Tag(0xfffe,0xe000) ); // We should not be reading the next item...
+        gdcm_assert( de.GetTag() != Tag(0xfffe,0xe000) ); // We should not be reading the next item...
 #endif
         InsertDataElement( de );
         const VL oflen = de.GetLength<TDE>();
         l += oflen;
         const std::streampos curpos = is.tellg();
-        //assert( (curpos - startpos) == l || (curpos - startpos) + 1 == l );
+        //gdcm_assert( (curpos - startpos) == l || (curpos - startpos) + 1 == l );
 
         //std::cout << "l:" << l << std::endl;
-        //assert( !de.GetVL().IsUndefined() );
+        //gdcm_assert( !de.GetVL().IsUndefined() );
         //std::cerr << "DEBUG: " << de.GetTag() << " "<< de.GetLength() <<
         //  "," << de.GetVL() << "," << l << std::endl;
         // Bug_Philips_ItemTag_3F3F
@@ -415,7 +415,7 @@ namespace gdcm_ns
         {
         // gdcm-MR-PHILIPS-16-Multi-Seq.dcm
         // Long story short, I think Philips engineer inserted 0xfffe,0x0000 instead of an item start element
-        // assert( FindDataElement( Tag(0xfffe,0x0000) ) == false );
+        // gdcm_assert( FindDataElement( Tag(0xfffe,0x0000) ) == false );
         is.seekg(-6, std::ios::cur );
         length = locallength = l;
         }
@@ -465,15 +465,15 @@ namespace gdcm_ns
           }
         // seek back since we read the next item starter:
         int iteml = de.GetLength<TDE>();
-        //assert( de.GetTag().GetElement() );
+        //gdcm_assert( de.GetTag().GetElement() );
         if( !de.GetTag().GetElement() )
           {
-          assert( iteml == 12 ); (void)iteml;
+          gdcm_assert( iteml == 12 ); (void)iteml;
           is.seekg( -12, std::ios::cur );
           }
         else
           {
-          //assert( de.GetTag() == Tag(0xfffe,0xe000) );
+          //gdcm_assert( de.GetTag() == Tag(0xfffe,0xe000) );
           is.seekg( -4, std::ios::cur );
           }
         // let's fix the length now:
@@ -495,8 +495,8 @@ namespace gdcm_ns
 
     // technically we could only do this assert if the dataset did not contains
     // duplicate data elements so only do a <= instead:
-    //assert( l == locallength );
-    assert( l <= locallength );
+    //gdcm_assert( l == locallength );
+    gdcm_assert( l <= locallength );
     return is;
   }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmElement.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmElement.h
@@ -92,18 +92,18 @@ public:
     return Internal;
   }
   const typename VRToType<TVR>::Type &GetValue(unsigned int idx = 0) const {
-    assert( idx < VMToLength<TVM>::Length );
+    gdcm_assert( idx < VMToLength<TVM>::Length );
     return Internal[idx];
   }
   typename VRToType<TVR>::Type &GetValue(unsigned int idx = 0) {
-    assert( idx < VMToLength<TVM>::Length );
+    gdcm_assert( idx < VMToLength<TVM>::Length );
     return Internal[idx];
   }
   typename VRToType<TVR>::Type operator[] (unsigned int idx) const {
     return GetValue(idx);
   }
   void SetValue(typename VRToType<TVR>::Type v, unsigned int idx = 0) {
-    assert( idx < VMToLength<TVM>::Length );
+    gdcm_assert( idx < VMToLength<TVM>::Length );
     Internal[idx] = v;
   }
 
@@ -130,7 +130,7 @@ public:
     EncodingImplementation<VRToEncoding<TVR>::Mode>::Write(Internal,
       GetLength(),os);
     ret.SetVR( (VR::VRType)TVR );
-    assert( ret.GetVR() != VR::SQ );
+    gdcm_assert( ret.GetVR() != VR::SQ );
     if( (VR::VRType)VRToEncoding<TVR>::Mode == VR::VRASCII )
       {
       if( GetVR() != VR::UI )
@@ -172,7 +172,7 @@ public:
 protected:
   void SetNoSwap(Value const &v) {
     const ByteValue *bv = dynamic_cast<const ByteValue*>(&v);
-    assert( bv ); // That would be bad...
+    gdcm_assert( bv ); // That would be bad...
     //memcpy(Internal, bv->GetPointer(), bv->GetLength());
     std::stringstream ss;
     std::string s = std::string( bv->GetPointer(), bv->GetLength() );
@@ -203,18 +203,18 @@ public:
   template<typename T> // FIXME this should be VRToType<TVR>::Type
   static inline void ReadComputeLength(T* data, unsigned int &length,
                           std::istream &_is) {
-    assert( data );
-    //assert( length ); // != 0
+    gdcm_assert( data );
+    //gdcm_assert( length ); // != 0
     length = 0;
-    assert( _is );
+    gdcm_assert( _is );
 #if 0
     char sep;
     while( _is >> data[length++] )
       {
       // Get the separator in between the values
-      assert( _is );
+      gdcm_assert( _is );
       _is.get(sep);
-      assert( sep == '\\' || sep == ' ' ); // FIXME: Bad use of assert
+      gdcm_assert( sep == '\\' || sep == ' ' ); // FIXME: Bad use of assert
       if( sep == ' ' ) length--; // FIXME
       }
 #else
@@ -227,19 +227,19 @@ public:
   template<typename T> // FIXME this should be VRToType<TVR>::Type
   static inline void Read(T* data, unsigned long length,
                           std::istream &_is) {
-    assert( data );
-    assert( length ); // != 0
-    assert( _is );
+    gdcm_assert( data );
+    gdcm_assert( length ); // != 0
+    gdcm_assert( _is );
     // FIXME BUG: what if >> operation fails ?
     // gdcmData/MR00010001.dcm / SpacingBetweenSlices
     _is >> std::ws >> data[0];
     char sep;
     //std::cout << "GetLength: " << af->GetLength() << std::endl;
     for(unsigned long i=1; i<length;++i) {
-      //assert( _is );
+      //gdcm_assert( _is );
       // Get the separator in between the values
       _is >> std::ws >> sep; //_is.get(sep);
-      //assert( sep == '\\' ); // FIXME: Bad use of assert
+      //gdcm_assert( sep == '\\' ); // FIXME: Bad use of assert
       _is >> std::ws >> data[i];
       }
     }
@@ -252,12 +252,12 @@ public:
   template<typename T>
   static inline void Write(const T* data, unsigned long length,
                            std::ostream &_os)  {
-    assert( data );
-    assert( length );
-    assert( _os );
+    gdcm_assert( data );
+    gdcm_assert( length );
+    gdcm_assert( _os );
     _os << data[0];
     for(unsigned long i=1; i<length; ++i) {
-      assert( _os );
+      gdcm_assert( _os );
       _os << "\\" << data[i];
       }
     }
@@ -421,9 +421,9 @@ static void x16printf(char *buf, int size, Float f) {
 #endif
 
 template<> inline void EncodingImplementation<VR::VRASCII>::Write(const double* data, unsigned long length, std::ostream &_os)  {
-    assert( data );
-    assert( length );
-    assert( _os );
+    gdcm_assert( data );
+    gdcm_assert( length );
+    gdcm_assert( _os );
 #ifdef VRDS16ILLEGAL
     _os << to_string(data[0]);
 #else
@@ -432,7 +432,7 @@ template<> inline void EncodingImplementation<VR::VRASCII>::Write(const double* 
     _os << buf;
 #endif
     for(unsigned long i=1; i<length; ++i) {
-      assert( _os );
+      gdcm_assert( _os );
 #ifdef VRDS16ILLEGAL
       _os << "\\" << to_string(data[i]);
 #else
@@ -454,13 +454,13 @@ public:
     static inline void ReadComputeLength(T* data, unsigned int &length,
       std::istream &_is) {
     const unsigned int type_size = sizeof(T);
-    assert( data ); // Can we read from pointer ?
-    //assert( length );
+    gdcm_assert( data ); // Can we read from pointer ?
+    //gdcm_assert( length );
     length /= type_size;
-    assert( _is ); // Is stream valid ?
+    gdcm_assert( _is ); // Is stream valid ?
     _is.read( reinterpret_cast<char*>(data+0), type_size);
     for(unsigned long i=1; i<length; ++i) {
-      assert( _is );
+      gdcm_assert( _is );
       _is.read( reinterpret_cast<char*>(data+i), type_size );
     }
     }
@@ -468,9 +468,9 @@ public:
   static inline void ReadNoSwap(T* data, unsigned long length,
     std::istream &_is) {
     const unsigned int type_size = sizeof(T);
-    assert( data ); // Can we read from pointer ?
-    assert( length );
-    assert( _is ); // Is stream valid ?
+    gdcm_assert( data ); // Can we read from pointer ?
+    gdcm_assert( length );
+    gdcm_assert( _is ); // Is stream valid ?
     _is.read( reinterpret_cast<char*>(data+0), type_size);
     for(unsigned long i=1; i<length; ++i) {
       if( _is )
@@ -484,9 +484,9 @@ public:
   static inline void Read(T* data, unsigned long length,
     std::istream &_is) {
     const unsigned int type_size = sizeof(T);
-    assert( data ); // Can we read from pointer ?
-    assert( length );
-    assert( _is ); // Is stream valid ?
+    gdcm_assert( data ); // Can we read from pointer ?
+    gdcm_assert( length );
+    gdcm_assert( _is ); // Is stream valid ?
     _is.read( reinterpret_cast<char*>(data+0), type_size);
     for(unsigned long i=1; i<length; ++i) {
       if( _is )
@@ -500,15 +500,15 @@ public:
   static inline void Write(const T* data, unsigned long length,
     std::ostream &_os) {
     const unsigned int type_size = sizeof(T);
-    assert( data ); // Can we write into pointer ?
-    assert( length );
-    assert( _os ); // Is stream valid ?
+    gdcm_assert( data ); // Can we write into pointer ?
+    gdcm_assert( length );
+    gdcm_assert( _os ); // Is stream valid ?
     //ByteSwap<T>::SwapRangeFromSwapCodeIntoSystem((T*)data,
     //  _os.GetSwapCode(), length);
     T swappedData = SwapperNoOp::Swap(data[0]);
     _os.write( reinterpret_cast<const char*>(&swappedData), type_size);
     for(unsigned long i=1; i<length;++i) {
-      assert( _os );
+      gdcm_assert( _os );
       swappedData = SwapperNoOp::Swap(data[i]);
       _os.write( reinterpret_cast<const char*>(&swappedData), type_size );
     }
@@ -542,7 +542,7 @@ public:
     Internal[i] = sarray.substr(pos1, pos2-pos1);
     // Shouldn't we do the contrary, since we know how many separators
     // (and default behavior is to discard anything after the VM declared
-    assert( GetLength()-1 == i );
+    gdcm_assert( GetLength()-1 == i );
     }
 
   unsigned long GetLength() const {
@@ -601,9 +601,9 @@ public:
     if( len ) {
       if( len > Length ) {
         // perform realloc
-        assert( (len / size) * size == len );
+        gdcm_assert( (len / size) * size == len );
         Type *internal = new Type[len / size];
-        assert( Save == false );
+        gdcm_assert( Save == false );
         Save = true; // ????
         if( Internal )
           {
@@ -623,15 +623,15 @@ public:
     if( save ) {
       SetLength(len); // realloc
       memcpy(Internal, array, len/*/sizeof(Type)*/);
-      assert( Save == false );
+      gdcm_assert( Save == false );
       }
     else {
       // TODO rewrite this stupid code:
-      assert( Length == 0 );
-      assert( Internal == nullptr );
-      assert( Save == false );
+      gdcm_assert( Length == 0 );
+      gdcm_assert( Internal == nullptr );
+      gdcm_assert( Save == false );
       Length = len / sizeof(Type);
-      //assert( (len / sizeof(Type)) * sizeof(Type) == len );
+      //gdcm_assert( (len / sizeof(Type)) * sizeof(Type) == len );
       // MR00010001.dcm is a tough kid: 0019,105a is supposed to be VR::FL, VM::VM3 but
       // length is 14 bytes instead of 12 bytes. Simply consider value is total garbage.
       if( (len / sizeof(Type)) * sizeof(Type) != len ) { Internal = nullptr; Length = 0; }
@@ -640,15 +640,15 @@ public:
       Save = save;
   }
   void SetValue(typename VRToType<TVR>::Type v, unsigned int idx = 0) {
-    assert( idx < Length );
+    gdcm_assert( idx < Length );
     Internal[idx] = v;
   }
   const typename VRToType<TVR>::Type &GetValue(unsigned int idx = 0) const {
-    assert( idx < Length );
+    gdcm_assert( idx < Length );
     return Internal[idx];
   }
   typename VRToType<TVR>::Type &GetValue(unsigned int idx = 0) {
-    //assert( idx < Length );
+    //gdcm_assert( idx < Length );
     return Internal[idx];
   }
   typename VRToType<TVR>::Type operator[] (unsigned int idx) const {
@@ -656,13 +656,13 @@ public:
   }
   void Set(Value const &v) {
     const ByteValue *bv = dynamic_cast<const ByteValue*>(&v);
-    assert( bv ); // That would be bad...
+    gdcm_assert( bv ); // That would be bad...
     if( (VR::VRType)(VRToEncoding<TVR>::Mode) == VR::VRBINARY )
       {
       const Type* array = (const Type*)bv->GetVoidPointer();
       if( array ) {
-        assert( array ); // That would be bad...
-        assert( Internal == nullptr );
+        gdcm_assert( array ); // That would be bad...
+        gdcm_assert( Internal == nullptr );
         SetArray(array, bv->GetLength() ); }
       }
     else
@@ -699,8 +699,8 @@ public:
 
   // Implementation of Print is common to all Mode (ASCII/Binary)
   void Print(std::ostream &_os) const {
-    assert( Length );
-    assert( Internal );
+    gdcm_assert( Length );
+    gdcm_assert( Internal );
     _os << Internal[0]; // VM is at least guarantee to be one
     const unsigned long length = GetLength() < 25 ? GetLength() : 25;
     for(unsigned long i=1; i<length; ++i)
@@ -724,7 +724,7 @@ public:
   DataElement GetAsDataElement() const {
     DataElement ret;
     ret.SetVR( (VR::VRType)TVR );
-    assert( ret.GetVR() != VR::SQ );
+    gdcm_assert( ret.GetVR() != VR::SQ );
     if( Internal )
       {
       std::ostringstream os;
@@ -761,13 +761,13 @@ public:
 protected:
   void SetNoSwap(Value const &v) {
     const ByteValue *bv = dynamic_cast<const ByteValue*>(&v);
-    assert( bv ); // That would be bad...
+    gdcm_assert( bv ); // That would be bad...
     if( (VR::VRType)(VRToEncoding<TVR>::Mode) == VR::VRBINARY )
       {
       const Type* array = (const Type*)bv->GetPointer();
       if( array ) {
-        assert( array ); // That would be bad...
-        assert( Internal == nullptr );
+        gdcm_assert( array ); // That would be bad...
+        gdcm_assert( Internal == nullptr );
         SetArray(array, bv->GetLength() ); }
       }
     else

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL ExplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -32,27 +32,27 @@ VL ExplicitDataElement::GetLength() const
     if( sq )
       {
       const VL sqlen = sq->ComputeLength<ExplicitDataElement>();
-      assert( sqlen % 2 == 0 );
+      gdcm_assert( sqlen % 2 == 0 );
       return TagField.GetLength() + VRField.GetLength() +
         ValueLengthField.GetLength() + sqlen;
       }
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & VR::OB_OW ); // VR::INVALID is not possible AFAIK...
+      gdcm_assert( VRField & VR::OB_OW ); // VR::INVALID is not possible AFAIK...
       const VL sflen = sf->ComputeLength();
-      assert( sflen % 2 == 0 );
+      gdcm_assert( sflen % 2 == 0 );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sflen;
       }
-    assert(0);
+    gdcm_assert(0);
     return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     const bool vr16bitsimpossible = (VRField & VR::VL16) && (ValueLengthField > (uint32_t)VL::GetVL16Max());
 
     if( vr16bitsimpossible || VRField == VR::INVALID )

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
@@ -43,7 +43,7 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !is.eof() ) // FIXME This should not be needed
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       }
     return is;
     }
@@ -53,13 +53,13 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     pe.SetLastElement( *this );
     throw pe;
     }
-  //assert( TagField != Tag(0xfeff,0xdde0) );
+  //gdcm_assert( TagField != Tag(0xfeff,0xdde0) );
   const Tag itemDelItem(0xfffe,0xe00d);
   if( TagField == itemDelItem )
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( ValueLengthField )
@@ -78,7 +78,7 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
   if( TagField == Tag(0x00ff, 0x4aa5) )
     {
-    //assert(0 && "Should not happen" );
+    //gdcm_assert(0 && "Should not happen" );
     // gdcmDataExtra/gdcmBreakers/DigitexAlpha_no_7FE0.dcm
     is.seekg( -4, std::ios::cur );
     TagField = Tag(0x7fe0,0x0010);
@@ -101,7 +101,7 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !VRField.Read(is) )
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       return is;
       }
     }
@@ -109,13 +109,13 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     {
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
     // gdcm-MR-PHILIPS-16-Multi-Seq.dcm
-    // assert( TagField == Tag(0xfffe, 0xe000) );
+    // gdcm_assert( TagField == Tag(0xfffe, 0xe000) );
     // -> For some reason VR is written as {44,0} well I guess this is a VR...
     // Technically there is a second bug, dcmtk assume other things when reading this tag,
     // so I need to change this tag too, if I ever want dcmtk to read this file. oh well
     // 0019004_Baseline_IMG1.dcm
     // -> VR is garbage also...
-    // assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
+    // gdcm_assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
     //gdcmWarningMacro( "Assuming 16 bits VR for Tag=" <<
     //  TagField << " in order to read a buggy DICOM file." );
     //VRField = VR::INVALID;
@@ -132,7 +132,7 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     }
@@ -141,7 +141,7 @@ std::istream &ExplicitDataElement::ReadPreValue(std::istream &is)
     // 16bits only
     if( !ValueLengthField.template Read16<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -188,11 +188,11 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     }
 
   // Read the Value
-  //assert( ValueField == 0 );
+  //gdcm_assert( ValueField == 0 );
   if( VRField == VR::SQ )
     {
     // Check whether or not this is an undefined length sequence
-    assert( TagField != Tag(0x7fe0,0x0010) );
+    gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new SequenceOfItems;
     }
   else if( ValueLengthField.IsUndefined() )
@@ -200,7 +200,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     if( TagField == Tag(0x7fe0,0x0010) )
       {
       // Ok this is Pixel Data fragmented...
-      assert( VRField & VR::OB_OW || VRField == VR::UN );
+      gdcm_assert( VRField & VR::OB_OW || VRField == VR::UN );
       ValueField = new SequenceOfFragments;
       }
     else
@@ -209,8 +209,8 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
       // Enhanced_MR_Image_Storage_PixelSpacingNotIn_0028_0030.dcm (illegal)
       // vs
       // undefined_length_un_vr.dcm
-      assert( TagField != Tag(0x7fe0,0x0010) );
-      assert( VRField == VR::UN );
+      gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
+      gdcm_assert( VRField == VR::UN );
       ValueField = new SequenceOfItems;
       ValueField->SetLength(ValueLengthField); // perform realloc
       try
@@ -218,7 +218,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
         //if( !ValueIO<ExplicitDataElement,TSwap>::Read(is,*ValueField) ) // non cp246
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) ) // cp246 compliant
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       catch( std::exception &)
@@ -235,7 +235,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     }
   else
     {
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
     }
   // We have the length we should be able to read the value
@@ -254,17 +254,17 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
   )
     {
     gdcmWarningMacro( "ByteSwaping Private SQ: " << TagField );
-    assert( VRField == VR::SQ );
-    assert( TagField.IsPrivate() );
+    gdcm_assert( VRField == VR::SQ );
+    gdcm_assert( TagField.IsPrivate() );
     try
       {
       if( !ValueIO<ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         }
       Value* v = &*ValueField;
       SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(v);
-      assert( sq );
+      gdcm_assert( sq );
       SequenceOfItems::Iterator it = sq->Begin();
       for( ; it != sq->End(); ++it)
         {
@@ -283,17 +283,17 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
 #endif
 
   bool failed;
-  //assert( VRField != VR::UN );
+  //gdcm_assert( VRField != VR::UN );
   if( VRField & VR::VRASCII )
     {
-    //assert( VRField.GetSize() == 1 );
+    //gdcm_assert( VRField.GetSize() == 1 );
     failed = !ValueIO<ExplicitDataElement,TSwap>::Read(is,*ValueField,readvalues);
     }
   else
     {
-    assert( VRField & VR::VRBINARY );
+    gdcm_assert( VRField & VR::VRBINARY );
     unsigned int vrsize = VRField.GetSize();
-    assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
+    gdcm_assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
     if(VRField==VR::AT) vrsize = 2;
     switch(vrsize)
       {
@@ -311,7 +311,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
       break;
     default:
       failed = true;
-      assert(0);
+      gdcm_assert(0);
       }
     }
   if( failed )
@@ -339,7 +339,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
   if( SequenceOfItems *sqi = dynamic_cast<SequenceOfItems*>(&GetValue()) )
     {
-    assert( ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( ValueField->GetLength() == ValueLengthField );
     // Recompute the total length:
     if( !ValueLengthField.IsUndefined() )
       {
@@ -354,9 +354,9 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     }
   else if( SequenceOfFragments *sqf = dynamic_cast<SequenceOfFragments*>(&GetValue()) )
     {
-    assert( ValueField->GetLength() == ValueLengthField );
-    assert( sqf->GetLength() == ValueLengthField ); (void)sqf;
-    assert( ValueLengthField.IsUndefined() );
+    gdcm_assert( ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( sqf->GetLength() == ValueLengthField ); (void)sqf;
+    gdcm_assert( ValueLengthField.IsUndefined() );
     }
 #endif
 
@@ -378,14 +378,14 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
   //if( TagField == Tag(0xfffe,0xe0dd) ) return os;
   if( !TagField.Write<TSwap>(os) )
     {
-    assert( 0 && "Should not happen" );
+    gdcm_assert( 0 && "Should not happen" );
     return os;
     }
   const Tag itemDelItem(0xfffe,0xe00d);
   if( TagField == itemDelItem )
     {
-    assert(0);
-    assert( ValueField == nullptr );
+    gdcm_assert(0);
+    gdcm_assert( ValueField == nullptr );
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
     if( ValueLengthField != 0 )
       {
@@ -397,10 +397,10 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
       }
 #endif
     // else
-    assert( ValueLengthField == 0 );
+    gdcm_assert( ValueLengthField == 0 );
     if( !ValueLengthField.Write<TSwap>(os) )
       {
-      assert( 0 && "Should not happen" );
+      gdcm_assert( 0 && "Should not happen" );
       return os;
       }
     return os;
@@ -437,7 +437,7 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
       if( ValueField && dynamic_cast<const SequenceOfItems*>(&*ValueField) )
         {
         VL vl = 0xFFFFFFFF;
-        assert( vl.IsUndefined() );
+        gdcm_assert( vl.IsUndefined() );
         vl.Write<TSwap>(os);
         }
       else
@@ -446,17 +446,17 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
     }
   else
     {
-    assert( VRField.IsVRFile() && VRField != VR::INVALID );
+    gdcm_assert( VRField.IsVRFile() && VRField != VR::INVALID );
     if( !VRField.Write(os) )
       {
-      assert( 0 && "Should not happen" );
+      gdcm_assert( 0 && "Should not happen" );
       return os;
       }
     if( VRField & VR::VL32 )
       {
       if( !ValueLengthField.Write<TSwap>(os) )
         {
-        assert( 0 && "Should not happen" );
+        gdcm_assert( 0 && "Should not happen" );
         return os;
         }
       }
@@ -465,7 +465,7 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
       // 16bits only
       if( !ValueLengthField.template Write16<TSwap>(os) )
         {
-        assert( 0 && "Should not happen" );
+        gdcm_assert( 0 && "Should not happen" );
         return os;
         }
       }
@@ -481,12 +481,12 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
     // check consistency in Length:
     if( GetByteValue() )
       {
-      assert( ValueField->GetLength() == ValueLengthField );
+      gdcm_assert( ValueField->GetLength() == ValueLengthField );
       }
     //else if( GetSequenceOfItems() )
     else if( const SequenceOfItems *sqi = dynamic_cast<const SequenceOfItems*>(&GetValue()) )
       {
-      assert( ValueField->GetLength() == ValueLengthField );
+      gdcm_assert( ValueField->GetLength() == ValueLengthField );
       // Recompute the total length:
       if( !ValueLengthField.IsUndefined() )
         {
@@ -496,13 +496,13 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
       }
     else if( GetSequenceOfFragments() )
       {
-      assert( ValueField->GetLength() == ValueLengthField );
+      gdcm_assert( ValueField->GetLength() == ValueLengthField );
       }
 //#endif
     // We have the length we should be able to write the value
     if( VRField == VR::UN && ValueLengthField.IsUndefined() )
       {
-      assert( TagField == Tag(0x7fe0,0x0010) || GetValueAsSQ() );
+      gdcm_assert( TagField == Tag(0x7fe0,0x0010) || GetValueAsSQ() );
       ValueIO<ImplicitDataElement,TSwap>::Write(os,*ValueField);
       }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -533,9 +533,9 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
         }
       else
         {
-        assert( VRField & VR::VRBINARY );
+        gdcm_assert( VRField & VR::VRBINARY );
         unsigned int vrsize = VRField.GetSize();
-        assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
+        gdcm_assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
         if(VRField == VR::AT) vrsize = 2;
         switch(vrsize)
           {
@@ -553,12 +553,12 @@ const std::ostream &ExplicitDataElement::Write(std::ostream &os) const
           break;
         default:
           failed = true;
-          assert(0);
+          gdcm_assert(0);
           }
         }
       if( failed )
         {
-        assert( 0 && "Should not happen" );
+        gdcm_assert( 0 && "Should not happen" );
         }
       }
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL ExplicitImplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -37,18 +37,18 @@ VL ExplicitImplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & (VR::OB | VR::OW) );
+      gdcm_assert( VRField & (VR::OB | VR::OW) );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
-    assert(0);
+    gdcm_assert(0);
   return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + 2*VRField.GetLength() + ValueLengthField;
     }
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.txx
@@ -44,7 +44,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !is.eof() ) // FIXME This should not be needed
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       }
     return is;
     }
@@ -54,7 +54,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     pe.SetLastElement( *this );
     throw pe;
     }
-  //assert( TagField != Tag(0xfeff,0xdde0) );
+  //gdcm_assert( TagField != Tag(0xfeff,0xdde0) );
   const Tag itemDelItem(0xfffe,0xe00d);
   if( TagField == itemDelItem )
     {
@@ -63,7 +63,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     //throw pe;
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( ValueLengthField )
@@ -80,7 +80,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
   if( TagField == Tag(0x00ff, 0x4aa5) )
     {
-    //assert(0 && "Should not happen" );
+    //gdcm_assert(0 && "Should not happen" );
     // gdcmDataExtra/gdcmBreakers/DigitexAlpha_no_7FE0.dcm
     is.seekg( -4, std::ios::cur );
     TagField = Tag(0x7fe0,0x0010);
@@ -103,7 +103,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !VRField.Read(is) )
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       return is;
       }
   // Read Value Length
@@ -111,7 +111,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     }
@@ -120,7 +120,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     // 16bits only
     if( !ValueLengthField.template Read16<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -145,11 +145,11 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
   const Tag itemStartItem(0xfffe,0xe000);
   if( TagField == itemStartItem ) return is;
 
-  //assert( TagField != Tag(0xfffe,0xe0dd) );
+  //gdcm_assert( TagField != Tag(0xfffe,0xe0dd) );
   // Read Value Length
   if( !ValueLengthField.Read<TSwap>(is) )
     {
-    //assert(0 && "Should not happen");
+    //gdcm_assert(0 && "Should not happen");
     throw Exception("Impossible");
     return is;
     }
@@ -162,9 +162,9 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     }
   else if( ValueLengthField.IsUndefined() )
     {
-    //assert( de.GetVR() == VR::SQ );
+    //gdcm_assert( de.GetVR() == VR::SQ );
     // FIXME what if I am reading the pixel data...
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     if( TagField != Tag(0x7fe0,0x0010) )
       {
       ValueField = new SequenceOfItems;
@@ -202,7 +202,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
       is.seekg(-4, std::ios::cur );
       if( item == itemStart )
         {
-        assert( TagField != Tag(0x7fe0,0x0010) );
+        gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
         ValueField = new SequenceOfItems;
         }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -219,7 +219,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
           {
           if( !ValueIO<ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,true) )
             {
-            assert(0 && "Should not happen");
+            gdcm_assert(0 && "Should not happen");
             }
           }
         catch( std::exception &ex2 )
@@ -237,7 +237,7 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
         ValueField->SetLength(ValueLengthField); // perform realloc
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,true) )
           {
-          assert(0 && "Should not happen");
+          gdcm_assert(0 && "Should not happen");
           }
         return is;
         }
@@ -299,12 +299,12 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
   VL dummy = ValueField->GetLength();
   if( ValueLengthField != dummy )
     {
-    gdcmWarningMacro( "ValueLengthField was bogus" ); assert(0);
+    gdcmWarningMacro( "ValueLengthField was bogus" ); gdcm_assert(0);
     ValueLengthField = dummy;
     }
 #else
-  assert( ValueLengthField == ValueField->GetLength() );
-  assert( VRField == VR::INVALID );
+  gdcm_assert( ValueLengthField == ValueField->GetLength() );
+  gdcm_assert( VRField == VR::INVALID );
 #endif
 
   return is;
@@ -349,11 +349,11 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
     }
 
   // Read the Value
-  //assert( ValueField == 0 );
+  //gdcm_assert( ValueField == 0 );
   if( VRField == VR::SQ )
     {
     // Check whether or not this is an undefined length sequence
-    assert( TagField != Tag(0x7fe0,0x0010) );
+    gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new SequenceOfItems;
     }
   else if( ValueLengthField.IsUndefined() )
@@ -364,7 +364,7 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
       // Enhanced_MR_Image_Storage_PixelSpacingNotIn_0028_0030.dcm (illegal)
       // vs
       // undefined_length_un_vr.dcm
-      assert( TagField != Tag(0x7fe0,0x0010) );
+      gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
       ValueField = new SequenceOfItems;
       ValueField->SetLength(ValueLengthField); // perform realloc
       try
@@ -372,7 +372,7 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
         //if( !ValueIO<ExplicitDataElement,TSwap>::Read(is,*ValueField) ) // non cp246
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) ) // cp246 compliant
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       catch( std::exception &)
@@ -389,14 +389,14 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
     else
       {
       // Ok this is Pixel Data fragmented...
-      assert( TagField == Tag(0x7fe0,0x0010) );
-      assert( VRField & VR::OB_OW );
+      gdcm_assert( TagField == Tag(0x7fe0,0x0010) );
+      gdcm_assert( VRField & VR::OB_OW );
       ValueField = new SequenceOfFragments;
       }
     }
   else
     {
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
     }
   // We have the length we should be able to read the value
@@ -415,17 +415,17 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
   )
     {
     gdcmWarningMacro( "ByteSwaping Private SQ: " << TagField );
-    assert( VRField == VR::SQ );
-    assert( TagField.IsPrivate() );
+    gdcm_assert( VRField == VR::SQ );
+    gdcm_assert( TagField.IsPrivate() );
     try
       {
       if( !ValueIO<ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         }
       Value* v = &*ValueField;
       SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(v);
-      assert( sq );
+      gdcm_assert( sq );
       SequenceOfItems::Iterator it = sq->Begin();
       for( ; it != sq->End(); ++it)
         {
@@ -444,17 +444,17 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
 #endif
 
   bool failed;
-  //assert( VRField != VR::UN );
+  //gdcm_assert( VRField != VR::UN );
   if( VRField & VR::VRASCII )
     {
-    //assert( VRField.GetSize() == 1 );
+    //gdcm_assert( VRField.GetSize() == 1 );
     failed = !ValueIO<ExplicitDataElement,TSwap>::Read(is,*ValueField,readvalues);
     }
   else
     {
-    assert( VRField & VR::VRBINARY );
+    gdcm_assert( VRField & VR::VRBINARY );
     unsigned int vrsize = VRField.GetSize();
-    assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
+    gdcm_assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
     if(VRField==VR::AT) vrsize = 2;
     switch(vrsize)
       {
@@ -472,7 +472,7 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
       break;
     default:
     failed = true;
-      assert(0);
+      gdcm_assert(0);
       }
     }
   if( failed )

--- a/Source/DataStructureAndEncodingDefinition/gdcmFile.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFile.cxx
@@ -22,13 +22,13 @@ File::~File() = default;
 
 std::istream &File::Read(std::istream &is)
 {
-  assert(0);
+  gdcm_assert(0);
   return is;
 }
 
 std::ostream const &File::Write(std::ostream &os) const
 {
-  assert(0);
+  gdcm_assert(0);
   return os;
 }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmFile.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFile.h
@@ -71,7 +71,7 @@ inline std::ostream& operator<<(std::ostream &os, const File &val)
 {
   os << val.GetHeader() << std::endl;
   //os << val.GetDataSet() << std::endl; // FIXME
-  assert(0);
+  gdcm_assert(0);
   return os;
 }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmFileMetaInformation.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFileMetaInformation.cxx
@@ -190,7 +190,7 @@ void FileMetaInformation::FillFromDataSet(DataSet const &ds)
         {
         const DataElement& sopclass = ds.GetDataElement( Tag(0x0008, 0x0016) );
         DataElement mssopclass = GetDataElement( Tag(0x0002, 0x0002) );
-        assert( !mssopclass.IsEmpty() );
+        gdcm_assert( !mssopclass.IsEmpty() );
         const ByteValue *bv = sopclass.GetByteValue();
         if( bv )
           {
@@ -233,7 +233,7 @@ void FileMetaInformation::FillFromDataSet(DataSet const &ds)
       }
     else
       {
-      //assert(0);
+      //gdcm_assert(0);
       throw gdcm::Exception( "No 2,3 and 8,18 element sorry" );
       }
     }
@@ -248,26 +248,26 @@ void FileMetaInformation::FillFromDataSet(DataSet const &ds)
       if( !ds.FindDataElement( Tag(0x0008, 0x0018) ) || ds.GetDataElement( Tag(0x0008, 0x0018) ).IsEmpty() )
         {
         throw gdcm::Exception( "No 8,18 element sorry" );
-        //assert(0);
+        //gdcm_assert(0);
         }
       const DataElement& sopinst = ds.GetDataElement( Tag(0x0008, 0x0018) );
       //const DataElement & foo = GetDataElement( Tag(0x0002, 0x0003) );
-      assert( !GetDataElement( Tag(0x0002, 0x0003) ).IsEmpty() );
+      gdcm_assert( !GetDataElement( Tag(0x0002, 0x0003) ).IsEmpty() );
       DataElement mssopinst = GetDataElement( Tag(0x0002, 0x0003) );
       const ByteValue *bv = sopinst.GetByteValue();
-      assert( bv );
+      gdcm_assert( bv );
       mssopinst.SetByteValue( bv->GetPointer(), bv->GetLength() );
       Replace( mssopinst );
       }
     }
-  //assert( !GetDataElement( Tag(0x0002,0x0003) ).IsEmpty() );
+  //gdcm_assert( !GetDataElement( Tag(0x0002,0x0003) ).IsEmpty() );
   // Transfer Syntax UID (0002,0010) -> ??? (computed at write time at most)
   if( FindDataElement( Tag(0x0002, 0x0010) ) && !GetDataElement( Tag(0x0002,0x0010) ).IsEmpty() )
     {
     DataElement tsuid = GetDataElement( Tag(0x0002, 0x0010) );
     const char * datasetts = DataSetTS.GetString();
     const ByteValue * bv = tsuid.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     std::string currentts( bv->GetPointer(), bv->GetPointer() + bv->GetLength() );
     if( strlen(currentts.c_str()) != strlen(datasetts)
       || strcmp( currentts.c_str(), datasetts ) != 0 )
@@ -316,7 +316,7 @@ void FileMetaInformation::FillFromDataSet(DataSet const &ds)
     // TODO: Need to check Implementation UID is actually a valid UID...
     //const DataElement& impuid = GetDataElement( Tag(0x0002, 0x0012) );
     //const ByteValue *bv = impuid.GetByteValue();
-    //assert( bv );
+    //gdcm_assert( bv );
     //std::string copy( bv->GetPointer(), bv->GetLength() );
     //if( !UIDGenerator::IsValid( copy.c_str() ) )
     //  {
@@ -351,11 +351,11 @@ void FileMetaInformation::FillFromDataSet(DataSet const &ds)
   Attribute<0x0002, 0x0000> filemetagrouplength;
   Remove( filemetagrouplength.GetTag() );
   unsigned int glen = GetLength<ExplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   filemetagrouplength.SetValue( glen );
   Insert( filemetagrouplength.GetAsDataElement() );
 
-  assert( !IsEmpty() );
+  gdcm_assert( !IsEmpty() );
 }
 
 // FIXME
@@ -372,7 +372,7 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
   Tag t;
   if( !t.template Read<TSwap>(is) )
     {
-    assert(0 && "Should not happen" );
+    gdcm_assert(0 && "Should not happen" );
     return false;
     }
   //std::cout << "Tag: " << t << std::endl;
@@ -384,8 +384,8 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
     // which seems to be quite different than fseeking in reverse from
     // the current position... ???
     //is.seekg( start, std::ios::beg );
-    assert( (start - currentpos) <= 0);
-    assert( (int)(start - currentpos) == -4 );
+    gdcm_assert( (start - currentpos) <= 0);
+    gdcm_assert( (int)(start - currentpos) == -4 );
     is.seekg( (start - currentpos), std::ios::cur );
     return false;
     }
@@ -403,7 +403,7 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
     {
     if( !vl.template Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return false;
       }
     }
@@ -417,12 +417,12 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
   ByteValue *bv = nullptr;
   if( vr == VR::SQ )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   else if( vl.IsUndefined() )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   else
@@ -433,13 +433,13 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
   bv->SetLength(vl); // perform realloc
   if( !bv->template Read<TSwap>(is) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   //std::cout << "Value : ";
   //bv->Print( std::cout );
   //std::cout << std::endl;
-  assert( bv->GetLength() == vl );
+  gdcm_assert( bv->GetLength() == vl );
 
   de.SetTag(t);
   de.SetVR(vr);
@@ -449,7 +449,7 @@ bool ReadExplicitDataElement(std::istream &is, ExplicitDataElement &de)
 
 //  if( vl == 0 )
 //    {
-//    assert( de.IsEmpty() );
+//    gdcm_assert( de.IsEmpty() );
 //    }
 
   return true;
@@ -464,7 +464,7 @@ bool ReadImplicitDataElement(std::istream &is, ImplicitDataElement &de)
   Tag t;
   if( !t.template Read<TSwap>(is) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   //std::cout << "Tag: " << t << std::endl;
@@ -478,13 +478,13 @@ bool ReadImplicitDataElement(std::istream &is, ImplicitDataElement &de)
   VL vl;
   if( !vl.template Read<TSwap>(is) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   ByteValue *bv = nullptr;
   if( vl.IsUndefined() )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   else
@@ -495,7 +495,7 @@ bool ReadImplicitDataElement(std::istream &is, ImplicitDataElement &de)
   bv->SetLength(vl); // perform realloc
   if( !bv->template Read<TSwap>(is) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return false;
     }
   de.SetTag(t);
@@ -588,7 +588,7 @@ std::istream &FileMetaInformation::Read(std::istream &is)
 std::istream &FileMetaInformation::ReadCompat(std::istream &is)
 {
   // \precondition
-  assert( is.good() );
+  gdcm_assert( is.good() );
   // First off save position in case we fail (no File Meta Information)
   // See PS 3.5, Data Element Structure With Explicit VR
   if( !IsEmpty() )
@@ -659,7 +659,7 @@ std::istream &FileMetaInformation::ReadCompat(std::istream &is)
     }
   else
     {
-    //assert( t.GetElement() == 0x0 );
+    //gdcm_assert( t.GetElement() == 0x0 );
     char vr_str[3];
     VR::VRType vr = VR::VR_END;
     if( is.read(vr_str, 2) )
@@ -691,7 +691,7 @@ std::istream &FileMetaInformation::ReadCompat(std::istream &is)
         // something like IM-0001-0066.CommandTag00.dcm was crafted
         ide.ReadValue<SwapperNoOp>(is);
         ReadCompat(is); // this will read the next element
-        assert( DataSetTS == TransferSyntax::ImplicitVRLittleEndian );
+        gdcm_assert( DataSetTS == TransferSyntax::ImplicitVRLittleEndian );
         is.seekg(-12, std::ios::cur); // Seek back
         return is;
         }
@@ -730,7 +730,7 @@ bool AddVRToDataElement(DataElement &de)
 template <typename TSwap>
 std::istream &FileMetaInformation::ReadCompatInternal(std::istream &is)
 {
-  //assert( t.GetGroup() == 0x0002 );
+  //gdcm_assert( t.GetGroup() == 0x0002 );
 //  if( t.GetGroup() == 0x0002 )
     {
     // Purposely not Re-use ReadVR since we can read VR_END
@@ -821,7 +821,7 @@ std::istream &FileMetaInformation::ReadCompatInternal(std::istream &is)
 
 //void FileMetaInformation::SetTransferSyntaxType(TS const &ts)
 //{
-//  //assert( DS == 0 );
+//  //gdcm_assert( DS == 0 );
 //  //InternalTS = ts;
 //}
 
@@ -871,7 +871,7 @@ std::string FileMetaInformation::GetMediaStorageAsString() const
   std::string ts;
     {
     const ByteValue *bv = de.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     if( bv->GetPointer() && bv->GetLength() )
       {
       // Pad string with a \0
@@ -931,7 +931,7 @@ std::ostream &FileMetaInformation::Write(std::ostream &os) const
   }
 //  else
 //  {
-//    assert(0);
+//    gdcm_assert(0);
 //  }
 #if 0
     // At least make sure to have group length

--- a/Source/DataStructureAndEncodingDefinition/gdcmFragment.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFragment.cxx
@@ -18,8 +18,8 @@ namespace gdcm_ns
 
 VL Fragment::GetLength() const
 {
-  assert( !ValueLengthField.IsUndefined() );
-  assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+  gdcm_assert( !ValueLengthField.IsUndefined() );
+  gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
   return TagField.GetLength() + ValueLengthField.GetLength()
     + ValueLengthField;
 }
@@ -27,9 +27,9 @@ VL Fragment::GetLength() const
 VL Fragment::ComputeLength() const
 {
   const ByteValue *bv = GetByteValue();
-  assert( bv );
-  assert( !ValueLengthField.IsUndefined() );
-  //assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+  gdcm_assert( bv );
+  gdcm_assert( !ValueLengthField.IsUndefined() );
+  //gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
   return TagField.GetLength() + ValueLengthField.GetLength()
     + bv->ComputeLength() /*ValueLengthField*/;
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
@@ -119,7 +119,7 @@ public:
     while( cont )
       {
       TagField.Read<TSwap>(is);
-      assert( is );
+      gdcm_assert( is );
       if( TagField != itemStart && TagField != seqDelItem )
         {
         ++offset;
@@ -136,7 +136,7 @@ public:
         cont = false;
         }
       }
-    assert( TagField == itemStart || TagField == seqDelItem );
+    gdcm_assert( TagField == itemStart || TagField == seqDelItem );
     if( !ValueLengthField.Read<TSwap>(is) )
       {
       return is;
@@ -166,10 +166,10 @@ public:
     const Tag seqDelItem(0xfffe,0xe0dd);
     if( !TagField.Write<TSwap>(os) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
-    assert( TagField == itemStart
+    gdcm_assert( TagField == itemStart
          || TagField == seqDelItem );
     const ByteValue *bv = GetByteValue();
     // VL
@@ -177,23 +177,23 @@ public:
     // CompressedLossy.dcm
     if( IsEmpty() )
       {
-      //assert( bv );
+      //gdcm_assert( bv );
       VL zero = 0;
       if( !zero.Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }
     else
       {
-      assert( ValueLengthField );
-      assert( !ValueLengthField.IsUndefined() );
+      gdcm_assert( ValueLengthField );
+      gdcm_assert( !ValueLengthField.IsUndefined() );
       const VL actuallen = bv->ComputeLength();
-      assert( actuallen == ValueLengthField || actuallen == ValueLengthField + 1 );
+      gdcm_assert( actuallen == ValueLengthField || actuallen == ValueLengthField + 1 );
       if( !actuallen.Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }
@@ -201,11 +201,11 @@ public:
     if( ValueLengthField && bv )
       {
       // Self
-      assert( bv );
-      assert( bv->GetLength() == ValueLengthField );
+      gdcm_assert( bv );
+      gdcm_assert( bv->GetLength() == ValueLengthField );
       if( !bv->Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }

--- a/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.cxx
@@ -23,7 +23,7 @@ VL ImplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
     if( sq )
@@ -35,12 +35,12 @@ VL ImplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      //assert( VRField & VR::OB_OW ); // VR::INVALID is not possible AFAIK...
+      //gdcm_assert( VRField & VR::OB_OW ); // VR::INVALID is not possible AFAIK...
       return TagField.GetLength() /*+ VRField.GetLength()*/
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
 #endif
-    assert( !ValueLengthField.IsUndefined() );
+    gdcm_assert( !ValueLengthField.IsUndefined() );
     return ValueLengthField;
     }
   //else if( const SequenceOfItems *sqi = GetSequenceOfItems() )
@@ -52,7 +52,7 @@ VL ImplicitDataElement::GetLength() const
     }
   else
     {
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + ValueLengthField.GetLength()
       + ValueLengthField;
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
@@ -41,17 +41,17 @@ std::istream &ImplicitDataElement::ReadPreValue(std::istream& is)
   if( !is )
     {
     if( !is.eof() ) // FIXME This should not be needed
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
     return is;
     }
   const Tag itemStartItem(0xfffe,0xe000);
   if( TagField == itemStartItem ) return is;
 
-  //assert( TagField != Tag(0xfffe,0xe0dd) );
+  //gdcm_assert( TagField != Tag(0xfffe,0xe0dd) );
   // Read Value Length
   if( !ValueLengthField.Read<TSwap>(is) )
     {
-    //assert(0 && "Should not happen");
+    //gdcm_assert(0 && "Should not happen");
     throw Exception("Impossible ValueLengthField");
     return is;
     }
@@ -63,7 +63,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
 {
   if( is.eof() ) return is;
   const Tag itemStartItem(0xfffe,0xe000);
-  assert( TagField != itemStartItem );
+  gdcm_assert( TagField != itemStartItem );
 
   /*
    * technically this should not be needed, but what if an implementor, forgot
@@ -93,9 +93,9 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     }
   else if( ValueLengthField.IsUndefined() )
     {
-    //assert( de.GetVR() == VR::SQ );
+    //gdcm_assert( de.GetVR() == VR::SQ );
     // FIXME what if I am reading the pixel data...
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     if( TagField != Tag(0x7fe0,0x0010) )
       {
       ValueField = new SequenceOfItems;
@@ -133,7 +133,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
       is.seekg(-4, std::ios::cur );
       if( item == itemStart )
         {
-        assert( TagField != Tag(0x7fe0,0x0010) );
+        gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
         ValueField = new SequenceOfItems;
         }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -150,7 +150,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
           {
           if( !ValueIO<ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
             {
-            assert(0 && "Should not happen");
+            gdcm_assert(0 && "Should not happen");
             }
           gdcmWarningMacro( "Illegal: Explicit SQ found in a file with "
             "TransferSyntax=Implicit for tag: " << TagField );
@@ -161,7 +161,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
           std::streampos current = is.tellg();
           std::streamoff diff = start - current;
           is.seekg( diff, std::ios::cur );
-          assert( diff == -14 );
+          gdcm_assert( diff == -14 );
           ValueIO<ImplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues);
           }
         catch( std::exception & )
@@ -178,7 +178,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
         ValueField->SetLength(ValueLengthField); // perform realloc
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) )
           {
-          assert(0 && "Should not happen");
+          gdcm_assert(0 && "Should not happen");
           }
         return is;
         }
@@ -222,14 +222,14 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
   VR vrfield = GetVRFromTag( TagField );
   if( vrfield & VR::VRASCII || vrfield == VR::INVALID )
     {
-    //assert( VRField.GetSize() == 1 );
+    //gdcm_assert( VRField.GetSize() == 1 );
     failed = !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues);
     }
   else
     {
-    assert( vrfield & VR::VRBINARY );
+    gdcm_assert( vrfield & VR::VRBINARY );
     unsigned int vrsize = vrfield.GetSize();
-    assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
+    gdcm_assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
     if(vrfield==VR::AT) vrsize = 2;
     switch(vrsize)
       {
@@ -247,7 +247,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
       break;
     default:
     failed = true;
-      assert(0);
+      gdcm_assert(0);
       }
     }
 #else
@@ -276,12 +276,12 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
   VL dummy = ValueField->GetLength();
   if( ValueLengthField != dummy )
     {
-    gdcmWarningMacro( "ValueLengthField was bogus" ); assert(0);
+    gdcmWarningMacro( "ValueLengthField was bogus" ); gdcm_assert(0);
     ValueLengthField = dummy;
     }
 #else
-  assert( ValueLengthField == ValueField->GetLength() );
-  assert( VRField == VR::INVALID );
+  gdcm_assert( ValueLengthField == ValueField->GetLength() );
+  gdcm_assert( VRField == VR::INVALID );
 #endif
 
   return is;
@@ -330,9 +330,9 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
     }
   else if( ValueLengthField.IsUndefined() )
     {
-    //assert( de.GetVR() == VR::SQ );
+    //gdcm_assert( de.GetVR() == VR::SQ );
     // FIXME what if I am reading the pixel data...
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     if( TagField != Tag(0x7fe0,0x0010) )
       {
       ValueField = new SequenceOfItems;
@@ -370,7 +370,7 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
       is.seekg(-4, std::ios::cur );
       if( item == itemStart )
         {
-        assert( TagField != Tag(0x7fe0,0x0010) );
+        gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
         ValueField = new SequenceOfItems;
         }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -387,7 +387,7 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
           {
           if( !ValueIO<ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
             {
-            assert(0 && "Should not happen");
+            gdcm_assert(0 && "Should not happen");
             }
           gdcmWarningMacro( "Illegal: Explicit SQ found in a file with "
             "TransferSyntax=Implicit for tag: " << TagField );
@@ -398,7 +398,7 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
           std::streampos current = is.tellg();
           std::streamoff diff = start - current;//could be bad, if the specific implementation does not support negative streamoff values.
           is.seekg( diff, std::ios::cur );
-          assert( diff == -14 );
+          gdcm_assert( diff == -14 );
           ValueIO<ImplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues);
           }
         catch( std::exception & )
@@ -409,14 +409,14 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
         }
       else if ( item == itemPMSStart2 )
         {
-        assert( 0 ); // FIXME: Sync Read/ReadWithLength
+        gdcm_assert( 0 ); // FIXME: Sync Read/ReadWithLength
         gdcmWarningMacro( "Illegal: SQ start with " << itemPMSStart2
           << " instead of " << itemStart << " for tag: " << TagField );
         ValueField = new SequenceOfItems;
         ValueField->SetLength(ValueLengthField); // perform realloc
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) )
           {
-          assert(0 && "Should not happen");
+          gdcm_assert(0 && "Should not happen");
           }
         return is;
         }
@@ -460,14 +460,14 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
   VR vrfield = GetVRFromTag( TagField );
   if( vrfield & VR::VRASCII || vrfield == VR::INVALID )
     {
-    //assert( VRField.GetSize() == 1 );
+    //gdcm_assert( VRField.GetSize() == 1 );
     failed = !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues);
     }
   else
     {
-    assert( vrfield & VR::VRBINARY );
+    gdcm_assert( vrfield & VR::VRBINARY );
     unsigned int vrsize = vrfield.GetSize();
-    assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
+    gdcm_assert( vrsize == 1 || vrsize == 2 || vrsize == 4 || vrsize == 8 );
     if(vrfield==VR::AT) vrsize = 2;
     switch(vrsize)
       {
@@ -485,7 +485,7 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
       break;
     default:
     failed = true;
-      assert(0);
+      gdcm_assert(0);
       }
     }
 #else
@@ -519,8 +519,8 @@ std::istream &ImplicitDataElement::ReadValueWithLength(std::istream& is, VL & le
     ValueLengthField = dummy;
     }
 #else
-  assert( ValueLengthField == ValueField->GetLength() );
-  assert( VRField == VR::INVALID );
+  gdcm_assert( ValueLengthField == ValueField->GetLength() );
+  gdcm_assert( VRField == VR::INVALID );
 #endif
 
   return is;
@@ -534,7 +534,7 @@ const std::ostream &ImplicitDataElement::Write(std::ostream &os) const
   // Write Tag
   if( !TagField.Write<TSwap>(os) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return os;
     }
   // Write Value Length
@@ -547,10 +547,10 @@ const std::ostream &ImplicitDataElement::Write(std::ostream &os) const
     // Hum, we might have to recompute the length:
     // See TestWriter2, where an explicit SQ is converted to implicit SQ
     VL len = sqi->template ComputeLength<ImplicitDataElement>();
-    //assert( len == ValueLengthField );
+    //gdcm_assert( len == ValueLengthField );
     if( !len.Write<TSwap>(os) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
     }
@@ -560,20 +560,20 @@ const std::ostream &ImplicitDataElement::Write(std::ostream &os) const
     if( TagField == Tag(0x7fe0,0x0010) && ValueLengthField.IsUndefined() ) throw Exception( "VL u/f Impossible" );
     if( !ValueLengthField.Write<TSwap>(os) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
     }
   // Write Value
   if( ValueLengthField )
     {
-    assert( ValueField );
+    gdcm_assert( ValueField );
     gdcmAssertAlwaysMacro( ValueLengthField == ValueField->GetLength() );
-    assert( TagField != Tag(0xfffe, 0xe00d)
+    gdcm_assert( TagField != Tag(0xfffe, 0xe00d)
          && TagField != Tag(0xfffe, 0xe0dd) );
     if( !ValueIO<ImplicitDataElement,TSwap>::Write(os,*ValueField) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return os;
       }
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmItem.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmItem.h
@@ -61,7 +61,7 @@ public:
     // Update the length
     if( !IsUndefinedLength() )
       {
-      assert( 0 && "InsertDataElement" );
+      gdcm_assert( 0 && "InsertDataElement" );
       //ValueLengthField += de.GetLength();
       }
     }
@@ -99,7 +99,7 @@ public:
     {
         DataSet &nested = NestedDataSet;
         nested.Clear();
-        assert( nested.IsEmpty() );
+        gdcm_assert( nested.IsEmpty() );
     }
     if( !TagField.Read<TSwap>(is) )
       {
@@ -119,7 +119,7 @@ public:
 
       if( !ValueLengthField.Read<SwapperDoOp>(is) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return is;
         }
       // Self
@@ -133,7 +133,7 @@ public:
         }
       //else if( ValueLengthField == 0 )
       //  {
-      //  //assert( TagField == Tag( 0xfffe, 0xe0dd) );
+      //  //gdcm_assert( TagField == Tag( 0xfffe, 0xe0dd) );
       //  if( TagField != Tag( 0xfffe, 0xe0dd) )
       //    {
       //    gdcmErrorMacro( "SQ: " << TagField << " has a length of 0" );
@@ -143,7 +143,7 @@ public:
         {
         DataSet &nested = NestedDataSet;
         nested.Clear();
-        assert( nested.IsEmpty() );
+        gdcm_assert( nested.IsEmpty() );
         std::streampos start = is.tellg();
         try
           {
@@ -158,7 +158,7 @@ public:
           // You have to byteswap the length but not the tag...sigh
           gdcmWarningMacro( "Attempt to read nested Item without byteswapping the Value Length." );
           start -= is.tellg();
-          assert( start < 0 );
+          gdcm_assert( start < 0 );
           is.seekg( start, std::ios::cur );
           nested.Clear();
           nested.template ReadNested<TDE,SwapperNoOp>(is);
@@ -174,14 +174,14 @@ public:
           }
         catch(...)
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       else /* if( ValueLengthField.IsUndefined() ) */
         {
         DataSet &nested = NestedDataSet;
         nested.Clear();
-        assert( nested.IsEmpty() );
+        gdcm_assert( nested.IsEmpty() );
         nested.template ReadWithLength<TDE,SwapperDoOp>(is, ValueLengthField);
         ByteSwapFilter bsf(nested);
         bsf.ByteSwap();
@@ -200,11 +200,11 @@ public:
       gdcmDebugMacro( "Invalid Item, found tag: " << TagField);
       throw Exception( "Not a valid Item" );
       }
-    assert( TagField == Tag(0xfffe, 0xe000) || TagField == Tag(0xfffe, 0xe0dd) );
+    gdcm_assert( TagField == Tag(0xfffe, 0xe000) || TagField == Tag(0xfffe, 0xe0dd) );
 
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     // Self
@@ -220,15 +220,15 @@ public:
       {
       DataSet &nested = NestedDataSet;
       nested.Clear();
-      assert( nested.IsEmpty() );
+      gdcm_assert( nested.IsEmpty() );
       nested.template ReadNested<TDE,TSwap>(is);
       }
     else /* if( ValueLengthField.IsUndefined() ) */
       {
-      assert( !ValueLengthField.IsUndefined() );
+      gdcm_assert( !ValueLengthField.IsUndefined() );
       DataSet &nested = NestedDataSet;
       nested.Clear();
-      assert( nested.IsEmpty() );
+      gdcm_assert( nested.IsEmpty() );
       nested.template ReadWithLength<TDE,TSwap>(is, ValueLengthField);
       }
 
@@ -252,12 +252,12 @@ public:
       if( TagField == Tag(0xfffe, 0xe0dd) )
         {
         gdcmWarningMacro( "SeqDelItem found in defined length Sequence" );
-        assert( ValueLengthField == 0 );
-        assert( NestedDataSet.Size() == 0 );
+        gdcm_assert( ValueLengthField == 0 );
+        gdcm_assert( NestedDataSet.Size() == 0 );
         }
       if( !TagField.Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }
@@ -265,18 +265,18 @@ public:
       {
       if( !ValueLengthField.Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }
     else
       {
       const VL dummy = NestedDataSet.GetLength<TDE>();
-      assert( dummy % 2 == 0 );
-      //assert( ValueLengthField == dummy );
+      gdcm_assert( dummy % 2 == 0 );
+      //gdcm_assert( ValueLengthField == dummy );
       if( !dummy.Write<TSwap>(os) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         return os;
         }
       }

--- a/Source/DataStructureAndEncodingDefinition/gdcmItem.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmItem.txx
@@ -24,13 +24,13 @@ VL Item::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( !NestedDataSet.GetLength<TDE>().IsUndefined() );
+    gdcm_assert( !NestedDataSet.GetLength<TDE>().IsUndefined() );
     // Item Start             4
     // Item Length            4
     // DataSet                ?
     // Item End Delimitation  4
     // Item End Length        4
-    assert( NestedDataSet.GetLength<TDE>() % 2 == 0 );
+    gdcm_assert( NestedDataSet.GetLength<TDE>() % 2 == 0 );
     return TagField.GetLength() /* 4 */ + ValueLengthField.GetLength() /* 4 */
       + NestedDataSet.GetLength<TDE>() + 4 + 4;
     }
@@ -45,7 +45,7 @@ VL Item::GetLength() const
     // initially read explicit dataset in which case the two length cannot
     // related to each other
     //gdcmAssertAlwaysMacro( ValueLengthField == nestedlen );
-    assert( nestedlen % 2 == 0 );
+    gdcm_assert( nestedlen % 2 == 0 );
     return TagField.GetLength() /* 4 */ + ValueLengthField.GetLength() /* 4 */
       //+ ValueLengthField;
       + nestedlen;

--- a/Source/DataStructureAndEncodingDefinition/gdcmMediaStorage.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmMediaStorage.cxx
@@ -178,13 +178,13 @@ MediaStorage::MSType MediaStorage::GetMSType(const char *str)
       }
     }
 
-  //assert(0);
+  //gdcm_assert(0);
   return MS_END;
 }
 
 const char* MediaStorage::GetMSString(MSType ms)
 {
-  assert( ms <= MS_END );
+  gdcm_assert( ms <= MS_END );
   return MSStrings[(int)ms];
 }
 
@@ -349,21 +349,21 @@ static const MSModalityType MSModalityTypes[] = {
 unsigned int MediaStorage::GetNumberOfMSType()
 {
   const unsigned int n = MS_END;
-  assert( n > 0 );
+  gdcm_assert( n > 0 );
   return n;
 }
 
 unsigned int MediaStorage::GetNumberOfMSString()
 {
   static const unsigned int n = sizeof( MSStrings ) / sizeof( *MSStrings );
-  assert( n > 0 );
+  gdcm_assert( n > 0 );
   return n - 1;
 }
 
 unsigned int MediaStorage::GetNumberOfModality()
 {
   static const unsigned int n = sizeof( MSModalityTypes ) / sizeof( *MSModalityTypes );
-  assert( n > 0 );
+  gdcm_assert( n > 0 );
   return n - 1;
 }
 
@@ -371,7 +371,7 @@ const char *MediaStorage::GetModality() const
 {
   if (!MSModalityTypes[MSField].Modality)
     return nullptr;
-  assert( MSModalityTypes[MSField].Modality[0] != ' ' ); // FIXME
+  gdcm_assert( MSModalityTypes[MSField].Modality[0] != ' ' ); // FIXME
   return MSModalityTypes[MSField].Modality;
 }
 
@@ -379,7 +379,7 @@ unsigned int MediaStorage::GetModalityDimension() const
 {
   if (!MSModalityTypes[MSField].Modality)
     return 0;
-  assert( MSModalityTypes[MSField].Dimension );
+  gdcm_assert( MSModalityTypes[MSField].Dimension );
   return MSModalityTypes[MSField].Dimension;
 }
 
@@ -485,7 +485,7 @@ void MediaStorage::SetFromSourceImageSequence(DataSet const &ds)
       const DataElement& de = subds.GetDataElement( referencedSOPClassUIDTag );
       const ByteValue *sopclassuid = de.GetByteValue();
       // LEADTOOLS_FLOWERS-8-PAL-Uncompressed.dcm
-      //assert( sopclassuid );
+      //gdcm_assert( sopclassuid );
       if( sopclassuid )
         {
         std::string sopclassuid_str(
@@ -498,7 +498,7 @@ void MediaStorage::SetFromSourceImageSequence(DataSet const &ds)
           sopclassuid_str = sopclassuid_str.substr(0,pos);
           }
         MediaStorage ms = MediaStorage::GetMSType(sopclassuid_str.c_str());
-        assert( ms != MS_END );
+        gdcm_assert( ms != MS_END );
         MSField = ms;
         }
       }
@@ -608,7 +608,7 @@ bool MediaStorage::SetFromFile(File const &file)
     ms2.SetFromSourceImageSequence(ds);
     if( MSField != ms2 && ms2 != MediaStorage::MS_END )
       {
-      assert( MediaStorage::IsImage( ms2 ) );
+      gdcm_assert( MediaStorage::IsImage( ms2 ) );
       gdcmWarningMacro( "Object is declared as SecondaryCaptureImageStorage but according"
         " to Source Image Sequence it was derived from " << ms2 << ". Using it instead" );
       MSField = ms2;

--- a/Source/DataStructureAndEncodingDefinition/gdcmPrivateTag.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmPrivateTag.cxx
@@ -60,12 +60,12 @@ namespace gdcm_ns
       {
       const char *s1 = Owner.c_str();
       const char *s2 = _val.GetOwner();
-      assert( s1 );
-      assert( s2 );
+      gdcm_assert( s1 );
+      gdcm_assert( s2 );
       if( *s1 )
-        assert( s1[strlen(s1)-1] != ' ' );
+        gdcm_assert( s1[strlen(s1)-1] != ' ' );
       if( *s2 )
-        assert( s2[strlen(s2)-1] != ' ' );
+        gdcm_assert( s2[strlen(s2)-1] != ' ' );
       bool res = strcmp(s1, s2) < 0;
 #ifdef DEBUG_DUPLICATE
       if( *s1 && *s2 && gdcm::System::StrCaseCmp(s1,s2) == 0 && strcmp(s1,s2) != 0 )
@@ -73,11 +73,11 @@ namespace gdcm_ns
         // FIXME:
         // Typically this should only happen with the "Philips MR Imaging DD 001" vs "PHILIPS MR IMAGING DD 001"
         // or "Philips Imaging DD 001" vr "PHILIPS IMAGING DD 001"
-        //assert( strcmp(Owner.c_str(), _val.GetOwner()) == 0 );
+        //gdcm_assert( strcmp(Owner.c_str(), _val.GetOwner()) == 0 );
         //return true;
         const bool res2 = gdcm::System::StrCaseCmp(s1,s2) < 0;
         res = res2;
-        assert( 0 );
+        gdcm_assert( 0 );
         }
 #endif
       return res;

--- a/Source/DataStructureAndEncodingDefinition/gdcmPrivateTag.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmPrivateTag.h
@@ -90,7 +90,7 @@ private:
 
 inline std::ostream& operator<<(std::ostream &os, const PrivateTag &val)
 {
-  //assert( !val.Owner.empty() );
+  //gdcm_assert( !val.Owner.empty() );
   os.setf( std::ios::right );
   os << std::hex << '(' << std::setw( 4 ) << std::setfill( '0' )
     << val[0] << ',' << std::setw( 2 ) << std::setfill( '0' )

--- a/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmReader.cxx
@@ -85,7 +85,7 @@ bool Reader::ReadDataSet()
 TransferSyntax Reader::GuessTransferSyntax()
 {
   // Don't call this function if you have a meta file info
-  //assert( Header->GetTransferSyntaxType() == TransferSyntax::TS_END );
+  //gdcm_assert( Header->GetTransferSyntaxType() == TransferSyntax::TS_END );
   std::streampos start = Stream->tellg();
   SwapCode sc = SwapCode::Unknown;
   TransferSyntax::NegociatedType nts = TransferSyntax::Unknown;
@@ -103,7 +103,7 @@ TransferSyntax Reader::GuessTransferSyntax()
       sc = SwapCode::BigEndian;
       break;
     default:
-      assert(0);
+      gdcm_assert(0);
       }
     // Purposely not Re-use ReadVR since we can read VR_END
     char vr_str[3];
@@ -117,7 +117,7 @@ TransferSyntax Reader::GuessTransferSyntax()
       }
     else
       {
-      assert( !(VR::IsSwap(vr_str)));
+      gdcm_assert( !(VR::IsSwap(vr_str)));
       Stream->seekg(-2, std::ios::cur); // Seek back
       if( t.GetElement() == 0x0000 )
         {
@@ -140,7 +140,7 @@ TransferSyntax Reader::GuessTransferSyntax()
           gdcmWarningMacro( "Bad Big Endian" );
           break;
         default:
-          assert(0);
+          gdcm_assert(0);
           }
         }
       nts = TransferSyntax::Implicit;
@@ -149,14 +149,14 @@ TransferSyntax Reader::GuessTransferSyntax()
   else
     {
     gdcmWarningMacro( "Start with a private tag creator" );
-    assert( t.GetGroup() > 0x0002 );
+    gdcm_assert( t.GetGroup() > 0x0002 );
     switch( t.GetElement() )
       {
     case 0x0010:
       sc = SwapCode::LittleEndian;
       break;
     default:
-      assert(0);
+      gdcm_assert(0);
       }
     // Purposely not Re-use ReadVR since we can read VR_END
     char vr_str[3];
@@ -177,8 +177,8 @@ TransferSyntax Reader::GuessTransferSyntax()
       gdcmWarningMacro( "Very dangerous assertion needs some work" );
       }
     }
-  assert( nts != TransferSyntax::Unknown );
-  assert( sc != SwapCode::Unknown );
+  gdcm_assert( nts != TransferSyntax::Unknown );
+  gdcm_assert( sc != SwapCode::Unknown );
   if( nts == TransferSyntax::Implicit )
     {
     if( sc == SwapCode::BigEndian )
@@ -191,15 +191,15 @@ TransferSyntax Reader::GuessTransferSyntax()
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
   Stream->seekg( start, std::ios::beg );
-  assert( ts != TransferSyntax::TS_END );
+  gdcm_assert( ts != TransferSyntax::TS_END );
   return ts;
 }
 
@@ -227,7 +227,7 @@ namespace details
     static void Check(bool b, std::istream &stream)
       {
       (void)stream;
-      if( b ) assert( stream.eof() );
+      if( b ) gdcm_assert( stream.eof() );
       }
   };
 
@@ -362,7 +362,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
       }
     catch( ... )
       {
-      assert(0);
+      gdcm_assert(0);
       }
 
     bool hasmetaheader = false;
@@ -374,7 +374,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
           {
           F->GetHeader().Read( is );
           hasmetaheader = true;
-          assert( !F->GetHeader().IsEmpty() );
+          gdcm_assert( !F->GetHeader().IsEmpty() );
           }
         catch( std::exception &ex )
           {
@@ -382,7 +382,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
           gdcmWarningMacro(ex.what());
           // Weird implicit meta header:
           is.seekg(128+4, std::ios::beg );
-          assert( is.good() );
+          gdcm_assert( is.good() );
           try
             {
             F->GetHeader().ReadCompat(is);
@@ -410,7 +410,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
     catch( ... )
       {
       // Ooops..
-      assert(0);
+      gdcm_assert(0);
       }
     if( F->GetHeader().IsEmpty() )
       {
@@ -431,7 +431,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
 
     zlib_stream::zip_istream gzis( is );
     // FIXME: we also know in this case that we are dealing with Explicit:
-    assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
+    gdcm_assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
     //F->GetDataSet().ReadUpToTag<ExplicitDataElement,SwapperNoOp>(gzis,tag, skiptags);
     caller.template ReadCommon<ExplicitDataElement,SwapperNoOp>(gzis);
     // I need the following hack to read: srwithgraphdeflated.dcm
@@ -475,14 +475,14 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
           std::streampos start = is.tellg();
           is.seekg( 0, std::ios::end);
           std::streampos end = is.tellg();
-          assert( !is.eof() );
-          assert( is.good() );
+          gdcm_assert( !is.eof() );
+          gdcm_assert( is.good() );
           std::streamoff theOffset = end-start;
           assert (theOffset > 0 || (uint32_t)theOffset < std::numeric_limits<uint32_t>::max());
           VL l = (uint32_t)(theOffset);
           is.seekg( start, std::ios::beg );
-          assert( is.good() );
-          assert( !is.eof() );
+          gdcm_assert( is.good() );
+          gdcm_assert( !is.eof() );
           caller.template ReadCommonWithLength<ImplicitDataElement,SwapperNoOp>(is,l);
           }
         }
@@ -575,7 +575,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
       //
       gdcmWarningMacro( "Attempt to read Philips with ByteSwap private sequence wrongly encoded");
       F->GetDataSet().Clear(); // remove garbage from 1st attempt...
-      assert(0);  // TODO FIXME
+      gdcm_assert(0);  // TODO FIXME
       }
     else if( ex.GetLastElement().GetVR() == VR::INVALID )
       {
@@ -694,7 +694,7 @@ bool Reader::InternalReadCommon(const T_Caller &caller)
     success = false;
     }
 
-  //if( success ) assert( Stream->eof() );
+  //if( success ) gdcm_assert( Stream->eof() );
   caller.Check(success, *Stream );
     }
   catch( Exception &ex )
@@ -782,14 +782,14 @@ bool Reader::CanRead() const
   if (bigendian)
     {
     t.Read<SwapperDoOp>(ss);
-    //assert( t.GetGroup() != 0x2 );
+    //gdcm_assert( t.GetGroup() != 0x2 );
     if( t.GetGroup() <= 0xff )
       sc = SwapCode::BigEndian;
     }
   else
     {
     t.Read<SwapperNoOp>(ss);
-    //assert( t.GetGroup() != 0x2 );
+    //gdcm_assert( t.GetGroup() != 0x2 );
     if( t.GetGroup() <= 0xff )
       sc = SwapCode::LittleEndian;
     }
@@ -844,7 +844,7 @@ void Reader::SetFileName(const char *utf8path)
   if( Ifstream->is_open() )
     {
     Stream = Ifstream;
-    assert( Stream && *Stream );
+    gdcm_assert( Stream && *Stream );
     }
   else
     {

--- a/Source/DataStructureAndEncodingDefinition/gdcmReader.strict.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmReader.strict.cxx
@@ -28,7 +28,7 @@ namespace gdcm
   bool StrictReadUpToTag( const char * filename, Tag const & last, std::set<Tag> const & skiptags )
     {
     gdcmstrict::Reader reader;
-    assert( filename );
+    gdcm_assert( filename );
     reader.SetFileName( filename );
     bool read = false;
     try

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.cxx
@@ -27,7 +27,7 @@ void SequenceOfFragments::Clear()
 SequenceOfFragments::SizeType SequenceOfFragments::GetNumberOfFragments() const
 {
   // Do not count the last fragment
-  //assert( SequenceLengthField.IsUndefined() );
+  //gdcm_assert( SequenceLengthField.IsUndefined() );
   return Fragments.size();
 }
 
@@ -46,10 +46,10 @@ VL SequenceOfFragments::ComputeLength() const
   for(;it != Fragments.end(); ++it)
     {
     const VL fraglen = it->ComputeLength();
-    assert( fraglen % 2 == 0 );
+    gdcm_assert( fraglen % 2 == 0 );
     length += fraglen;
     }
-  assert( SequenceLengthField.IsUndefined() );
+  gdcm_assert( SequenceLengthField.IsUndefined() );
   length += 8; // seq end delimiter (tag + vl)
   return length;
 }
@@ -60,7 +60,7 @@ unsigned long SequenceOfFragments::ComputeByteLength() const
   FragmentVector::const_iterator it = Fragments.begin();
   for(;it != Fragments.end(); ++it)
     {
-    assert( !it->GetVL().IsUndefined() );
+    gdcm_assert( !it->GetVL().IsUndefined() );
     r += it->GetVL();
     }
   return r;
@@ -81,7 +81,7 @@ bool SequenceOfFragments::GetFragBuffer(unsigned int fragNb, char *buffer, unsig
 
 const Fragment& SequenceOfFragments::GetFragment(SizeType num) const
 {
-  assert( num < Fragments.size() );
+  gdcm_assert( num < Fragments.size() );
   FragmentVector::const_iterator it = Fragments.begin();
   const Fragment &frag = *(it+num);
   return frag;
@@ -103,7 +103,7 @@ bool SequenceOfFragments::GetBuffer(char *buffer, unsigned long length) const
   if( total != length )
     {
     //std::cerr << " DEBUG: " << total << " " << length << std::endl;
-    assert(0);
+    gdcm_assert(0);
     return false;
     }
   return true;
@@ -117,7 +117,7 @@ bool SequenceOfFragments::WriteBuffer(std::ostream &os) const
     {
     const Fragment &frag = *it;
     const ByteValue *bv = frag.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     const VL len = frag.GetVL();
     bv->WriteBuffer(os);
     total += len;
@@ -125,7 +125,7 @@ bool SequenceOfFragments::WriteBuffer(std::ostream &os) const
   //if( total != length )
   //  {
   //  //std::cerr << " DEBUG: " << total << " " << length << std::endl;
-  //  assert(0);
+  //  gdcm_assert(0);
   //  return false;
   //  }
   (void)total;

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
@@ -85,7 +85,7 @@ public:
 template <typename TSwap>
 std::istream& Read(std::istream &is, bool readvalues = true)
 {
-  assert( SequenceLengthField.IsUndefined() );
+  gdcm_assert( SequenceLengthField.IsUndefined() );
   ReadPreValue<TSwap>(is);
   return ReadValue<TSwap>(is, readvalues);
 }
@@ -122,7 +122,7 @@ std::istream& ReadPreValue(std::istream &is)
     else
       {
       throw "Catch me if you can";
-      //assert(0);
+      //gdcm_assert(0);
       }
     }
 #else
@@ -145,7 +145,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       //gdcmDebugMacro( "Frag: " << frag );
       Fragments.push_back( frag );
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
     }
   catch(Exception &ex)
     {
@@ -165,9 +165,9 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
     // 2. GENESIS_SIGNA-JPEG-CorruptFrag.dcm
     else if ( frag.GetTag() == Tag(0xddff,0x00e0) )
       {
-      assert( Fragments.size() == 1 );
+      gdcm_assert( Fragments.size() == 1 );
       const ByteValue *bv = Fragments[0].GetByteValue();
-      assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
+      gdcm_assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
       // Yes this is an extra copy, this is a bug anyway, go fix YOUR code
       Fragments[0].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       gdcmWarningMacro( "JPEG Fragment length was declared with an extra byte"
@@ -184,20 +184,20 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       // backward. This appears to be working on a set of DICOM/WSI files from
       // LEICA
       gdcmWarningMacro( "Trying to fix the even-but-odd value length bug #1" );
-      assert( Fragments.size() );
+      gdcm_assert( Fragments.size() );
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
       gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 1 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       is.seekg( -9, std::ios::cur );
-      assert( is.good() );
+      gdcm_assert( is.good() );
       while( frag.ReadBacktrack<TSwap>(is) && frag.GetTag() != seqDelItem )
         {
         gdcmDebugMacro( "Frag: " << frag );
         Fragments.push_back( frag );
         }
-      assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+      gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
       }
     // 4. LEICA/WSI (bis)
     else if ( frag.GetTag().GetGroup() == 0xe000 )
@@ -208,20 +208,20 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       // backward. This appears to be working on a set of DICOM/WSI files from
       // LEICA
       gdcmWarningMacro( "Trying to fix the even-but-odd value length bug #2" );
-      assert( Fragments.size() );
+      gdcm_assert( Fragments.size() );
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
       gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 2 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 2 );
       is.seekg( -10, std::ios::cur );
-      assert( is.good() );
+      gdcm_assert( is.good() );
       while( frag.ReadBacktrack<TSwap>(is) && frag.GetTag() != seqDelItem )
         {
         gdcmDebugMacro( "Frag: " << frag );
         Fragments.push_back( frag );
         }
-      assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+      gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
       }
     // 5. LEICA/WSI (ter)
     else if ( (frag.GetTag().GetGroup() & 0x00ff) == 0x00e0
@@ -233,20 +233,20 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       // backward. This appears to be working on a set of DICOM/WSI files from
       // LEICA
       gdcmWarningMacro( "Trying to fix the even-but-odd value length bug #3" );
-      assert( Fragments.size() );
+      gdcm_assert( Fragments.size() );
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
       gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 3 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 3 );
       is.seekg( -11, std::ios::cur );
-      assert( is.good() );
+      gdcm_assert( is.good() );
       while( frag.ReadBacktrack<TSwap>(is) && frag.GetTag() != seqDelItem )
         {
         gdcmDebugMacro( "Frag: " << frag );
         Fragments.push_back( frag );
         }
-      assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+      gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
       }
     else
       {
@@ -267,7 +267,7 @@ std::ostream const &Write(std::ostream &os) const
 {
   if( !Table.Write<TSwap>(os) )
     {
-    assert(0 && "Should not happen");
+    gdcm_assert(0 && "Should not happen");
     return os;
     }
   for(ConstIterator it = Begin();it != End(); ++it)
@@ -301,7 +301,7 @@ public:
       {
       os << "  " << *it << "\n";
       }
-    assert( SequenceLengthField.IsUndefined() );
+    gdcm_assert( SequenceLengthField.IsUndefined() );
       {
       const Tag seqDelItem(0xfffe,0xe0dd);
       VL zero = 0;

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.cxx
@@ -21,7 +21,7 @@ void SequenceOfItems::AddItem(Item const &item)
   Items.push_back( item );
   if( !SequenceLengthField.IsUndefined() )
     {
-    assert(0); // TODO
+    gdcm_assert(0); // TODO
     }
 }
 
@@ -36,7 +36,7 @@ Item & SequenceOfItems::AddNewUndefinedLengthItem()
 void SequenceOfItems::Clear()
 {
   Items.clear();
-  assert( SequenceLengthField.IsUndefined() );
+  gdcm_assert( SequenceLengthField.IsUndefined() );
 }
 
 bool SequenceOfItems::RemoveItemByIndex( const SizeType position )

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.h
@@ -111,11 +111,11 @@ public:
       while( item.Read<TDE,TSwap>(is) && item.GetTag() != seqDelItem )
         {
         //gdcmDebugMacro( "Item: " << item );
-        assert( item.GetTag() != seqDelItem );
+        gdcm_assert( item.GetTag() != seqDelItem );
         Items.push_back( item );
         item.Clear();
         }
-      //assert( item.GetTag() == seqDelItem && item.GetVL() == 0 );
+      //gdcm_assert( item.GetTag() == seqDelItem && item.GetVL() == 0 );
       }
     else
       {
@@ -149,8 +149,8 @@ public:
         if( item.GetTag() == seqDelItem )
           {
           gdcmWarningMacro( "SeqDelItem found in defined length Sequence. Skipping" );
-          assert( item.GetVL() == 0 );
-          assert( item.GetNestedDataSet().Size() == 0 );
+          gdcm_assert( item.GetVL() == 0 );
+          gdcm_assert( item.GetNestedDataSet().Size() == 0 );
           // we need to pay attention that the length of the Sequence of Items will be wrong
           // this way. Indeed by not adding this item we are changing the size of this sqi
           }
@@ -169,7 +169,7 @@ public:
           gdcmDebugMacro( "Found: Length of Item larger than expected" );
           throw "Length of Item larger than expected";
           }
-        assert( l <= SequenceLengthField );
+        gdcm_assert( l <= SequenceLengthField );
         //std::cerr << "sqi debug len: " << is.tellg() << " " <<  l << " " <<  SequenceLengthField << std::endl;
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
         // MR_Philips_Intera_No_PrivateSequenceImplicitVR.dcm
@@ -192,7 +192,7 @@ public:
           }
 #endif
         }
-      assert( l == SequenceLengthField );
+      gdcm_assert( l == SequenceLengthField );
       }
     return is;
     }

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfItems.txx
@@ -32,7 +32,7 @@ VL SequenceOfItems::ComputeLength() const
     }
   // For defined length SQ, make sure computation is correct (compare
   // to original length)
-  //assert( SequenceLengthField.IsUndefined()
+  //gdcm_assert( SequenceLengthField.IsUndefined()
   //  || length == SequenceLengthField );
   return length;
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmTag.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmTag.h
@@ -84,13 +84,13 @@ public:
   /// Returns the Group or Element of the given Tag, depending on id (0/1)
   const uint16_t &operator[](const unsigned int &_id) const
     {
-    assert(_id<2);
+    gdcm_assert(_id<2);
     return ElementTag.tags[_id];
     }
   /// Returns the Group or Element of the given Tag, depending on id (0/1)
   uint16_t &operator[](const unsigned int &_id)
     {
-    assert(_id<2);
+    gdcm_assert(_id<2);
     return ElementTag.tags[_id];
     }
 
@@ -194,7 +194,7 @@ public:
     {
     // See PS 3.5 - 7.8.1 PRIVATE DATA ELEMENT TAGS
     // eg: 0x0123,0x0045 -> 0x0123,0x4567
-    assert( t.IsPrivate() /*&& t.IsPrivateCreator()*/ );
+    gdcm_assert( t.IsPrivate() /*&& t.IsPrivateCreator()*/ );
     const uint16_t element = (uint16_t)(t.GetElement() << 8);
     const uint16_t base = (uint16_t)(GetElement() << 8);
     SetElement( (uint16_t)((base >> 8) + element) );

--- a/Source/DataStructureAndEncodingDefinition/gdcmTransferSyntax.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmTransferSyntax.cxx
@@ -118,14 +118,14 @@ TransferSyntax::TSType TransferSyntax::GetTSType(const char *cstr)
 
 const char* TransferSyntax::GetTSString(TSType ts)
 {
-  assert( ts <= TS_END );
+  gdcm_assert( ts <= TS_END );
   return TSStrings[(int)ts];
   //return TransferSyntaxStrings[(int)ts];
 }
 
 bool TransferSyntax::IsImplicit(TSType ts) const
 {
-  assert( ts != TS_END );
+  gdcm_assert( ts != TS_END );
   return ts == ImplicitVRLittleEndian
     || ts == ImplicitVRBigEndianACRNEMA
     || ts == ImplicitVRBigEndianPrivateGE
@@ -230,7 +230,7 @@ bool TransferSyntax::IsLossless() const
 // By implementation those two functions form a partition
 bool TransferSyntax::IsExplicit(TSType ts) const
 {
-  assert( ts != TS_END );
+  gdcm_assert( ts != TS_END );
   return !IsImplicit(ts);
 }
 
@@ -249,13 +249,13 @@ TransferSyntax::NegociatedType TransferSyntax::GetNegociatedType() const
 
 bool TransferSyntax::IsLittleEndian(TSType ts) const
 {
-  assert( ts != TS_END );
+  gdcm_assert( ts != TS_END );
   return !IsBigEndian(ts);
 }
 
 bool TransferSyntax::IsBigEndian(TSType ts) const
 {
-  assert( ts != TS_END );
+  gdcm_assert( ts != TS_END );
   return ts == ExplicitVRBigEndian
 //    || ts == ImplicitVRBigEndianPrivateGE // Indeed this is LittleEndian
     || ts == ImplicitVRBigEndianACRNEMA;
@@ -263,12 +263,12 @@ bool TransferSyntax::IsBigEndian(TSType ts) const
 
 SwapCode TransferSyntax::GetSwapCode() const
 {
-  assert( TSField != TS_END );
+  gdcm_assert( TSField != TS_END );
   if( IsBigEndian( TSField ) )
     {
     return SwapCode::BigEndian;
     }
-  assert( IsLittleEndian( TSField ) );
+  gdcm_assert( IsLittleEndian( TSField ) );
   return SwapCode::LittleEndian;
 }
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL UNExplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -37,18 +37,18 @@ VL UNExplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & (VR::OB | VR::OW) );
+      gdcm_assert( VRField & (VR::OB | VR::OW) );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
-    assert(0);
+    gdcm_assert(0);
   return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + 2*VRField.GetLength() + ValueLengthField;
     }
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.txx
@@ -44,7 +44,7 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !is.eof() ) // FIXME This should not be needed
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       }
     return is;
     }
@@ -54,14 +54,14 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     pe.SetLastElement( *this );
     throw pe;
     }
-  assert( TagField != Tag(0xfffe,0xe0dd) );
+  gdcm_assert( TagField != Tag(0xfffe,0xe0dd) );
 
   const Tag itemDelItem(0xfffe,0xe00d);
   if( TagField == itemDelItem )
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( ValueLengthField != 0 )
@@ -80,7 +80,7 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !VRField.Read(is) )
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       return is;
       }
     }
@@ -88,13 +88,13 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     {
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
     // gdcm-MR-PHILIPS-16-Multi-Seq.dcm
-    // assert( TagField == Tag(0xfffe, 0xe000) );
+    // gdcm_assert( TagField == Tag(0xfffe, 0xe000) );
     // -> For some reason VR is written as {44,0} well I guess this is a VR...
     // Technically there is a second bug, dcmtk assume other things when reading this tag,
     // so I need to change this tag too, if I ever want dcmtk to read this file. oh well
     // 0019004_Baseline_IMG1.dcm
     // -> VR is garbage also...
-    // assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
+    // gdcm_assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
     //gdcmWarningMacro( "Assuming 16 bits VR for Tag=" <<
     //  TagField << " in order to read a buggy DICOM file." );
     //VRField = VR::INVALID;
@@ -117,7 +117,7 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     }
@@ -126,7 +126,7 @@ std::istream &UNExplicitDataElement::ReadPreValue(std::istream &is)
     // 16bits only
     if( !ValueLengthField.template Read16<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     }
@@ -146,11 +146,11 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
 
   //std::cerr << "exp cur tag=" << TagField << " VR=" << VRField << " VL=" << ValueLengthField << std::endl;
   // Read the Value
-  //assert( ValueField == 0 );
+  //gdcm_assert( ValueField == 0 );
   if( VRField == VR::SQ )
     {
     // Check whether or not this is an undefined length sequence
-    assert( TagField != Tag(0x7fe0,0x0010) );
+    gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new SequenceOfItems;
     }
   else if( ValueLengthField.IsUndefined() )
@@ -161,7 +161,7 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
       // Enhanced_MR_Image_Storage_PixelSpacingNotIn_0028_0030.dcm (illegal)
       // vs
       // undefined_length_un_vr.dcm
-      assert( TagField != Tag(0x7fe0,0x0010) );
+      gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
       ValueField = new SequenceOfItems;
       ValueField->SetLength(ValueLengthField); // perform realloc
       try
@@ -169,7 +169,7 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
         //if( !ValueIO<UNExplicitDataElement,TSwap>::Read(is,*ValueField) ) // non cp246
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) ) // cp246 compliant
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       catch( std::exception &)
@@ -184,14 +184,14 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
     else
       {
       // Ok this is Pixel Data fragmented...
-      assert( TagField == Tag(0x7fe0,0x0010) );
-      assert( VRField & VR::OB_OW );
+      gdcm_assert( TagField == Tag(0x7fe0,0x0010) );
+      gdcm_assert( VRField & VR::OB_OW );
       ValueField = new SequenceOfFragments;
       }
     }
   else
     {
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
     }
   // We have the length we should be able to read the value
@@ -209,7 +209,7 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
     //we really need to read item marker
   )
     {
-    assert(0); // Could we possibly be so unlucky to have this mixture of bugs...
+    gdcm_assert(0); // Could we possibly be so unlucky to have this mixture of bugs...
     }
 
   if( !ValueIO<UNExplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) )

--- a/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitImplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitImplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL UNExplicitImplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -37,18 +37,18 @@ VL UNExplicitImplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & (VR::OB | VR::OW) );
+      gdcm_assert( VRField & (VR::OB | VR::OW) );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
-    assert(0);
+    gdcm_assert(0);
   return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + 2*VRField.GetLength() + ValueLengthField;
     }
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitImplicitDataElement.txx
@@ -37,7 +37,7 @@ std::istream &UNExplicitImplicitDataElement::Read(std::istream &is)
 template <typename TSwap>
 std::istream &UNExplicitImplicitDataElement::ReadPreValue(std::istream &is)
 {
-  assert(0);
+  gdcm_assert(0);
   //DataElement &de = *this;//unused de, fires a warning on macos
   //de.template ReadPreValue<UNExplicitDataElement,TSwap>( is );
   return is;

--- a/Source/DataStructureAndEncodingDefinition/gdcmVL.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVL.h
@@ -91,7 +91,7 @@ public:
     is.read((char*)(&copy), sizeof(uint16_t));
     TSwap::SwapArray(&copy,1);
     ValueLength = copy;
-    assert( ValueLength <=  65535 /*UINT16_MAX*/ ); // ?? doh !
+    gdcm_assert( ValueLength <=  65535 /*UINT16_MAX*/ ); // ?? doh !
     return is;
     }
 
@@ -110,7 +110,7 @@ public:
   template <typename TSwap>
   const std::ostream &Write16(std::ostream &os) const
     {
-    assert( ValueLength <=   65535 /*UINT16_MAX*/ );
+    gdcm_assert( ValueLength <=   65535 /*UINT16_MAX*/ );
     uint16_t copy = (uint16_t)ValueLength;
     if( IsOdd() )
       {

--- a/Source/DataStructureAndEncodingDefinition/gdcmVM.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVM.cxx
@@ -139,15 +139,15 @@ unsigned int VM::GetLength() const
     return 0;
   default:
     len = 0;
-    assert(0);
+    gdcm_assert(0);
     }
-  assert( len );
+  gdcm_assert( len );
   return len;
 }
 
 unsigned int VM::GetIndex(VMType vm)
 {
-  assert( vm <= VM_END );
+  gdcm_assert( vm <= VM_END );
   unsigned int l;
   switch(vm)
     {
@@ -225,8 +225,8 @@ unsigned int VM::GetIndex(VMType vm)
 const char *VM::GetVMString(VMType vm)
 {
   unsigned int idx = GetIndex(vm);
-  assert( idx < sizeof(VMStrings) / sizeof(VMStrings[0]) );
-  //assert( idx );
+  gdcm_assert( idx < sizeof(VMStrings) / sizeof(VMStrings[0]) );
+  //gdcm_assert( idx );
   return VMStrings[idx];
 }
 
@@ -250,7 +250,7 @@ VM::VMType VM::GetVMType(const char *vm)
 bool VM::IsValid(int vm1, VMType vm2)
 {
   bool r = false;
-  assert( vm1 >= 0 ); // Still need to check Part 3
+  gdcm_assert( vm1 >= 0 ); // Still need to check Part 3
   // If you update the VMType, you need to update this code. Hopefully a compiler is
   // able to tell when a case is missing
   switch(vm2)
@@ -313,7 +313,7 @@ bool VM::IsValid(int vm1, VMType vm2)
     r = (vm1 >= 3);
     break;
   default:
-    assert(0); // should not happen
+    gdcm_assert(0); // should not happen
     }
   return r;
 }
@@ -382,7 +382,7 @@ size_t VM::GetNumberOfElementsFromArray(const char *array, size_t length)
 bool VM::Compatible(VM const &vm) const
 {
   // make sure that vm is a numeric value
-  //assert( vm.VMField <= VM256 );
+  //gdcm_assert( vm.VMField <= VM256 );
   if ( VMField == VM::VM0 ) return false; // nothing was found in the dict
   if ( vm == VM::VM0 ) return true; // the user was not able to compute the vm from the empty bytevalue
   // let's start with the easy case:
@@ -431,7 +431,7 @@ bool VM::Compatible(VM const &vm) const
     }
   if( r )
     {
-    assert( VMField & vm.VMField );
+    gdcm_assert( VMField & vm.VMField );
     }
   return r;
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmVM.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVM.h
@@ -143,7 +143,7 @@ private:
 //-----------------------------------------------------------------------------
 inline std::ostream& operator<<(std::ostream& _os, const VM &_val)
 {
-  assert( VM::GetVMString(_val) );
+  gdcm_assert( VM::GetVMString(_val) );
   _os << VM::GetVMString(_val);
   return _os;
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR.cxx
@@ -260,7 +260,7 @@ unsigned int VR::GetSizeof() const
   default:
     size = 0;
     }
-  assert( size );
+  gdcm_assert( size );
   return size;
 }
 
@@ -268,7 +268,7 @@ unsigned int VR::GetIndex(VRType vr)
 {
   if( vr == VR::VL32 ) return 0;
   unsigned int l = 0;
-  assert( vr <= VR_END );
+  gdcm_assert( vr <= VR_END );
   switch(vr)
     {
   case INVALID:
@@ -310,13 +310,13 @@ const char *VR::GetVRStringFromFile(VRType vr)
 {
 #if 1
   static const int N = sizeof(VRValue) / sizeof(VRType);
-  assert( N == 35 );
+  gdcm_assert( N == 35 );
   static VRType *start = VRValue;
   static VRType *end   = VRValue+N;
   const VRType *p =
     std::lower_bound(start, end, vr);
-  assert( *p == vr );
-  assert( (p - start) == (long long)GetIndex(vr) );
+  gdcm_assert( *p == vr );
+  gdcm_assert( (p - start) == (long long)GetIndex(vr) );
   return VRStrings[p-start];
 #else
   const unsigned int idx = GetIndex(vr);
@@ -345,7 +345,7 @@ VR::VRType VR::GetVRTypeFromFile(const char *vr)
  */
 #if 0
   static const int N = sizeof(VRValue) / sizeof(VRType);
-  assert( N == 35 );
+  gdcm_assert( N == 35 );
   static const char **start = VRStrings+1;
   static const char **end   = VRStrings+N;
   //std::cerr << "VR=" << vr << std::endl;
@@ -364,9 +364,9 @@ VR::VRType VR::GetVRTypeFromFile(const char *vr)
       }
     return VR::INVALID;
     }
-  assert( (*p)[0] == vr[0] && (*p)[1] == vr[1] );
+  gdcm_assert( (*p)[0] == vr[0] && (*p)[1] == vr[1] );
   VRType r = VRValue[p-start+1];
-  assert( r == (VR::VRType)(1 << (p-start)) );
+  gdcm_assert( r == (VR::VRType)(1 << (p-start)) );
 #else // old version not optimized
   VRType r = VR::VR_END;
   for (int i = 1; VRStrings[i] != nullptr; i++)
@@ -394,7 +394,7 @@ VR::VRType VR::GetVRTypeFromFile(const char *vr)
     }
 #endif
   // postcondition
-  assert( r != VR::INVALID
+  gdcm_assert( r != VR::INVALID
        && r != VR::OB_OW
        && r != VR::US_SS
        && r != VR::US_SS_OW
@@ -429,10 +429,10 @@ VR::VRType VR::GetVRType(const char *vr)
         r = US_OW;
         break;
       case 39:
-        r = VR_END; assert(0);
+        r = VR_END; gdcm_assert(0);
         break;
       default:
-        assert( vr[2] == 0 );
+        gdcm_assert( vr[2] == 0 );
         r = (VR::VRType)(1LL << (i-1));
         }
       break; // found one value, we can exit the for loop
@@ -449,7 +449,7 @@ bool VR::IsValid(const char *vr)
     // Use lazy evaluation instead of strncmp
     if (ref[0] == vr[0] && ref[1] == vr[1] )
       {
-      assert( i < 35 ); // FIXME
+      gdcm_assert( i < 35 ); // FIXME
       return true;
       }
     }
@@ -458,19 +458,19 @@ bool VR::IsValid(const char *vr)
 
 bool VR::IsValid(const char *vr1, VRType vr2)
 {
-  assert( strlen(vr1) == 2 );
+  gdcm_assert( strlen(vr1) == 2 );
   VR::VRType vr = GetVRType(vr1);
   return ((vr & vr2) != 0 ? true : false);
 }
 
 bool VR::IsSwap(const char *vr)
 {
-  assert( vr[2] == '\0' );
+  gdcm_assert( vr[2] == '\0' );
   char vr_swap[3];
   vr_swap[0] = vr[1];
   vr_swap[1] = vr[0];
   vr_swap[2] = '\0';
-  assert( GetVRType(vr_swap) != SS );
+  gdcm_assert( GetVRType(vr_swap) != SS );
   return GetVRType(vr_swap) != VR_END;
 }
 
@@ -516,20 +516,20 @@ VRTemplateCase(UV,rep)
 
 bool VR::IsASCII(VRType vr)
 {
-  //assert( vr != VR::INVALID );
+  //gdcm_assert( vr != VR::INVALID );
   switch(vr)
     {
     VRTemplate(VRASCII)
   default:
       // 1.3.12.2.1107.5.1.4.54035.30000005100516290423400005768-no-phi.dcm has a VR=RT
-      //assert(0);
+      //gdcm_assert(0);
       return false;
     }
 }
 
 bool VR::IsASCII2(VRType vr)
 {
-  assert( vr != VR::INVALID );
+  gdcm_assert( vr != VR::INVALID );
   return
     vr == AE ||
     vr == AS ||
@@ -549,7 +549,7 @@ bool VR::IsASCII2(VRType vr)
 
 bool VR::IsBinary(VRType vr)
 {
-  //assert( vr != VR::INVALID );
+  //gdcm_assert( vr != VR::INVALID );
   switch(vr)
     {
     VRTemplate(VRBINARY)
@@ -562,14 +562,14 @@ bool VR::IsBinary(VRType vr)
     return true;
   default:
       // 1.3.12.2.1107.5.1.4.54035.30000005100516290423400005768-no-phi.dcm has a VR=RT
-      //assert(0);
+      //gdcm_assert(0);
       return false;
     }
 }
 
 bool VR::IsBinary2(VRType vr)
 {
-  //assert( vr != OF );
+  //gdcm_assert( vr != OF );
   return
     vr == OB ||
     vr == OW ||

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR.h
@@ -158,7 +158,7 @@ public:
     char vr[2];
     is.read(vr, 2);
     VRField = GetVRTypeFromFile(vr);
-    assert( VRField != VR::VR_END );
+    gdcm_assert( VRField != VR::VR_END );
     if( VRField == VR::INVALID )
     {
       // \0\2 Data/TheralysGDCM120Bug.dcm
@@ -199,8 +199,8 @@ public:
       //vrfield = VR::UN;
       }
     const char *vr = GetVRString(vrfield);
-    //assert( strlen( vr ) == 2 );
-    assert( vr[0] && vr[1] && vr[2] == 0 );
+    //gdcm_assert( strlen( vr ) == 2 );
+    gdcm_assert( vr[0] && vr[1] && vr[2] == 0 );
     os.write(vr, 2);
     // See PS 3.5, Data Element Structure With Explicit VR
     if( vrfield & VL32 )
@@ -369,7 +369,7 @@ inline unsigned int VR::GetSize() const
     case VR::VRALL:
     case VR::VR_END:
     default:
-       assert( 0 && "should not" );
+       gdcm_assert( 0 && "should not" );
   }
   return 0;
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.cxx
@@ -24,7 +24,7 @@ VL VR16ExplicitDataElement::GetLength() const
 {
   if( ValueLengthField.IsUndefined() )
     {
-    assert( ValueField->GetLength().IsUndefined() );
+    gdcm_assert( ValueField->GetLength().IsUndefined() );
     Value *p = ValueField;
     // If this is a SQ we need to compute it's proper length
     SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(p);
@@ -37,18 +37,18 @@ VL VR16ExplicitDataElement::GetLength() const
     SequenceOfFragments *sf = dynamic_cast<SequenceOfFragments*>(p);
     if( sf )
       {
-      assert( VRField & (VR::OB | VR::OW) );
+      gdcm_assert( VRField & (VR::OB | VR::OW) );
       return TagField.GetLength() + VRField.GetLength()
         + ValueLengthField.GetLength() + sf->ComputeLength();
       }
-    assert(0);
+    gdcm_assert(0);
   return 0;
     }
   else
     {
     // Each time VR::GetLength() is 2 then Value Length is coded in 2
     //                              4 then Value Length is coded in 4
-    assert( !ValueField || ValueField->GetLength() == ValueLengthField );
+    gdcm_assert( !ValueField || ValueField->GetLength() == ValueLengthField );
     return TagField.GetLength() + 2*VRField.GetLength() + ValueLengthField;
     }
 }

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.txx
@@ -43,20 +43,20 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !is.eof() ) // FIXME This should not be needed
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       }
     return is;
     }
-  assert( TagField != Tag(0xfffe,0xe0dd) );
-  //assert( TagField != Tag(0xfeff,0xdde0) );
+  gdcm_assert( TagField != Tag(0xfffe,0xe0dd) );
+  //gdcm_assert( TagField != Tag(0xfeff,0xdde0) );
   const Tag itemDelItem(0xfffe,0xe00d);
   const Tag itemStartItem(0xfffe,0x0000);
-  assert( TagField != itemStartItem );
+  gdcm_assert( TagField != itemStartItem );
   if( TagField == itemDelItem )
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( ValueLengthField )
@@ -72,7 +72,7 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
   if( TagField == Tag(0x00ff, 0x4aa5) )
     {
-    assert(0 && "Should not happen" );
+    gdcm_assert(0 && "Should not happen" );
     //  char c;
     //  is.read(&c, 1);
     //  std::cerr << "Debug: " << c << std::endl;
@@ -87,7 +87,7 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !VRField.Read(is) )
       {
-      assert(0 && "Should not happen" );
+      gdcm_assert(0 && "Should not happen" );
       return is;
       }
     }
@@ -107,14 +107,14 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
     // so I need to change this tag too, if I ever want dcmtk to read this file. oh well
     // 0019004_Baseline_IMG1.dcm
     // -> VR is garbage also...
-    // assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
+    // gdcm_assert( TagField == Tag(8348,0339) || TagField == Tag(b5e8,0338))
     if( TagField == Tag(0x7fe0,0x0010) )
       {
       OX_hack = true;
       VRField = VR::UN; // make it a fake 32bits for now...
       char dummy[2];
       is.read(dummy,2);
-      assert( dummy[0] == 0 && dummy[1] == 0 );
+      gdcm_assert( dummy[0] == 0 && dummy[1] == 0 );
       gdcmWarningMacro( "Assuming 32 bits VR for Tag=" <<
         TagField << " in order to read a buggy DICOM file." );
       }
@@ -129,7 +129,7 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
     {
     if( !ValueLengthField.Read<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
     if( OX_hack )
@@ -139,11 +139,11 @@ std::istream &VR16ExplicitDataElement::ReadPreValue(std::istream &is)
     }
   else
     {
-    assert( OX_hack == false );
+    gdcm_assert( OX_hack == false );
     // 16bits only
     if( !ValueLengthField.template Read16<TSwap>(is) )
       {
-      assert(0 && "Should not happen");
+      gdcm_assert(0 && "Should not happen");
       return is;
       }
 #ifdef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
@@ -185,11 +185,11 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
     }
 
   // Read the Value
-  //assert( ValueField == 0 );
+  //gdcm_assert( ValueField == 0 );
   if( VRField == VR::SQ )
     {
     // Check whether or not this is an undefined length sequence
-    assert( TagField != Tag(0x7fe0,0x0010) );
+    gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new SequenceOfItems;
     }
   else if( ValueLengthField.IsUndefined() )
@@ -200,7 +200,7 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
       // Enhanced_MR_Image_Storage_PixelSpacingNotIn_0028_0030.dcm (illegal)
       // vs
       // undefined_length_un_vr.dcm
-      assert( TagField != Tag(0x7fe0,0x0010) );
+      gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
       ValueField = new SequenceOfItems;
       ValueField->SetLength(ValueLengthField); // perform realloc
       try
@@ -208,7 +208,7 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
         //if( !ValueIO<VR16ExplicitDataElement,TSwap>::Read(is,*ValueField) ) // non cp246
         if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,readvalues) ) // cp246 compliant
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       catch( std::exception &)
@@ -232,14 +232,14 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
         throw pe;
         }
       // Ok this is Pixel Data fragmented...
-      assert( TagField == Tag(0x7fe0,0x0010) );
-      assert( VRField & VR::OB_OW );
+      gdcm_assert( TagField == Tag(0x7fe0,0x0010) );
+      gdcm_assert( VRField & VR::OB_OW );
       ValueField = new SequenceOfFragments;
       }
     }
   else
     {
-    //assert( TagField != Tag(0x7fe0,0x0010) );
+    //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
     }
   // We have the length we should be able to read the value
@@ -258,17 +258,17 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
   )
     {
     gdcmWarningMacro( "ByteSwaping Private SQ: " << TagField );
-    assert( VRField == VR::SQ );
-    assert( TagField.IsPrivate() );
+    gdcm_assert( VRField == VR::SQ );
+    gdcm_assert( TagField.IsPrivate() );
     try
       {
       if( !ValueIO<VR16ExplicitDataElement,SwapperDoOp>::Read(is,*ValueField,readvalues) )
         {
-        assert(0 && "Should not happen");
+        gdcm_assert(0 && "Should not happen");
         }
       Value* v = &*ValueField;
       SequenceOfItems *sq = dynamic_cast<SequenceOfItems*>(v);
-      assert( sq );
+      gdcm_assert( sq );
       SequenceOfItems::Iterator it = sq->Begin();
       for( ; it != sq->End(); ++it)
         {

--- a/Source/DataStructureAndEncodingDefinition/gdcmValueIO.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmValueIO.txx
@@ -42,7 +42,7 @@ namespace gdcm_ns
       }
     else
       {
-      assert( 0 && "error" );
+      gdcm_assert( 0 && "error" );
       }
     return is;
   }
@@ -57,7 +57,7 @@ namespace gdcm_ns
     else if( const SequenceOfItems *si = dynamic_cast<const SequenceOfItems*>(v) )
       {
       //VL dummy = si->ComputeLength<DE>();
-      //assert( /*dummy.IsUndefined() ||*/ dummy == si->GetLength() );
+      //gdcm_assert( /*dummy.IsUndefined() ||*/ dummy == si->GetLength() );
       si->template Write<DE,TSwap>(os);
       }
     else if( const SequenceOfFragments *sf = dynamic_cast<const SequenceOfFragments*>(v) )
@@ -66,7 +66,7 @@ namespace gdcm_ns
       }
     else
       {
-      assert( 0 && "error" );
+      gdcm_assert( 0 && "error" );
       }
     return os;
   }

--- a/Source/DataStructureAndEncodingDefinition/gdcmWriter.cxx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmWriter.cxx
@@ -99,7 +99,7 @@ bool Writer::Write()
     //gzostream gzos(os.rdbuf());
       try {
       zlib_stream::zip_ostream gzos( os );
-      assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
+      gdcm_assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
       DS.Write<ExplicitDataElement,SwapperNoOp>(gzos);
       //gzos.flush();
       } catch (...){
@@ -122,7 +122,7 @@ bool Writer::Write()
         }
       else
         {
-        assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
+        gdcm_assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
         DS.Write<ExplicitDataElement,SwapperDoOp>(os);
         }
       }
@@ -134,7 +134,7 @@ bool Writer::Write()
         }
       else
         {
-        assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
+        gdcm_assert( ts.GetNegociatedType() == TransferSyntax::Explicit );
         DS.Write<ExplicitDataElement,SwapperNoOp>(os);
         }
       }
@@ -181,8 +181,8 @@ void Writer::SetFileName(const char *utf8path)
 #else
       Ofstream->open(utf8path, std::ios::out | std::ios::binary);
 #endif
-      assert(Ofstream->is_open());
-      assert(!Ofstream->fail());
+      gdcm_assert(Ofstream->is_open());
+      gdcm_assert(!Ofstream->fail());
     }
     //std::cerr << Stream.is_open() << std::endl;
     Stream = Ofstream;

--- a/Source/InformationObjectDefinition/gdcmDefs.cxx
+++ b/Source/InformationObjectDefinition/gdcmDefs.cxx
@@ -49,7 +49,7 @@ void Defs::LoadDefaults()
 
 void Defs::LoadFromFile(const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   TableReader tr(*this);
   tr.SetFilename(filename);
   tr.Read();

--- a/Source/InformationObjectDefinition/gdcmIODEntry.cxx
+++ b/Source/InformationObjectDefinition/gdcmIODEntry.cxx
@@ -20,7 +20,7 @@ namespace gdcm
 
 Usage::UsageType IODEntry::GetUsageType() const
 {
-  assert( !usage.empty() );
+  gdcm_assert( !usage.empty() );
   if( usage == "M" )
     {
     return Usage::Mandatory;
@@ -42,7 +42,7 @@ Usage::UsageType IODEntry::GetUsageType() const
     return Usage::Conditional;
     }
   //else
-  assert(0); // Keep me so that I can debug Part3.xml
+  gdcm_assert(0); // Keep me so that I can debug Part3.xml
   return Usage::Invalid;
 }
 

--- a/Source/InformationObjectDefinition/gdcmIODs.h
+++ b/Source/InformationObjectDefinition/gdcmIODs.h
@@ -46,8 +46,8 @@ public:
     {
     //return IODsInternal[name];
     IODMapType::const_iterator it = IODsInternal.find( name );
-    assert( it != IODsInternal.end() );
-    assert( it->first == name );
+    gdcm_assert( it != IODsInternal.end() );
+    gdcm_assert( it->first == name );
     return it->second;
     }
 

--- a/Source/InformationObjectDefinition/gdcmMacro.cxx
+++ b/Source/InformationObjectDefinition/gdcmMacro.cxx
@@ -37,7 +37,7 @@ const MacroEntry& Macro::GetMacroEntry(const Tag &tag) const
   MapModuleEntry::const_iterator it = ModuleInternal.find(tag);
   if( it != ModuleInternal.end() )
     {
-    assert( it->first == tag );
+    gdcm_assert( it->first == tag );
     return it->second;
     }
   // Not found anywhere :(

--- a/Source/InformationObjectDefinition/gdcmMacros.h
+++ b/Source/InformationObjectDefinition/gdcmMacros.h
@@ -39,17 +39,17 @@ public:
   // A Module is inserted based on it's ref
   void AddMacro(const char *ref, const Macro & module )
     {
-    assert( ref && *ref );
-    assert( ModulesInternal.find( ref ) == ModulesInternal.end() );
+    gdcm_assert( ref && *ref );
+    gdcm_assert( ModulesInternal.find( ref ) == ModulesInternal.end() );
     ModulesInternal.insert(
       ModuleMapType::value_type(ref, module));
     }
   const Macro &GetMacro(const char *name) const
     {
-    assert( name && *name );
+    gdcm_assert( name && *name );
     ModuleMapType::const_iterator it = ModulesInternal.find( name );
-    assert( it != ModulesInternal.end() );
-    assert( it->first == name );
+    gdcm_assert( it != ModulesInternal.end() );
+    gdcm_assert( it->first == name );
     return it->second;
     }
 

--- a/Source/InformationObjectDefinition/gdcmModule.cxx
+++ b/Source/InformationObjectDefinition/gdcmModule.cxx
@@ -59,7 +59,7 @@ const ModuleEntry& Module::GetModuleEntryInMacros(Macros const &macros, const Ta
   MapModuleEntry::const_iterator it = ModuleInternal.find(tag);
   if( it != ModuleInternal.end() )
     {
-    assert( it->first == tag );
+    gdcm_assert( it->first == tag );
     return it->second;
     }
   // Need to search within Nested-Included Macro:

--- a/Source/InformationObjectDefinition/gdcmModules.h
+++ b/Source/InformationObjectDefinition/gdcmModules.h
@@ -39,17 +39,17 @@ public:
   // A Module is inserted based on it's ref
   void AddModule(const char *ref, const Module & module )
     {
-    assert( ref && *ref );
-    assert( ModulesInternal.find( ref ) == ModulesInternal.end() );
+    gdcm_assert( ref && *ref );
+    gdcm_assert( ModulesInternal.find( ref ) == ModulesInternal.end() );
     ModulesInternal.insert(
       ModuleMapType::value_type(ref, module));
     }
   const Module &GetModule(const char *name) const
     {
-    assert( name && *name );
+    gdcm_assert( name && *name );
     ModuleMapType::const_iterator it = ModulesInternal.find( name );
-    assert( it != ModulesInternal.end() );
-    assert( it->first == name );
+    gdcm_assert( it != ModulesInternal.end() );
+    gdcm_assert( it->first == name );
     return it->second;
     }
 

--- a/Source/InformationObjectDefinition/gdcmTable.h
+++ b/Source/InformationObjectDefinition/gdcmTable.h
@@ -43,7 +43,7 @@ public:
 #endif
     TableInternal.insert(
       MapTableEntry::value_type(tag, te));
-    assert( s < TableInternal.size() );
+    gdcm_assert( s < TableInternal.size() );
     }
 
   const TableEntry &GetTableEntry(const Tag &tag) const
@@ -52,7 +52,7 @@ public:
       TableInternal.find(tag);
     if (it == TableInternal.end())
       {
-      assert( 0 && "Impossible" );
+      gdcm_assert( 0 && "Impossible" );
       return GetTableEntry(Tag(0,0));
       }
     return it->second;

--- a/Source/InformationObjectDefinition/gdcmTableReader.cxx
+++ b/Source/InformationObjectDefinition/gdcmTableReader.cxx
@@ -70,29 +70,29 @@ static void XMLCALL characterDataHandler(void* userData, const char* data,
 void TableReader::HandleMacroEntryDescription(const char **atts)
 {
   (void)atts;
-  assert( ParsingMacroEntryDescription == false );
+  gdcm_assert( ParsingMacroEntryDescription == false );
   ParsingMacroEntryDescription = true;
-  assert( *atts == nullptr );
-  assert( Description.empty() );
+  gdcm_assert( *atts == nullptr );
+  gdcm_assert( Description.empty() );
 }
 
 void TableReader::HandleModuleInclude(const char **atts)
 {
   const char *ref = *atts;
-  assert( strcmp(ref, "ref") == 0 );
+  gdcm_assert( strcmp(ref, "ref") == 0 );
   (void)ref; //removing warning
   const char *include = *(atts+1);
   CurrentModule.AddMacro( include );
-  //assert( *(atts+2) == 0 ); // description ?
+  //gdcm_assert( *(atts+2) == 0 ); // description ?
 }
 
 void TableReader::HandleModuleEntryDescription(const char **atts)
 {
   (void)atts;
-  assert( ParsingModuleEntryDescription == false );
+  gdcm_assert( ParsingModuleEntryDescription == false );
   ParsingModuleEntryDescription = true;
-  assert( *atts == nullptr );
-  assert( Description.empty() );
+  gdcm_assert( *atts == nullptr );
+  gdcm_assert( Description.empty() );
 }
 
 void TableReader::HandleMacroEntry(const char **atts)
@@ -111,8 +111,8 @@ void TableReader::HandleMacroEntry(const char **atts)
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
       (void)r; //removing warning
       tag.SetGroup( (uint16_t)v );
       }
@@ -121,8 +121,8 @@ void TableReader::HandleMacroEntry(const char **atts)
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
       (void)r; //removing warning
       tag.SetElement( (uint16_t)v );
       }
@@ -138,7 +138,7 @@ void TableReader::HandleMacroEntry(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     ++current;
     ++current;
@@ -161,8 +161,8 @@ void TableReader::HandleModuleEntry(const char **atts)
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
       (void)r; //removing warning
       tag.SetGroup( (uint16_t)v );
       }
@@ -171,8 +171,8 @@ void TableReader::HandleModuleEntry(const char **atts)
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
       (void)r; //removing warning
       tag.SetElement( (uint16_t)v );
       }
@@ -188,7 +188,7 @@ void TableReader::HandleModuleEntry(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     ++current;
     ++current;
@@ -230,7 +230,7 @@ void TableReader::HandleIODEntry(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     ++current;
     ++current;
@@ -270,7 +270,7 @@ void TableReader::HandleModule(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     ++current;
     ++current;
@@ -334,7 +334,7 @@ void TableReader::StartElement(const char *name, const char **atts)
       }
     else /*if( ParsingIODoEntry )*/
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
   else if( strcmp(name, "section" ) == 0 )
@@ -400,7 +400,7 @@ void TableReader::StartElement(const char *name, const char **atts)
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -467,13 +467,13 @@ void TableReader::EndElement(const char *name)
     else if( ParsingMacroEntry )
       {
       ParsingMacroEntryDescription = false;
-      //assert( !Description.empty() );
+      //gdcm_assert( !Description.empty() );
       CurrentMacroEntry.SetDescription( Description.c_str() );
       Description = "";
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
   else if( strcmp(name, "mapping" ) == 0 )
@@ -543,12 +543,12 @@ void TableReader::EndElement(const char *name)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -557,18 +557,18 @@ void TableReader::CharacterDataHandler(const char *data, int length)
   if( ParsingModuleEntryDescription )
     {
     std::string name( data, length);
-    assert( (unsigned int)length == strlen( name.c_str() ) );
+    gdcm_assert( (unsigned int)length == strlen( name.c_str() ) );
     Description.append( name );
     }
   else if( ParsingMacroEntryDescription )
     {
     std::string name( data, length);
-    assert( (unsigned int)length == strlen( name.c_str() ) );
+    gdcm_assert( (unsigned int)length == strlen( name.c_str() ) );
     Description.append( name );
     }
   else
     {
-    //assert(0);
+    //gdcm_assert(0);
     }
 }
 

--- a/Source/InformationObjectDefinition/gdcmXMLDictReader.cxx
+++ b/Source/InformationObjectDefinition/gdcmXMLDictReader.cxx
@@ -26,10 +26,10 @@ XMLDictReader::XMLDictReader():ParsingDescription(false),Description()
 
 void XMLDictReader::HandleEntry(const char **atts)
 {
-  assert( !ParsingDescription );
+  gdcm_assert( !ParsingDescription );
   VR vr;
   VM vm;
-  assert( vm == VM::VM0 );
+  gdcm_assert( vm == VM::VM0 );
   std::string name;
   bool ret;
 
@@ -51,25 +51,25 @@ void XMLDictReader::HandleEntry(const char **atts)
 
   while(*current /*&& current+1*/)
     {
-    assert( *(current + 1) );
+    gdcm_assert( *(current + 1) );
     if( group == *current )
       {
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
 
       char sv[4+1];
       r = snprintf(sv, sizeof(sv), "%04x", v);
-      assert( r == 4 );
+      gdcm_assert( r == 4 );
       if( strncmp(raw, sv, 4) == 0 ) // GroupXX
         {
         tag.SetGroup( v );
         }
       else
         {
-        assert( (raw[0] == '5' && raw[1] == '0') || (raw[0] == '6' && raw[1] == '0') );
+        gdcm_assert( (raw[0] == '5' && raw[1] == '0') || (raw[0] == '6' && raw[1] == '0') );
         if( raw[0] == '5' ) tag.SetGroup( 0x5000 );
         if( raw[0] == '6' ) tag.SetGroup( 0x6000 );
         CurrentDE.SetGroupXX( true );
@@ -80,19 +80,19 @@ void XMLDictReader::HandleEntry(const char **atts)
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
 
       char sv[4+1];
       r = snprintf(sv, sizeof(sv), "%04x", v);
-      assert( r == 4 );
+      gdcm_assert( r == 4 );
       if( strncmp(raw, sv, 4) == 0 )
         {
         tag.SetElement( v );
         }
       else
         {
-        assert( raw[0] == '3' && raw[1] == '1' );
+        gdcm_assert( raw[0] == '3' && raw[1] == '1' );
         tag.SetElement( 0x3100 );
         CurrentDE.SetElementXX( true );
         }
@@ -100,14 +100,14 @@ void XMLDictReader::HandleEntry(const char **atts)
     else if( strvr == *current )
       {
       vr = VR::GetVRTypeFromFile( *(current + 1) );
-      //assert( vr != VR::INVALID );
+      //gdcm_assert( vr != VR::INVALID );
       }
     else if( strvm == *current )
       {
       vm = VM::GetVMType( *(current + 1) );
-      //assert( *(current+1) != '\0' );
-      //assert( vm != VM::VM0 );
-      //assert( vm != VM::VM_END );
+      //gdcm_assert( *(current+1) != '\0' );
+      //gdcm_assert( vm != VM::VM0 );
+      //gdcm_assert( vm != VM::VM_END );
       }
     else if( retired == *current )
       {
@@ -121,7 +121,7 @@ void XMLDictReader::HandleEntry(const char **atts)
         }
       else
         {
-        assert(0);
+        gdcm_assert(0);
         }
       }
     else if( version == *current )
@@ -134,7 +134,7 @@ void XMLDictReader::HandleEntry(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     // goes on to the next attribute (need to skip value)
     ++current;
@@ -146,9 +146,9 @@ void XMLDictReader::HandleEntry(const char **atts)
 
 void XMLDictReader::HandleDescription(const char **atts)
 {
-  assert( ParsingDescription );
-  assert( *atts == NULL );
-  assert( Description == "" );
+  gdcm_assert( ParsingDescription );
+  gdcm_assert( *atts == NULL );
+  gdcm_assert( Description == "" );
 #if 0
   DictEntry &de = CurrentDE;
 
@@ -156,7 +156,7 @@ void XMLDictReader::HandleDescription(const char **atts)
   std::string description;
   while(*current /*&& current+1*/)
     {
-    assert( *(current + 1) );
+    gdcm_assert( *(current + 1) );
     ++current;
     }
   // Done !
@@ -188,7 +188,7 @@ void XMLDictReader::StartElement(const char *name, const char **atts)
   else
     {
     std::cerr << name << std::endl;
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -204,7 +204,7 @@ void XMLDictReader::EndElement(const char *name)
     }
   else if( description == name )
     {
-    assert( ParsingDescription );
+    gdcm_assert( ParsingDescription );
     ParsingDescription = false;
 
     // TODO: do something with description ??
@@ -215,7 +215,7 @@ void XMLDictReader::EndElement(const char *name)
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -224,7 +224,7 @@ void XMLDictReader::CharacterDataHandler(const char *data, int length)
   if( ParsingDescription )
     {
     std::string name( data, length);
-    assert( length == strlen( name.c_str() ) );
+    gdcm_assert( length == strlen( name.c_str() ) );
     Description.append( name );
     }
 }

--- a/Source/InformationObjectDefinition/gdcmXMLPrivateDictReader.cxx
+++ b/Source/InformationObjectDefinition/gdcmXMLPrivateDictReader.cxx
@@ -26,7 +26,7 @@ XMLPrivateDictReader::XMLPrivateDictReader():ParsingDescription(false),Descripti
 
 void XMLPrivateDictReader::HandleEntry(const char **atts)
 {
-  assert( !ParsingDescription );
+  gdcm_assert( !ParsingDescription );
   std::string name;
   std::string owner;
   VR vr;
@@ -52,37 +52,37 @@ void XMLPrivateDictReader::HandleEntry(const char **atts)
 
   while(*current /*&& current+1*/)
     {
-    assert( *(current + 1) );
+    gdcm_assert( *(current + 1) );
     if( group == *current )
       {
       unsigned int v;
       const char *raw = *(current+1);
       int r = sscanf(raw, "%04x", &v);
-      assert( r == 1 );
-      assert( v <= 0xFFFF );
+      gdcm_assert( r == 1 );
+      gdcm_assert( v <= 0xFFFF );
 
       char sv[4+1];
       r = snprintf(sv, sizeof(sv), "%04x", v);
-      assert( r == 4 );
+      gdcm_assert( r == 4 );
       if( strncmp(raw, sv, 4) == 0 ) // GroupXX
         {
         tag.SetGroup( v );
         }
       else
         {
-        assert( (raw[0] == '5' && raw[1] == '0') || (raw[0] == '6' && raw[1] == '0') ||
+        gdcm_assert( (raw[0] == '5' && raw[1] == '0') || (raw[0] == '6' && raw[1] == '0') ||
           (raw[0] == '7' && raw[1] == '0') );
         if( raw[0] == '5' ) tag.SetGroup( 0x5000 );
         else if( raw[0] == '6' ) tag.SetGroup( 0x6000 );
         else if( raw[0] == '7' ) tag.SetGroup( 0x7000 );
-        else assert(0);
+        else gdcm_assert(0);
         CurrentDE.SetGroupXX( true );
         }
       }
     else if( element == *current )
       {
       const char *raw = *(current+1);
-      assert( (raw[0] == 'x' && raw[1] == 'x' )
+      gdcm_assert( (raw[0] == 'x' && raw[1] == 'x' )
            || (raw[2] == 'x' && raw[3] == 'x') );
       if (raw[2] == 'x' && raw[3] == 'x')
         {
@@ -98,40 +98,40 @@ void XMLPrivateDictReader::HandleEntry(const char **atts)
           }
         else
           {
-          assert(0); // FIXME
+          gdcm_assert(0); // FIXME
           }
         }
       else
         {
         unsigned int v;
         int r = sscanf(raw+2, "%02x", &v);
-        assert( r == 1 );
-        assert( v <= 0xFF );
+        gdcm_assert( r == 1 );
+        gdcm_assert( v <= 0xFF );
 
         char sv[4+1];
         r = snprintf(sv, sizeof(sv), "xx%02x", v);
-        assert( r == 4 );
+        gdcm_assert( r == 4 );
         if( strncmp(raw, sv, 4) == 0 )
           {
           tag.SetElement( v );
           }
         else
           {
-          assert(0);
+          gdcm_assert(0);
           }
         }
       }
     else if( strvr == *current )
       {
       vr = VR::GetVRTypeFromFile( *(current + 1) );
-      //assert( vr != VR::INVALID );
+      //gdcm_assert( vr != VR::INVALID );
       }
     else if( strvm == *current )
       {
       vm = VM::GetVMType( *(current + 1) );
-      //assert( *(current+1) != '\0' );
-      //assert( vm != VM::VM0 );
-      //assert( vm != VM::VM_END );
+      //gdcm_assert( *(current+1) != '\0' );
+      //gdcm_assert( vm != VM::VM0 );
+      //gdcm_assert( vm != VM::VM_END );
       }
     else if( retired == *current )
       {
@@ -145,7 +145,7 @@ void XMLPrivateDictReader::HandleEntry(const char **atts)
         }
       else
         {
-        assert(0);
+        gdcm_assert(0);
         }
       }
     else if( version == *current )
@@ -162,7 +162,7 @@ void XMLPrivateDictReader::HandleEntry(const char **atts)
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     // goes on to the next attribute (need to skip value)
     ++current;
@@ -175,9 +175,9 @@ void XMLPrivateDictReader::HandleEntry(const char **atts)
 
 void XMLPrivateDictReader::HandleDescription(const char **atts)
 {
-  assert( ParsingDescription );
-  assert( *atts == NULL );
-  assert( Description == "" );
+  gdcm_assert( ParsingDescription );
+  gdcm_assert( *atts == NULL );
+  gdcm_assert( Description == "" );
 #if 0
   DictEntry &de = CurrentDE;
 
@@ -185,7 +185,7 @@ void XMLPrivateDictReader::HandleDescription(const char **atts)
   std::string description;
   while(*current /*&& current+1*/)
     {
-    assert( *(current + 1) );
+    gdcm_assert( *(current + 1) );
     ++current;
     }
   // Done !
@@ -217,7 +217,7 @@ void XMLPrivateDictReader::StartElement(const char *name, const char **atts)
   else
     {
     std::cerr << name << std::endl;
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -233,7 +233,7 @@ void XMLPrivateDictReader::EndElement(const char *name)
     }
   else if( description == name )
     {
-    assert( ParsingDescription );
+    gdcm_assert( ParsingDescription );
     ParsingDescription = false;
 
     // TODO: do something with description ??
@@ -246,7 +246,7 @@ void XMLPrivateDictReader::EndElement(const char *name)
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -255,7 +255,7 @@ void XMLPrivateDictReader::CharacterDataHandler(const char *data, int length)
   if( ParsingDescription )
     {
     std::string name( data, length);
-    assert( length == strlen( name.c_str() ) );
+    gdcm_assert( length == strlen( name.c_str() ) );
     Description.append( name );
     }
 }

--- a/Source/MediaStorageAndFileFormat/gdcmAnonymizer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmAnonymizer.cxx
@@ -210,7 +210,7 @@ bool Anonymizer::Replace( Tag const &t, const char *value, VL const & vl )
   else
     {
     // Ok this is a public element
-    assert( t.IsPublic() || t.IsPrivateCreator() );
+    gdcm_assert( t.IsPublic() || t.IsPrivateCreator() );
     const DictEntry &dictentry = dicts.GetDictEntry(t);
     if ( dictentry.GetVR() == VR::INVALID
       || dictentry.GetVR() == VR::UN
@@ -275,7 +275,7 @@ bool Anonymizer::Replace( Tag const &t, const char *value, VL const & vl )
     else
       {
       // vr from dict seems to be ascii, so it seems reasonable to write a ByteValue here:
-      assert( dictentry.GetVR() & VR::VRASCII );
+      gdcm_assert( dictentry.GetVR() & VR::VRASCII );
       if( value )
         {
         std::string padded( value, vl );
@@ -343,18 +343,18 @@ bool Anonymizer::Replace( PrivateTag const &pt, const char *value, VL const & vl
         needcreator = false;
         found = true;
       } else {
-        assert( start.GetElement() != 0xff );
+        gdcm_assert( start.GetElement() != 0xff );
         start.SetElement( start.GetElement() + 1 );
       }
     } while ( !found );
-    assert( start.GetGroup() == pt.GetGroup() );
+    gdcm_assert( start.GetGroup() == pt.GetGroup() );
     if(needcreator)
     {
       // add private creator:
       Element<VR::LO,VM::VM1> priv_creator;
       priv_creator.SetValue( pt.GetOwner() );
       DataElement creator = priv_creator.GetAsDataElement();
-      assert( start.GetElement() <= 0xff );
+      gdcm_assert( start.GetElement() <= 0xff );
       start.SetElement( start.GetElement() );
       creator.SetTag( start );
       ds.Insert(creator);
@@ -365,14 +365,14 @@ bool Anonymizer::Replace( PrivateTag const &pt, const char *value, VL const & vl
     const DictEntry &dictentry = dicts.GetDictEntry(pt);
     DataElement fake;
     Tag privateLocation(pt);
-    assert( pt.GetElement() <= 0xff );
+    gdcm_assert( pt.GetElement() <= 0xff );
     privateLocation.SetElement( start.GetElement() << 8 | pt.GetElement() );
-    assert( start == privateLocation.GetPrivateCreator() );
+    gdcm_assert( start == privateLocation.GetPrivateCreator() );
     fake.SetTag( privateLocation );
     fake.SetVR( dictentry.GetVR() );
     ds.Insert( fake );
 
-    assert(ds.FindDataElement(pt));
+    gdcm_assert(ds.FindDataElement(pt));
     return Replace( privateLocation, value, vl );
     }
 }
@@ -701,7 +701,7 @@ bool Anonymizer::BasicApplicationLevelConfidentialityProfile1()
           }
         else
           {
-          assert( de == encryptedds.GetDataElement( de.GetTag() ) );
+          gdcm_assert( de == encryptedds.GetDataElement( de.GetTag() ) );
           }
         }
       }
@@ -741,7 +741,7 @@ bool Anonymizer::BasicApplicationLevelConfidentialityProfile1()
     gdcmErrorMacro( "Problem with Encrypt" );
     return false;
   }
-  assert( encrypted_len <= encrypted_len2 );
+  gdcm_assert( encrypted_len <= encrypted_len2 );
   (void)encrypted_len2;//warning removal
 
     {
@@ -896,11 +896,11 @@ bool Anonymizer::CanEmptyTag(Tag const &tag, const IOD &iod) const
   const DataSet &ds = F->GetDataSet(); (void)ds;
   //Type told = defs.GetTypeFromTag(*F, tag);
   Type t = iod.GetTypeFromTag(defs, tag);
-  //assert( t == told );
+  //gdcm_assert( t == told );
 
   gdcmDebugMacro( "Type for tag=" << tag << " is " << t );
 
-  //assert( t != Type::UNKNOWN );
+  //gdcm_assert( t != Type::UNKNOWN );
 
   if( t == Type::T1 || t == Type::T1C )
     {
@@ -940,7 +940,7 @@ generate a DICOMDIR
 
   // This is a Type 3 attribute but with VR=UI
   // <entry group="0008" element="0014" vr="UI" vm="1" name="Instance Creator UID"/>
-  //assert( dicts.GetDictEntry(tag).GetVR() != VR::UI );
+  //gdcm_assert( dicts.GetDictEntry(tag).GetVR() != VR::UI );
   return !b;
 }
 
@@ -956,7 +956,7 @@ void Anonymizer::ClearInternalUIDs()
 bool Anonymizer::BALCPProtect(DataSet &ds, Tag const & tag, IOD const & iod)
 {
   // \precondition
-  assert( ds.FindDataElement(tag) );
+  gdcm_assert( ds.FindDataElement(tag) );
 
   AnonymizeEvent ae;
   ae.SetTag( tag );
@@ -1010,7 +1010,7 @@ bool Anonymizer::BALCPProtect(DataSet &ds, Tag const & tag, IOD const & iod)
       TagValueKey tvk;
       tvk.first = tag;
 
-      assert( dummyMapNonUIDTags.count( tvk ) == 0 || dummyMapNonUIDTags.count( tvk ) == 1 );
+      gdcm_assert( dummyMapNonUIDTags.count( tvk ) == 0 || dummyMapNonUIDTags.count( tvk ) == 1 );
       if( dummyMapNonUIDTags.count( tvk ) == 0 )
         {
         const char *ret = DummyValueGenerator::Generate( tvk.second.c_str() );
@@ -1068,7 +1068,7 @@ void Anonymizer::RecurseDataSet( DataSet & ds )
   DataSet::ConstIterator it = ds.Begin();
   for( ; it != ds.End(); /*++it*/ )
     {
-    assert( it != ds.End() );
+    gdcm_assert( it != ds.End() );
     DataElement de = *it; ++it;
     //const SequenceOfItems *sqi = de.GetSequenceOfItems();
     VR vr = DataSetHelper::ComputeVR(*F, ds, de.GetTag() );
@@ -1083,7 +1083,7 @@ void Anonymizer::RecurseDataSet( DataSet & ds )
       // Legacy behavior has been to create CP-246 / undefined length SQ as VR:UN...
       if( de.GetVR() == VR::OB ) de.SetVR( VR::UN );
       de.SetVLToUndefined();
-      assert( sqi->IsUndefinedLength() );
+      gdcm_assert( sqi->IsUndefinedLength() );
       //de.GetVL().SetToUndefined();
       //sqi->SetLengthToUndefined();
       SequenceOfItems::SizeType n = sqi->GetNumberOfItems();
@@ -1179,7 +1179,7 @@ bool Anonymizer::BasicApplicationLevelConfidentialityProfile2()
     gdcmDebugMacro( "Could not decrypt" );
     return false;
     }
-  assert( encrypted_len <= encrypted_len2 );
+  gdcm_assert( encrypted_len <= encrypted_len2 );
   (void)encrypted_len2;//warning removal
 
   std::stringstream ss;
@@ -1205,7 +1205,7 @@ bool Anonymizer::BasicApplicationLevelConfidentialityProfile2()
   //std::cout << des << std::endl;
   //std::cout << dummy << std::endl;
   //std::cout << ss.tellg() << std::endl;
-  assert( (size_t)ss.tellg() <= encrypted_len );
+  gdcm_assert( (size_t)ss.tellg() <= encrypted_len );
   // TODO: check that for i = ss.tellg() to encrypted_len, ss[i] == 0
   delete[] buf;
   delete[] orig;
@@ -1214,11 +1214,11 @@ bool Anonymizer::BasicApplicationLevelConfidentialityProfile2()
   // of the Modified Attributes Sequence (0400,0550) of the decoded dataset
   // into the main dataset, replacing dummy value Attributes that may be
   // present in the main dataset.
-  //assert( dummy.GetVR() == VR::SQ );
+  //gdcm_assert( dummy.GetVR() == VR::SQ );
 {
   //const SequenceOfItems *sqi = dummy.GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi = dummy.GetValueAsSQ();
-  assert( sqi && sqi->GetNumberOfItems() == 1 );
+  gdcm_assert( sqi && sqi->GetNumberOfItems() == 1 );
   Item const & item2 = sqi->GetItem( 1 );
   const DataSet &nds2 = item2.GetNestedDataSet();
   DataSet::ConstIterator it = nds2.Begin();

--- a/Source/MediaStorageAndFileFormat/gdcmApplicationEntity.h
+++ b/Source/MediaStorageAndFileFormat/gdcmApplicationEntity.h
@@ -50,11 +50,11 @@ public:
   }
   void SetBlob(const std::vector<char>& v) {
     (void)v;
-    assert(0); //TODO
+    gdcm_assert(0); //TODO
   }
   void Print(std::ostream &os) const {
   (void)os;
-    assert(0); //TODO
+    gdcm_assert(0); //TODO
   }
 };
 

--- a/Source/MediaStorageAndFileFormat/gdcmBitmap.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmBitmap.cxx
@@ -63,16 +63,16 @@ Bitmap::~Bitmap() = default;
  */
 unsigned int Bitmap::GetNumberOfDimensions() const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   return NumberOfDimensions;
 }
 
 void Bitmap::SetNumberOfDimensions(unsigned int dim)
 {
   NumberOfDimensions = dim;
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   Dimensions.resize( 3 /*NumberOfDimensions*/ ); // fill with 0
-  assert( NumberOfDimensions == 2 || NumberOfDimensions == 3 );
+  gdcm_assert( NumberOfDimensions == 2 || NumberOfDimensions == 3 );
   if( NumberOfDimensions == 2 )
     {
     Dimensions[2] = 1;
@@ -82,25 +82,25 @@ void Bitmap::SetNumberOfDimensions(unsigned int dim)
 
 const unsigned int *Bitmap::GetDimensions() const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   return Dimensions.data();
 }
 
 unsigned int Bitmap::GetDimension(unsigned int idx) const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   return Dimensions[idx];
 }
 
 void Bitmap::SetDimensions(const unsigned int *dims)
 {
-  assert( NumberOfDimensions );
-  //assert( Dimensions.empty() );
+  gdcm_assert( NumberOfDimensions );
+  //gdcm_assert( Dimensions.empty() );
 #if 0
   Dimensions = std::vector<unsigned int>(dims,
     dims+NumberOfDimensions);
 #else
-  assert( Dimensions.size() == 3 );
+  gdcm_assert( Dimensions.size() == 3 );
   Dimensions[0] = dims[0];
   Dimensions[1] = dims[1];
   if( NumberOfDimensions == 2 )
@@ -112,13 +112,13 @@ void Bitmap::SetDimensions(const unsigned int *dims)
 
 void Bitmap::SetDimension(unsigned int idx, unsigned int dim)
 {
-  //assert( dim );
-  assert( NumberOfDimensions );
-  assert( idx < NumberOfDimensions );
+  //gdcm_assert( dim );
+  gdcm_assert( NumberOfDimensions );
+  gdcm_assert( idx < NumberOfDimensions );
   Dimensions.resize( 3 /*NumberOfDimensions*/ );
   // Can dim be 0 ??
   // -> no !
-  //assert( dim ); // PhilipsLosslessRice.dcm
+  //gdcm_assert( dim ); // PhilipsLosslessRice.dcm
   Dimensions[idx] = dim;
   if( NumberOfDimensions == 2 )
     {
@@ -145,7 +145,7 @@ unsigned int Bitmap::GetPlanarConfiguration() const
 void Bitmap::SetPlanarConfiguration(unsigned int pc)
 {
   // precondition
-  assert( pc == 0 || pc == 1 );
+  gdcm_assert( pc == 0 || pc == 1 );
   PlanarConfiguration = pc;
   if( pc )
     {
@@ -181,7 +181,7 @@ void Bitmap::SetPlanarConfiguration(unsigned int pc)
       }
     }
   // \postcondition
-  assert( PlanarConfiguration == 0 || PlanarConfiguration == 1 );
+  gdcm_assert( PlanarConfiguration == 0 || PlanarConfiguration == 1 );
 }
 
 
@@ -225,9 +225,9 @@ bool Bitmap::GetBuffer(char *buffer) const
     buffer = 0;
     return false;
     }
-  assert( bv );
+  gdcm_assert( bv );
   RAWCodec codec;
-  //assert( GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
+  //gdcm_assert( GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
   //codec.SetPhotometricInterpretation( GetPhotometricInterpretation() );
   if( GetPhotometricInterpretation() != PhotometricInterpretation::MONOCHROME2 )
     {
@@ -238,9 +238,9 @@ bool Bitmap::GetBuffer(char *buffer) const
   codec.SetPlanarConfiguration( 0 );
   DataElement out;
   bool r = codec.Decode(PixelData, out);
-  assert( r );
+  gdcm_assert( r );
   const ByteValue *outbv = out.GetByteValue();
-  assert( outbv );
+  gdcm_assert( outbv );
   //unsigned long check = outbv->GetLength();  // FIXME
   memcpy(buffer, outbv->GetPointer(), outbv->GetLength() );  // FIXME
   return r;
@@ -249,14 +249,14 @@ bool Bitmap::GetBuffer(char *buffer) const
 
 unsigned long Bitmap::GetBufferLength() const
 {
-  //assert( !IsEncapsulated() );
+  //gdcm_assert( !IsEncapsulated() );
   if( PF == PixelFormat::UNKNOWN ) return 0;
 
-  assert( NumberOfDimensions );
-  //assert( NumberOfDimensions == Dimensions.size() );
+  gdcm_assert( NumberOfDimensions );
+  //gdcm_assert( NumberOfDimensions == Dimensions.size() );
   if( NumberOfDimensions != Dimensions.size() )
     {
-    assert( Dimensions[2] == 1 );
+    gdcm_assert( Dimensions[2] == 1 );
     }
   unsigned long len = 0;
   unsigned int mul = 1;
@@ -274,23 +274,23 @@ unsigned long Bitmap::GetBufferLength() const
 #if 1
     mul *= PF.GetPixelSize();
 #else
-    assert( PF.GetSamplesPerPixel() == 1 );
+    gdcm_assert( PF.GetSamplesPerPixel() == 1 );
     unsigned int save = mul;
     save *= 12;
     save /= 8;
-    assert( save * 8 / 12 == mul );
+    gdcm_assert( save * 8 / 12 == mul );
     mul = save;
 #endif
     }
   else if( PF == PixelFormat::SINGLEBIT )
     {
-    assert( PF.GetSamplesPerPixel() == 1 );
+    gdcm_assert( PF.GetSamplesPerPixel() == 1 );
     const size_t bytesPerRow = Dimensions[0] / 8 + (Dimensions[0] % 8 != 0 ? 1 : 0);
     size_t save = bytesPerRow * Dimensions[1];
     if( NumberOfDimensions > 2 )
       save *= Dimensions[2];
     if(Dimensions[0] % 8 == 0 )
-      assert( save * 8 == mul );
+      gdcm_assert( save * 8 == mul );
     mul = (unsigned int)save;
     }
   else if( PF.GetBitsAllocated() % 8 != 0 )
@@ -299,12 +299,12 @@ unsigned long Bitmap::GetBufferLength() const
     // BitsAllocated      :14
     // BitsStored         :14
     // HighBit            :13
-    assert( PF.GetSamplesPerPixel() == 1 );
+    gdcm_assert( PF.GetSamplesPerPixel() == 1 );
     const ByteValue *bv = PixelData.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     unsigned int ref = bv->GetLength() / mul;
     if( !GetTransferSyntax().IsEncapsulated() )
-      assert( bv->GetLength() % mul == 0 );
+      gdcm_assert( bv->GetLength() % mul == 0 );
     mul *= ref;
     }
   else
@@ -313,7 +313,7 @@ unsigned long Bitmap::GetBufferLength() const
     }
   len = mul;
 
-  //assert( len != 0 );
+  //gdcm_assert( len != 0 );
   return len;
 }
 
@@ -358,7 +358,7 @@ bool Bitmap::TryRAWCodec(char *buffer, bool &lossyflag) const
       }
     if( !r ) return false;
     //const ByteValue *outbv = out.GetByteValue();
-    //assert( outbv );
+    //gdcm_assert( outbv );
     if( len != bv->GetLength() )
       {
       // SIEMENS_GBS_III-16-ACR_NEMA_1.acr
@@ -380,7 +380,7 @@ bool Bitmap::TryRAWCodec(char *buffer, bool &lossyflag) const
     unsigned long check; // = outbv->GetLength();  // FIXME
     check = len;
     // DermaColorLossLess.dcm
-    assert( check == len || check == len + 1 );
+    gdcm_assert( check == len || check == len + 1 );
     (void)check;// removing warning
     //if(buffer) memcpy(buffer, outbv->GetPointer(), outbv->GetLength() );  // FIXME
     return r;
@@ -410,7 +410,7 @@ bool Bitmap::TryJPEGCodec(char *buffer, bool &lossyflag) const
       bool b = codec.GetHeaderInfo( ss, ts2 );
       //bool b = codec.GetHeaderInfo( bv2.GetPointer(), bv2.GetLength() , ts2 );
       if(!b) return false;
-      assert( b );
+      gdcm_assert(b);
       lossyflag = codec.IsLossy();
       // we need to know the actual pixeltype after ::Read
 #if 0
@@ -525,7 +525,7 @@ bool Bitmap::TryJPEGCodec(char *buffer, bool &lossyflag) const
     //  i->SetPhotometricInterpretation( PhotometricInterpretation::RGB );
     //  }
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
     // DermaColorLossLess.dcm has a len of 63531, but DICOM will give us: 63532 ...
@@ -534,11 +534,11 @@ bool Bitmap::TryJPEGCodec(char *buffer, bool &lossyflag) const
       gdcmErrorMacro( "Impossible length: " << len << " should be (max): " << outbv->GetLength() );
       return false;
       }
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     if(buffer) memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
 
     lossyflag = codec.IsLossy();
-    //assert( codec.IsLossy() == ts.IsLossy() );
+    //gdcm_assert( codec.IsLossy() == ts.IsLossy() );
 
     return true;
     }
@@ -574,11 +574,11 @@ bool Bitmap::TryJPEGCodec2(std::ostream &os) const
       //i->SetPhotometricInterpretation( codec.GetPhotometricInterpretation() );
       }
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
     // DermaColorLossLess.dcm has a len of 63531, but DICOM will give us: 63532 ...
-    assert( outbv->GetLength() < len ); (void)len;
+    gdcm_assert( outbv->GetLength() < len ); (void)len;
     //memcpy(buffer, outbv->GetPointer(), outbv->GetLength() );
     os.write( outbv->GetPointer(), outbv->GetLength() );
 
@@ -606,21 +606,21 @@ bool Bitmap::TryPVRGCodec(char *buffer, bool &lossyflag) const
     bool r = codec.Decode(PixelData, out);
     if(!r) return false;
     codec.SetLossyFlag( ts.IsLossy() );
-    assert( r );
+    gdcm_assert( r );
     if ( GetPlanarConfiguration() != codec.GetPlanarConfiguration() )
       {
       Bitmap *i = const_cast<Bitmap*>(this);
       i->PlanarConfiguration = codec.GetPlanarConfiguration();
       }
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     if(buffer) memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
 
     lossyflag = codec.IsLossy();
-    //assert( codec.IsLossy() == ts.IsLossy() );
+    //gdcm_assert( codec.IsLossy() == ts.IsLossy() );
 
     return r;
     }
@@ -646,15 +646,15 @@ bool Bitmap::TryKAKADUCodec(char *buffer, bool &lossyflag) const
     bool r = codec.Decode(PixelData, out);
     if( !r ) return false;
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     // DermaColorLossLess.dcm has a len of 63531, but DICOM will give us: 63532 ...
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     if(buffer) memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
 
-    //assert( codec.IsLossy() == ts.IsLossy() );
+    //gdcm_assert( codec.IsLossy() == ts.IsLossy() );
     lossyflag = codec.IsLossy();
     if( codec.IsLossy() != ts.IsLossy() )
       {
@@ -720,15 +720,15 @@ bool Bitmap::TryJPEGLSCodec(char *buffer, bool &lossyflag) const
     bool r = codec.Decode(PixelData, out);
     if( !r ) return false;
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     // DermaColorLossLess.dcm has a len of 63531, but DICOM will give us: 63532 ...
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
 
-    //assert( codec.IsLossy() == ts.IsLossy() );
+    //gdcm_assert( codec.IsLossy() == ts.IsLossy() );
     lossyflag = codec.IsLossy();
     if( codec.IsLossy() != ts.IsLossy() )
       {
@@ -877,19 +877,19 @@ bool Bitmap::TryJPEG2000Codec(char *buffer, bool &lossyflag) const
     DataElement out;
     bool r = codec.Decode(PixelData, out);
     if(!r) return false;
-    assert( r );
+    gdcm_assert( r );
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
 
     lossyflag = codec.IsLossy();
     if( codec.IsLossy() && !ts.IsLossy() )
       {
-      assert( codec.IsLossy() );
-      assert( !ts.IsLossy() );
+      gdcm_assert( codec.IsLossy() );
+      gdcm_assert( !ts.IsLossy() );
       gdcmErrorMacro( "EVIL file, it is declared as lossless but is in fact lossy." );
       }
 #if 0
@@ -942,9 +942,9 @@ bool Bitmap::TryJPEG2000Codec2(std::ostream &os) const
     codec.SetNeedOverlayCleanup( AreOverlaysInPixelData() || UnusedBitsPresentInPixelData() );
     DataElement out;
     bool r = codec.Code(PixelData, out);
-    assert( r );
+    gdcm_assert( r );
     const ByteValue *outbv = out.GetByteValue();
-    assert( outbv );
+    gdcm_assert( outbv );
     unsigned long check = outbv->GetLength();  // FIXME
     (void)check;
     //memcpy(buffer, outbv->GetPointer(), outbv->GetLength() );  // FIXME
@@ -962,8 +962,8 @@ bool Bitmap::TryRLECodec(char *buffer, bool &lossyflag ) const
   RLECodec codec;
   if( codec.CanDecode( ts ) )
     {
-    //assert( sf->GetNumberOfFragments() == 1 );
-    //assert( sf->GetNumberOfFragments() == GetDimensions(2) );
+    //gdcm_assert( sf->GetNumberOfFragments() == 1 );
+    //gdcm_assert( sf->GetNumberOfFragments() == GetDimensions(2) );
     codec.SetDimensions( GetDimensions() );
     codec.SetNumberOfDimensions( GetNumberOfDimensions() );
     codec.SetPlanarConfiguration( GetPlanarConfiguration() );
@@ -978,7 +978,7 @@ bool Bitmap::TryRLECodec(char *buffer, bool &lossyflag ) const
     const ByteValue *outbv = out.GetByteValue();
     //unsigned long check = outbv->GetLength();  // FIXME
     // DermaColorLossLess.dcm has a len of 63531, but DICOM will give us: 63532 ...
-    assert( len <= outbv->GetLength() );
+    gdcm_assert( len <= outbv->GetLength() );
     if(buffer) memcpy(buffer, outbv->GetPointer(), len /*outbv->GetLength()*/ );  // FIXME
     lossyflag = false;
     return true;
@@ -1046,11 +1046,11 @@ bool Bitmap::IsTransferSyntaxCompatible( TransferSyntax const & ts ) const
 void Bitmap::Print(std::ostream &os) const
 {
   Object::Print(os);
-  //assert( NumberOfDimensions );
+  //gdcm_assert( NumberOfDimensions );
   if( !IsEmpty() )
     {
     os << "NumberOfDimensions: " << NumberOfDimensions << "\n";
-    assert( !Dimensions.empty() );
+    gdcm_assert( !Dimensions.empty() );
     os << "Dimensions: (";
     std::vector<unsigned int>::const_iterator it = Dimensions.begin();
     os << *it;

--- a/Source/MediaStorageAndFileFormat/gdcmBitmapToBitmapFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmBitmapToBitmapFilter.cxx
@@ -44,7 +44,7 @@ void BitmapToBitmapFilter::SetInput(const Bitmap& image)
   else
     {
     Output = nullptr;
-    assert( 0 );
+    gdcm_assert( 0 );
     }
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmCleaner.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmCleaner.cxx
@@ -684,13 +684,13 @@ static VR ComputeDictVR(File &file, DataSet &ds, DataElement const &de) {
   } else {
     const PrivateTag pt = ds.GetPrivateTag(tag);
     const char *owner = pt.GetOwner();
-    assert(owner);
+    gdcm_assert(owner);
     compute_dict_vr = *owner != 0;
   }
   if (compute_dict_vr) dict_vr = DataSetHelper::ComputeVR(file, ds, tag);
 
   if (de.GetVR() == VR::SQ) {
-    assert(dict_vr != VR::UN);
+    gdcm_assert(dict_vr != VR::UN);
     if (!dict_vr.Compatible(de.GetVR())) {
       gdcmErrorMacro("Impossible. Dict states VR is: "
                      << dict_vr << " which is impossible for SQ");
@@ -700,7 +700,7 @@ static VR ComputeDictVR(File &file, DataSet &ds, DataElement const &de) {
   if (dict_vr != VR::SQ) {
     if (de.GetVL().IsUndefined()) {
       Tag pixelData(0x7fe0, 0x0010);
-      assert(dict_vr == VR::OB);
+      gdcm_assert(dict_vr == VR::OB);
       if (tag != pixelData) {
         gdcmErrorMacro("Impossible happen: " << de);
         return VR::SQ;
@@ -812,7 +812,7 @@ static inline int bs_memcmp(const void *s1, const void *s2, size_t n) {
   size_t i;
   const unsigned char *us1 = (const unsigned char *)s1;
   const unsigned char *us2 = (const unsigned char *)s2;
-  assert(n % 2 == 0);
+  gdcm_assert(n % 2 == 0);
 
   for (i = 0; i < n; i += 2, us1 += 2, us2 += 2) {
     if (*us1 < *(us2 + 1)) {
@@ -1107,9 +1107,9 @@ Cleaner::impl::ACTION Cleaner::impl::ComputeAction(
     // Empty
     if (empty_tags.find(tag) != empty_tags.end() ||
         IsDPathInSet(empty_dpaths, dpath)) {
-      assert(!tag.IsGroupLength());
-      assert(!tag.IsPrivateCreator());
-      assert(ds.FindDataElement(tag));
+      gdcm_assert(!tag.IsGroupLength());
+      gdcm_assert(!tag.IsPrivateCreator());
+      gdcm_assert(ds.FindDataElement(tag));
       return Cleaner::impl::EMPTY;
     }
     // Remove
@@ -1122,7 +1122,7 @@ Cleaner::impl::ACTION Cleaner::impl::ComputeAction(
   if (tag.IsPrivate() && !tag.IsPrivateCreator() && !tag.IsGroupLength()) {
     const PrivateTag pt = ds.GetPrivateTag(tag);
     const char *owner = pt.GetOwner();
-    assert(owner);
+    gdcm_assert(owner);
     if (*owner == 0 && AllMissingPrivateCreator) {
       return Cleaner::impl::REMOVE;
     }
@@ -1150,7 +1150,7 @@ Cleaner::impl::ACTION Cleaner::impl::ComputeAction(
   // VR cleanup
   if (!empty_vrs.empty() || !remove_vrs.empty()) {
     VR vr = de.GetVR();
-    assert(ref_dict_vr != VR::INVALID);
+    gdcm_assert(ref_dict_vr != VR::INVALID);
     // be careful with vr handling since we must always prefer the one from
     // the dict in case of attribute written as 'OB' but dict states 'PN':
     if (ref_dict_vr != VR::UN /*&& ref_dict_vr != VR::INVALID*/) {
@@ -1161,7 +1161,7 @@ Cleaner::impl::ACTION Cleaner::impl::ComputeAction(
         vr = ref_dict_vr;
       }
       if (vr != ref_dict_vr) {
-        // assert(vr == VR::OB || vr == VR::OW);
+        // gdcm_assert(vr == VR::OB || vr == VR::OW);
         vr = ref_dict_vr;
       }
     }

--- a/Source/MediaStorageAndFileFormat/gdcmCurve.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmCurve.cxx
@@ -153,13 +153,13 @@ unsigned int Curve::GetNumberOfCurves(DataSet const & ds)
 
 void Curve::Update(const DataElement & de)
 {
-  assert( de.GetTag().IsPublic() );
+  gdcm_assert( de.GetTag().IsPublic() );
   const ByteValue* bv = de.GetByteValue();
   if( !bv ) return; // Discard any empty element (will default to another value)
-  assert( bv->GetPointer() && bv->GetLength() );
+  gdcm_assert( bv->GetPointer() && bv->GetLength() );
   std::string s( bv->GetPointer(), bv->GetLength() );
   // What if a \0 can be found before the end of string...
-  //assert( strlen( s.c_str() ) == s.size() );
+  //gdcm_assert( strlen( s.c_str() ) == s.size() );
 
   // First thing check consistency:
   if( !GetGroup() )
@@ -168,7 +168,7 @@ void Curve::Update(const DataElement & de)
     }
   else // check consistency
     {
-    assert( GetGroup() == de.GetTag().GetGroup() ); // programmer error
+    gdcm_assert( GetGroup() == de.GetTag().GetGroup() ); // programmer error
     }
 
   //std::cerr << "Tag: " << de.GetTag() << std::endl;
@@ -258,7 +258,7 @@ void Curve::Update(const DataElement & de)
     }
   else
     {
-    assert( 0 && "should not happen: Unknown curve tag" );
+    gdcm_assert( 0 && "should not happen: Unknown curve tag" );
     }
 
 }
@@ -345,15 +345,15 @@ void Curve::SetCurve(const char *array, unsigned int length)
   if( !array || length == 0 ) return;
   Internal->Data.resize( length );
   std::copy(array, array+length, Internal->Data.begin());
-  //assert( 8 * length == (unsigned int)Internal->Rows * Internal->Columns );
-  //assert( Internal->Data.size() == length );
+  //gdcm_assert( 8 * length == (unsigned int)Internal->Rows * Internal->Columns );
+  //gdcm_assert( Internal->Data.size() == length );
 }
 
 void Curve::Decode(std::istream &is, std::ostream &os)
 {
   (void)is;
   (void)os;
-  assert(0);
+  gdcm_assert(0);
 }
 
 /*
@@ -408,7 +408,7 @@ The data points of this dimension will be absent from Curve Data (50xx,3000).
 */
 double Curve::ComputeValueFromStartAndStep(unsigned int idx) const
 {
-  assert( !Internal->CurveDataDescriptor.empty() );
+  gdcm_assert( !Internal->CurveDataDescriptor.empty() );
   const double res = Internal->CoordinateStartValue +
     Internal->CoordinateStepValue * idx;
   return res;
@@ -416,49 +416,49 @@ double Curve::ComputeValueFromStartAndStep(unsigned int idx) const
 
 void Curve::GetAsPoints(float *array) const
 {
-  assert( getsizeofrep(Internal->DataValueRepresentation) );
+  gdcm_assert( getsizeofrep(Internal->DataValueRepresentation) );
   if( Internal->CurveDataDescriptor.empty() )
     {
-    assert( Internal->Data.size() == (uint32_t)Internal->NumberOfPoints *
+    gdcm_assert( Internal->Data.size() == (uint32_t)Internal->NumberOfPoints *
       Internal->Dimensions * getsizeofrep( Internal->DataValueRepresentation) );
     }
   else
     {
-    assert( Internal->Data.size() == (uint32_t)Internal->NumberOfPoints *
+    gdcm_assert( Internal->Data.size() == (uint32_t)Internal->NumberOfPoints *
       1 * getsizeofrep( Internal->DataValueRepresentation) );
     }
-  assert( Internal->Dimensions == 1 || Internal->Dimensions == 2 );
+  gdcm_assert( Internal->Dimensions == 1 || Internal->Dimensions == 2 );
 
   const int mult = Internal->Dimensions;
   int genidx = -1;
   if( !Internal->CurveDataDescriptor.empty() )
     {
-    assert( Internal->CurveDataDescriptor.size() == Internal->Dimensions );
-    assert( Internal->CurveDataDescriptor.size() == 2 ); // FIXME
+    gdcm_assert( Internal->CurveDataDescriptor.size() == Internal->Dimensions );
+    gdcm_assert( Internal->CurveDataDescriptor.size() == 2 ); // FIXME
     if( Internal->CurveDataDescriptor[0] == 0 )
       {
-      assert( Internal->CurveDataDescriptor[1] == 1 );
+      gdcm_assert( Internal->CurveDataDescriptor[1] == 1 );
       genidx = 0;
       }
     else if( Internal->CurveDataDescriptor[1] == 0 )
       {
-      assert( Internal->CurveDataDescriptor[0] == 1 );
+      gdcm_assert( Internal->CurveDataDescriptor[0] == 1 );
       genidx = 1;
       }
     else
       {
-      assert( 0 && "TODO" );
+      gdcm_assert( 0 && "TODO" );
       }
     }
   const char * beg = Internal->Data.data();
   const char * end = beg + Internal->Data.size();
   if( genidx == -1 )
     {
-    assert( end == beg + 2 * Internal->NumberOfPoints ); (void)beg;(void)end;
+    gdcm_assert( end == beg + 2 * Internal->NumberOfPoints ); (void)beg;(void)end;
     }
   else
     {
-    assert( end == beg + mult * Internal->NumberOfPoints ); (void)beg;(void)end;
+    gdcm_assert( end == beg + mult * Internal->NumberOfPoints ); (void)beg;(void)end;
     }
 
 
@@ -554,7 +554,7 @@ void Curve::GetAsPoints(float *array) const
     }
   else
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     }
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmDICOMDIRGenerator.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDICOMDIRGenerator.cxx
@@ -87,7 +87,7 @@ static const char *GetLowerLevelDirectoryRecord(const char *input)
     {
     return nullptr;
     }
-  assert( 0 );
+  gdcm_assert( 0 );
   //std::cerr << "COULD NOT FIND:" << input << std::endl;
   return nullptr;
 }
@@ -113,13 +113,13 @@ DICOMDIRGenerator::MyPair DICOMDIRGenerator::GetReferenceValueForDirectoryType(s
   directoryrecordtype.Set( ds );
 
   const char *input = directoryrecordtype.GetValue();
-  assert( input );
+  gdcm_assert( input );
 
   if( strcmp( input, "PATIENT " ) == 0 )
     {
     Attribute<0x10,0x20> patientid;
     patientid.Set( ds );
-    assert( patientid.GetValue() );
+    gdcm_assert( patientid.GetValue() );
     ret.first = patientid.GetValue();
     ret.second = patientid.GetTag();
     }
@@ -127,7 +127,7 @@ DICOMDIRGenerator::MyPair DICOMDIRGenerator::GetReferenceValueForDirectoryType(s
     {
     Attribute <0x20,0xd> studyuid;
     studyuid.Set( ds );
-    assert( studyuid.GetValue() );
+    gdcm_assert( studyuid.GetValue() );
     ret.first = studyuid.GetValue();
     ret.second = studyuid.GetTag();
     }
@@ -135,7 +135,7 @@ DICOMDIRGenerator::MyPair DICOMDIRGenerator::GetReferenceValueForDirectoryType(s
     {
     Attribute <0x20,0xe> seriesuid;
     seriesuid.Set( ds );
-    assert( seriesuid.GetValue() );
+    gdcm_assert( seriesuid.GetValue() );
     ret.first = seriesuid.GetValue();
     ret.second = seriesuid.GetTag();
     }
@@ -143,13 +143,13 @@ DICOMDIRGenerator::MyPair DICOMDIRGenerator::GetReferenceValueForDirectoryType(s
     {
     Attribute <0x04,0x1511> sopuid;
     sopuid.Set( ds );
-    assert( sopuid.GetValue() );
+    gdcm_assert( sopuid.GetValue() );
     ret.first = sopuid.GetValue();
     ret.second = Tag(0x8,0x18); // watch out !
     }
   else
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     }
   return ret;
 }
@@ -175,15 +175,15 @@ static Tag GetParentTag(Tag const &t)
     }
   else
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     }
   return ret;
 }
 
 bool DICOMDIRGenerator::SeriesBelongToStudy(const char *seriesuid, const char *studyuid)
 {
-  assert( seriesuid );
-  assert( studyuid );
+  gdcm_assert( seriesuid );
+  gdcm_assert( studyuid );
   const Scanner &scanner = GetScanner();
 
   Scanner::TagToValue const &ttv = scanner.GetMappingFromTagToValue(Tag(0x20,0xe), seriesuid);
@@ -203,8 +203,8 @@ bool DICOMDIRGenerator::SeriesBelongToStudy(const char *seriesuid, const char *s
 
 bool DICOMDIRGenerator::ImageBelongToSeries(const char *sopuid, const char *seriesuid, Tag const &t1, Tag const &t2)
 {
-  assert( seriesuid );
-  assert( sopuid );
+  gdcm_assert( seriesuid );
+  gdcm_assert( sopuid );
   const Scanner &scanner = GetScanner();
 
   Scanner::TagToValue const &ttv = scanner.GetMappingFromTagToValue(t1, sopuid);
@@ -223,8 +223,8 @@ bool DICOMDIRGenerator::ImageBelongToSeries(const char *sopuid, const char *seri
 
 bool DICOMDIRGenerator::ImageBelongToSameSeries(const char *sopuid1, const char *sopuid2, Tag const &t)
 {
-  assert( sopuid1 );
-  assert( sopuid2 );
+  gdcm_assert( sopuid1 );
+  gdcm_assert( sopuid2 );
   const Scanner &scanner = GetScanner();
 
   Scanner::TagToValue const &ttv1 = scanner.GetMappingFromTagToValue(t, sopuid1);
@@ -246,8 +246,8 @@ bool DICOMDIRGenerator::ImageBelongToSameSeries(const char *sopuid1, const char 
     {
     seriesuid2 = ttv2.find(tseriesuid)->second;
     }
-  assert( seriesuid1 );
-  assert( seriesuid2 );
+  gdcm_assert( seriesuid1 );
+  gdcm_assert( seriesuid2 );
 
   b = strcmp( seriesuid1, seriesuid2) == 0;
   return b;
@@ -278,7 +278,7 @@ size_t DICOMDIRGenerator::FindLowerLevelDirectoryRecord( size_t item1, const cha
         refval1.first.c_str(), refval2.second, refval1.second);
       if( b ) return i;
       }
-    //assert( strncmp( lowerdirectorytype, directoryrecordtype.GetValue(), strlen( lowerdirectorytype ) ) != 0 );
+    //gdcm_assert( strncmp( lowerdirectorytype, directoryrecordtype.GetValue(), strlen( lowerdirectorytype ) ) != 0 );
     }
 
   // Not found
@@ -313,7 +313,7 @@ size_t DICOMDIRGenerator::FindNextDirectoryRecord( size_t item1, const char *dir
       bool b = ImageBelongToSameSeries(refval1.first.c_str(), refval2.first.c_str(), refval1.second);
       if( b ) return i;
       }
-    //assert( strncmp( directorytype, directoryrecordtype.GetValue(), strlen( directorytype ) ) != 0 );
+    //gdcm_assert( strncmp( directorytype, directoryrecordtype.GetValue(), strlen( directorytype ) ) != 0 );
     }
 
   // Not found
@@ -359,7 +359,7 @@ void SingleDataElementInserter(DataSet &ds, Scanner const & scanner)
   Scanner::ValuesType patientsnames = scanner.GetValues( patientsname.GetTag() );
 #ifndef NDEBUG
   const unsigned int npatient = patientsnames.size();
-  assert( npatient == 1 );
+  gdcm_assert( npatient == 1 );
 #endif
 
   Scanner::ValuesType::const_iterator it = patientsnames.begin();
@@ -682,7 +682,7 @@ bool DICOMDIRGenerator::AddImageDirectoryRecord()
     std::string::size_type l = relative.find( rd );
     if( l != std::string::npos )
       {
-      assert( l == 0 ); // FIXME
+      gdcm_assert( l == 0 ); // FIXME
       relative.replace( l, strlen_rd, "" );
       fn = relative.c_str() + 1;
       }
@@ -719,7 +719,7 @@ bool DICOMDIRGenerator::AddImageDirectoryRecord()
     Attribute<0x8,0x8> imagetype;
     //Scanner::ValuesType imagetypes = scanner.GetValues( imagetype.GetTag() );
     //Scanner::ValuesType::const_iterator it = imagetypes.begin();
-    //assert( imagetypes.size() == 1 );
+    //gdcm_assert( imagetypes.size() == 1 );
     //imagetype.SetNumberOfValues( 1 );
     //imagetype.SetValue( it->c_str() );
     //ds.Replace( imagetype.GetAsDataElement() );
@@ -861,7 +861,7 @@ bool DICOMDIRGenerator::Generate()
     std::string::size_type l = relative.find( rd );
     if( l != std::string::npos )
       {
-      assert( l == 0 ); // FIXME
+      gdcm_assert( l == 0 ); // FIXME
       relative.replace( l, strlen_rd, "" );
       f = relative.c_str() + 1;
       }
@@ -1046,7 +1046,7 @@ SequenceOfItems *DICOMDIRGenerator::GetDirectoryRecordSequence()
 
 const char *DICOMDIRGenerator::ComputeFileID(const char *input)
 {
-  assert( 0 ); (void)input;
+  gdcm_assert( 0 ); (void)input;
   return nullptr;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmDPath.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDPath.cxx
@@ -48,7 +48,7 @@ static inline std::string tostring(uint16_t const val, int const width = 4) {
 
 static std::vector<std::string> tag2strings(gdcm::Tag const &tag) {
   std::vector<std::string> ret;
-  assert(tag.IsPublic() || tag.IsPrivateCreator() || tag.IsGroupLength());
+  gdcm_assert(tag.IsPublic() || tag.IsPrivateCreator() || tag.IsGroupLength());
   ret.push_back(tostring(tag.GetGroup()));
   ret.push_back(tostring(tag.GetElement()));
   return ret;
@@ -86,7 +86,7 @@ static std::vector<std::string> split_from_slash_separated(
       comps.push_back(sub);
     } else {
 #if 0
-      assert(!comps.empty());
+      gdcm_assert(!comps.empty());
       std::string &last = comps.back();
       last.push_back(separator);
       last.append(sub);
@@ -122,7 +122,7 @@ bool DPath::ConstructFromString(const char *spath) {
   std::ostringstream os;
   std::vector<std::string>::const_iterator it = comps.begin();
   unsigned int index = 0;
-  assert(comps.size() >= 2);
+  gdcm_assert(comps.size() >= 2);
   // check root
   if (!it->empty()) return false;
   ++it;

--- a/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDataSetHelper.cxx
@@ -143,7 +143,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
       // In case of SAX parser, we would have had to process Pixel Representation already:
       Attribute<0x0028,0x0103> at;
       const Tag &pixelrep = at.GetTag();
-      assert( pixelrep < t );
+      gdcm_assert( pixelrep < t );
       const DataSet &rootds = file.GetDataSet();
       // FIXME
       // PhilipsWith15Overlays.dcm has a Private SQ with public elements such as
@@ -153,7 +153,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
       // FIXME:
       // gdcmDataExtra/gdcmSampleData/ImagesPapyrus/TestImages/wristb.pap
       // It's the contrary: root dataset does not have a Pixel Representation, but each SQ do...
-      //assert( rootds.FindDataElement( pixelrep ) || ds.FindDataElement( pixelrep ) );
+      //gdcm_assert( rootds.FindDataElement( pixelrep ) || ds.FindDataElement( pixelrep ) );
       if( ds.FindDataElement( pixelrep ) )
         {
         at.SetFromDataElement( ds.GetDataElement( pixelrep ) );
@@ -168,7 +168,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
         gdcmWarningMacro( "Unhandled" ); // Typical to PDF encapsulated with some illegal attribute
         vr = VR::INVALID;
         }
-      //assert( at.GetValue() == 0 || at.GetValue() == 1 );
+      //gdcm_assert( at.GetValue() == 0 || at.GetValue() == 1 );
       if( at.GetValue() == 1 )
         {
         vr = VR::SS;
@@ -197,14 +197,14 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
     Tag bitsallocated(0x0028,0x0100);
     Tag channelminval(0x5400,0x0110);
     Tag channelmaxval(0x5400,0x0112);
-    //assert( ds.FindDataElement( pixeldata ) );
+    //gdcm_assert( ds.FindDataElement( pixeldata ) );
     int v = -1;
     if( waveformdata == t || waveformpaddingvalue == t )
       {
       Tag waveformbitsallocated(0x5400,0x1004);
       // For Waveform Data:
       // (5400,1004) US 16                                             # 2,1 Waveform Bits Allocated
-      assert( ds.FindDataElement( waveformbitsallocated ) );
+      gdcm_assert( ds.FindDataElement( waveformbitsallocated ) );
       Attribute<0x5400,0x1004> at;
       at.SetFromDataElement( ds.GetDataElement( waveformbitsallocated ) );
       v = at.GetValue();
@@ -230,7 +230,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
       }
     else if( waveformdata == t || waveformpaddingvalue == t )
       {
-      //assert( v == 8 || v == 16 );
+      //gdcm_assert( v == 8 || v == 16 );
       vr = VR::OW;
       }
     else if ( t.IsGroupXX(audiodata) )
@@ -282,16 +282,16 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
   // TODO need to treat US_SS_OW too
 
   // \postcondition:
-  assert( vr.IsVRFile() );
-  assert( vr != VR::INVALID );
+  gdcm_assert( vr.IsVRFile() );
+  gdcm_assert( vr != VR::INVALID );
 
   if( tag.IsGroupLength() )
     {
-    assert( vr == VR::UL );
+    gdcm_assert( vr == VR::UL );
     }
   if( tag.IsPrivateCreator() )
     {
-    assert( vr == VR::LO );
+    gdcm_assert( vr == VR::LO );
     }
   return vr;
 }
@@ -301,7 +301,7 @@ VR DataSetHelper::ComputeVR(File const &file, DataSet const &ds, const Tag& tag)
 SequenceOfItems* DataSetHelper::ComputeSQFromByteValue(File const & file, DataSet const &ds, const Tag &tag)
 {
   const TransferSyntax &ts = file.GetHeader().GetDataSetTransferSyntax();
-  assert( ts != TransferSyntax::DeflatedExplicitVRLittleEndian );
+  gdcm_assert( ts != TransferSyntax::DeflatedExplicitVRLittleEndian );
   const DataElement &de = ds.GetDataElement( tag );
   if( de.IsEmpty() )
     {
@@ -319,15 +319,15 @@ SequenceOfItems* DataSetHelper::ComputeSQFromByteValue(File const & file, DataSe
     {
     if( ts.GetSwapCode() == SwapCode::BigEndian )
       {
-      assert(0);
+      gdcm_assert(0);
       }
     else
       {
       if( ts.GetNegociatedType() == TransferSyntax::Implicit )
         {
-        assert( de.GetVR() == VR::INVALID );
+        gdcm_assert( de.GetVR() == VR::INVALID );
         const ByteValue *bv = de.GetByteValue();
-        assert( bv );
+        gdcm_assert( bv );
         SequenceOfItems *sqi = new SequenceOfItems;
         sqi->SetLength( bv->GetLength() );
         std::stringstream ss;
@@ -337,9 +337,9 @@ SequenceOfItems* DataSetHelper::ComputeSQFromByteValue(File const & file, DataSe
         }
       else
         {
-        assert( de.GetVR() == VR::UN ); // cp 246, IVRLE SQ
+        gdcm_assert( de.GetVR() == VR::UN ); // cp 246, IVRLE SQ
         const ByteValue *bv = de.GetByteValue();
-        assert( bv );
+        gdcm_assert( bv );
         SequenceOfItems *sqi = new SequenceOfItems;
         sqi->SetLength( bv->GetLength() );
         std::stringstream ss;

--- a/Source/MediaStorageAndFileFormat/gdcmDictPrinter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDictPrinter.cxx
@@ -51,7 +51,7 @@ VM GuessVMType(DataElement const &de)
     }
   else
     {
-    assert( VR::IsASCII( vr ) || vr == VR::INVALID );
+    gdcm_assert( VR::IsASCII( vr ) || vr == VR::INVALID );
     switch(vr)
       {
     case VR::INVALID:
@@ -75,7 +75,7 @@ VM GuessVMType(DataElement const &de)
         vm = VM::VM1; // why not ?
         if(!de.IsEmpty())
           {
-          assert( bv && "not bv" );
+          gdcm_assert( bv && "not bv" );
           const char *array = bv->GetPointer();
           size_t c = VM::GetNumberOfElementsFromArray(array, vl);
           vm = VM::GetVMTypeFromLength( c, 1 );
@@ -84,7 +84,7 @@ VM GuessVMType(DataElement const &de)
       break;
     default:
       vm = VM::VM0;
-      assert( 0 ); // Impossible happen ! (someone added new VR and forgot this switch)
+      gdcm_assert( 0 ); // Impossible happen ! (someone added new VR and forgot this switch)
       }
     }
 
@@ -406,7 +406,7 @@ std::string GetVersion(std::string const &owner)
 //      {
 //      // HEY !
 //      std::cerr << "OWNER= \"" << p->owner << "\"" << std::endl;
-//      assert(0);
+//      gdcm_assert(0);
 //      }
 //#endif
     //if( owner == p->owner )
@@ -449,7 +449,7 @@ void DictPrinter::PrintDataElement2(std::ostream& os, const DataSet &ds, const D
     const DictEntry &entry = dicts.GetDictEntry(t,owner);
     dict_vr = entry.GetVR();
 
-    assert(t.GetElement() >= 0x0100 );
+    gdcm_assert(t.GetElement() >= 0x0100 );
     //owner = GetOwner(ds,de);
     //version = GetVersion(owner);
 
@@ -475,7 +475,7 @@ void DictPrinter::PrintDataElement2(std::ostream& os, const DataSet &ds, const D
       os <<  "vr=\"" << pvr << "\" vm=\"" << vm << "\" ";
     if( t.IsPrivate() )
       {
-      assert( owner && *owner );
+      gdcm_assert( owner && *owner );
       os << R"(name="?" owner=")" << owner << "\"/>\n";
       }
     }

--- a/Source/MediaStorageAndFileFormat/gdcmDirectionCosines.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmDirectionCosines.cxx
@@ -73,7 +73,7 @@ bool DirectionCosines::IsValid() const
 
 void DirectionCosines::Cross(double z[3]) const
 {
-  //assert( Dot() == 0 );
+  //gdcm_assert( Dot() == 0 );
   const double *x = Values;
   const double *y = x+3;
   double Zx = x[1]*y[2] - x[2]*y[1];

--- a/Source/MediaStorageAndFileFormat/gdcmFileAnonymizer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileAnonymizer.cxx
@@ -146,9 +146,9 @@ bool FileAnonymizer::ComputeReplaceTagPosition()
  will try very hard to decode it as SQ...which obviously will fail
  Instead do not support SQ at all here and document it should not be used for SQ
  */
-  assert( !Internals->InputFilename.empty() );
+  gdcm_assert( !Internals->InputFilename.empty() );
   const char *filename = Internals->InputFilename.c_str();
-  assert( filename );
+  gdcm_assert( filename );
   const bool inplace = file_exist(Internals->OutputFilename.c_str());
 
   std::map<Tag, std::string>::reverse_iterator rit = Internals->ReplaceTags.rbegin();
@@ -184,9 +184,9 @@ bool FileAnonymizer::ComputeReplaceTagPosition()
       pe.IsTagFound = true;
       pe.DE.SetVL( de.GetVL() ); // Length is not used, unless to check undefined flag
       pe.DE.SetVR( de.GetVR() );
-      assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
-      assert( pe.DE.GetVR() == de.GetVR() );
-      assert( pe.DE.GetTag() == de.GetTag() );
+      gdcm_assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
+      gdcm_assert( pe.DE.GetVR() == de.GetVR() );
+      gdcm_assert( pe.DE.GetTag() == de.GetTag() );
       if( de.GetVL().IsUndefined() )
         {
         // This is a SQ
@@ -200,15 +200,15 @@ bool FileAnonymizer::ComputeReplaceTagPosition()
           gdcmErrorMacro( "inplace mode requires same length attribute" ); // TODO we could allow smaller size (and pad with space...)
           return false;
           }
-        assert( !de.GetVL().IsUndefined() );
+        gdcm_assert( !de.GetVL().IsUndefined() );
         pe.BeginPos -= de.GetVL();
         pe.BeginPos -= 2 * de.GetVR().GetLength(); // (VR+) VL
         pe.BeginPos -= 4; // Tag
-        assert( (int)pe.EndPos ==
+        gdcm_assert( (int)pe.EndPos ==
           (int)pe.BeginPos + (int)de.GetVL() + 2 * de.GetVR().GetLength() + 4 );
         }
       pe.DE.SetByteValue( valuereplace.c_str(), (uint32_t)valuereplace.size() );
-      assert( pe.DE.GetVL() == valuereplace.size() );
+      gdcm_assert( pe.DE.GetVL() == valuereplace.size() );
       }
     else
       {
@@ -221,7 +221,7 @@ bool FileAnonymizer::ComputeReplaceTagPosition()
       //FIXME, for some public element we could do something nicer than VR:UN
       pe.DE.SetVR( VR::UN );
       pe.DE.SetByteValue( valuereplace.c_str(), (uint32_t)valuereplace.size() );
-      assert( pe.DE.GetVL() == valuereplace.size() );
+      gdcm_assert( pe.DE.GetVL() == valuereplace.size() );
       }
 
     // We need to push_back outside of if() since Action:Replace
@@ -235,9 +235,9 @@ bool FileAnonymizer::ComputeReplaceTagPosition()
 
 bool FileAnonymizer::ComputeRemoveTagPosition()
 {
-  assert( !Internals->InputFilename.empty() );
+  gdcm_assert( !Internals->InputFilename.empty() );
   const char *filename = Internals->InputFilename.c_str();
-  assert( filename );
+  gdcm_assert( filename );
   const bool inplace = file_exist(Internals->OutputFilename.c_str());
   if( inplace && !Internals->RemoveTags.empty())
     {
@@ -277,9 +277,9 @@ bool FileAnonymizer::ComputeRemoveTagPosition()
       pe.IsTagFound = true;
       pe.DE.SetVL( de.GetVL() ); // Length is not used, unless to check undefined flag
       pe.DE.SetVR( de.GetVR() );
-      assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
-      assert( pe.DE.GetVR() == de.GetVR() );
-      assert( pe.DE.GetTag() == de.GetTag() );
+      gdcm_assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
+      gdcm_assert( pe.DE.GetVR() == de.GetVR() );
+      gdcm_assert( pe.DE.GetTag() == de.GetTag() );
       if( de.GetVL().IsUndefined() )
         {
         // This is a SQ
@@ -292,16 +292,16 @@ bool FileAnonymizer::ComputeRemoveTagPosition()
           {
           vl = de.GetLength<ExplicitDataElement>();
           }
-        assert( pe.BeginPos > vl );
+        gdcm_assert( pe.BeginPos > vl );
         pe.BeginPos -= vl;
         }
       else
         {
-        assert( !de.GetVL().IsUndefined() );
+        gdcm_assert( !de.GetVL().IsUndefined() );
         pe.BeginPos -= de.GetVL();
         pe.BeginPos -= 2 * de.GetVR().GetLength(); // (VR+) VL
         pe.BeginPos -= 4; // Tag
-        assert( (int)pe.EndPos ==
+        gdcm_assert( (int)pe.EndPos ==
           (int)pe.BeginPos + (int)de.GetVL() + 2 * de.GetVR().GetLength() + 4 );
         }
       Internals->PositionEmptyArray.push_back( pe );
@@ -320,9 +320,9 @@ bool FileAnonymizer::ComputeRemoveTagPosition()
 bool FileAnonymizer::ComputeEmptyTagPosition()
 {
   // FIXME we sometime empty, attributes that are already empty...
-  assert( !Internals->InputFilename.empty() );
+  gdcm_assert( !Internals->InputFilename.empty() );
   const char *filename = Internals->InputFilename.c_str();
-  assert( filename );
+  gdcm_assert( filename );
   const bool inplace = file_exist(Internals->OutputFilename.c_str());
   if( inplace && !Internals->EmptyTags.empty())
     {
@@ -362,9 +362,9 @@ bool FileAnonymizer::ComputeEmptyTagPosition()
       pe.IsTagFound = true;
       pe.DE.SetVL( de.GetVL() ); // Length is not used, unless to check undefined flag
       pe.DE.SetVR( de.GetVR() );
-      assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
-      assert( pe.DE.GetVR() == de.GetVR() );
-      assert( pe.DE.GetTag() == de.GetTag() );
+      gdcm_assert( pe.DE.GetVL().IsUndefined() == de.GetVL().IsUndefined() );
+      gdcm_assert( pe.DE.GetVR() == de.GetVR() );
+      gdcm_assert( pe.DE.GetTag() == de.GetTag() );
       if( de.GetVL().IsUndefined() )
         {
         // This is a SQ
@@ -377,7 +377,7 @@ bool FileAnonymizer::ComputeEmptyTagPosition()
           {
           vl = de.GetLength<ExplicitDataElement>();
           }
-        assert( pe.BeginPos > vl );
+        gdcm_assert( pe.BeginPos > vl );
         pe.BeginPos -= vl;
         pe.BeginPos += 4; // Tag
         if( ts.GetNegociatedType() == TransferSyntax::Implicit )
@@ -391,7 +391,7 @@ bool FileAnonymizer::ComputeEmptyTagPosition()
         }
       else
         {
-        assert( !de.GetVL().IsUndefined() );
+        gdcm_assert( !de.GetVL().IsUndefined() );
         pe.BeginPos -= de.GetVL();
         if( ts.GetNegociatedType() == TransferSyntax::Implicit )
           {
@@ -400,7 +400,7 @@ bool FileAnonymizer::ComputeEmptyTagPosition()
         else
           {
           pe.BeginPos -= de.GetVR().GetLength();
-          assert( (int)pe.EndPos ==
+          gdcm_assert( (int)pe.EndPos ==
             (int)pe.BeginPos + (int)de.GetVL() + de.GetVR().GetLength() );
           }
         }
@@ -489,7 +489,7 @@ bool FileAnonymizer::Write()
         }
       if( action == EMPTY )
         {
-        assert( !inplace );
+        gdcm_assert( !inplace );
         // Create a 0 Value Length (VR+Tag was copied in previous loop)
         for( int i = 0; i < vrlen; ++i)
           {
@@ -523,11 +523,11 @@ bool FileAnonymizer::Write()
           }
         }
       // Skip the Value
-      assert( is.good() );
+      gdcm_assert( is.good() );
       is.seekg( pe.EndPos );
-      assert( is.good() );
+      gdcm_assert( is.good() );
       prev = is.tellg();
-      assert( prev == pe.EndPos );
+      gdcm_assert( prev == pe.EndPos );
       }
     else
       {

--- a/Source/MediaStorageAndFileFormat/gdcmFileChangeTransferSyntax.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileChangeTransferSyntax.cxx
@@ -124,7 +124,7 @@ bool FileChangeTransferSyntax::Change()
 
   Internals->Progress = 0;
   bool b = Internals->IC->StartEncode(os);
-  assert( b );
+  gdcm_assert(b);
   size_t len = 0; // actual size compressed:
   if( Internals->IC->IsRowEncoder() )
     {
@@ -145,7 +145,7 @@ bool FileChangeTransferSyntax::Change()
       for( unsigned int y = 0; y < dims[1]; ++y )
         {
         is.read( data, datalen );
-        assert( is.good() );
+        gdcm_assert( is.good() );
         b = Internals->IC->CleanupUnusedBits(data, datalen);
         if( !b ) return false;
         b = Internals->IC->AppendRowEncode(os, data, datalen);
@@ -189,7 +189,7 @@ bool FileChangeTransferSyntax::Change()
       std::streampos start = os.tellp();
         {
         is.read( data, datalen );
-        assert( is.good() );
+        gdcm_assert( is.good() );
         b = Internals->IC->CleanupUnusedBits(data, datalen);
         if( !b ) return false;
         b = Internals->IC->AppendFrameEncode(os, data, datalen);
@@ -221,7 +221,7 @@ bool FileChangeTransferSyntax::Change()
     return false;
     }
   b = Internals->IC->StopEncode(os);
-  assert( b );
+  gdcm_assert(b);
 
   const Tag seqDelItem(0xfffe,0xe0dd);
   seqDelItem.Write<SwapperNoOp>(os);
@@ -295,7 +295,7 @@ void FileChangeTransferSyntax::SetTransferSyntax( TransferSyntax const & ts )
       Internals->IC = codecs[i]->Clone();
       }
     }
-  assert( Internals->TS );
+  gdcm_assert( Internals->TS );
 }
 
 ImageCodec * FileChangeTransferSyntax::GetCodec()

--- a/Source/MediaStorageAndFileFormat/gdcmFileDecompressLookupTable.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileDecompressLookupTable.cxx
@@ -28,8 +28,8 @@ bool FileDecompressLookupTable::Change()
     if ( pi == PhotometricInterpretation::PALETTE_COLOR )
       {
       const LookupTable &lut = PixelData->GetLUT();
-      assert( lut.Initialized() );
-//      assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
+      gdcm_assert( lut.Initialized() );
+//      gdcm_assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
 //           || (pf.GetBitsAllocated() == 16 && pf.GetPixelRepresentation() == 0) );
       // lut descriptor:
       // (0028,1101) US 256\0\16                                 #   6, 3 RedPaletteColorLookupTableDescriptor

--- a/Source/MediaStorageAndFileFormat/gdcmFileExplicitFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileExplicitFilter.cxx
@@ -92,10 +92,10 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
     const DictEntry &entry = dicts.GetDictEntry(t,owner);
     const VR &vr = entry.GetVR();
 
-    //assert( de.GetVR() == VR::INVALID );
+    //gdcm_assert( de.GetVR() == VR::INVALID );
     VR cvr = DataSetHelper::ComputeVR(*F,ds, t);
     VR oldvr = de.GetVR();
-    if( cvr == VR::SQ ) { assert( oldvr == VR::SQ || oldvr == VR::UN || oldvr == VR::INVALID || oldvr == VR::OB ); }
+    if( cvr == VR::SQ ) { gdcm_assert( oldvr == VR::SQ || oldvr == VR::UN || oldvr == VR::INVALID || oldvr == VR::OB ); }
     //SequenceOfItems *sqi = de.GetSequenceOfItems();
     //SequenceOfItems *sqi = dynamic_cast<SequenceOfItems*>(&de.GetValue());
     SmartPointer<SequenceOfItems> sqi = nullptr;
@@ -115,15 +115,15 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
     if( de.GetByteValue() && !sqi )
       {
       // all set
-      //assert( cvr != VR::SQ /*&& cvr != VR::UN*/ );
-      assert( cvr != VR::INVALID );
+      //gdcm_assert( cvr != VR::SQ /*&& cvr != VR::UN*/ );
+      gdcm_assert( cvr != VR::INVALID );
       if( cvr != VR::UN )
         {
         // about to change , make some paranoid test:
-        //assert( cvr.Compatible( oldvr ) ); // LT != LO but there are somewhat compatible
+        //gdcm_assert( cvr.Compatible( oldvr ) ); // LT != LO but there are somewhat compatible
         if( cvr & VR::VRASCII )
           {
-          //assert( oldvr & VR::VRASCII || oldvr == VR::INVALID || oldvr == VR::UN );
+          //gdcm_assert( oldvr & VR::VRASCII || oldvr == VR::INVALID || oldvr == VR::UN );
           // gdcm-JPEG-Extended.dcm has a couple of VR::OB private field
           // is this a good idea to change them to an ASCII when we know this might not work ?
           if( !(oldvr & VR::VRASCII || oldvr == VR::INVALID || oldvr == VR::UN || oldvr == VR::OB) )
@@ -143,7 +143,7 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
           }
         else
           {
-          assert( 0 ); // programmer error
+          gdcm_assert( 0 ); // programmer error
           }
 
         // let's do one more check we are going to make this attribute explicit VR, there is
@@ -157,7 +157,7 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
       }
     else if( sqi )
       {
-      assert( cvr == VR::SQ || cvr == VR::UN );
+      gdcm_assert( cvr == VR::SQ || cvr == VR::UN );
       de.SetVR( VR::SQ );
       if( de.GetByteValue() )
         {
@@ -165,7 +165,7 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
         //de.SetVL( sqi->ComputeLength<ExplicitDataElement>() );
         }
       de.SetVLToUndefined();
-      assert( sqi->GetLength().IsUndefined() );
+      gdcm_assert( sqi->GetLength().IsUndefined() );
       // recursive
       SequenceOfItems::ItemVector::iterator sit = sqi->Items.begin();
       for(; sit != sqi->Items.end(); ++sit)
@@ -181,7 +181,7 @@ bool FileExplicitFilter::ProcessDataSet(DataSet &ds, Dicts const & dicts)
       }
     else if( de.GetSequenceOfFragments() )
       {
-      assert( cvr & VR::OB );
+      gdcm_assert( cvr & VR::OB );
       }
     else
       {

--- a/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
@@ -105,7 +105,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
   char buffer[BUFFERSIZE];
   struct stat sb;
 
-  assert( pFile );
+  gdcm_assert( pFile );
   int fd = fileno( pFile );
   if (fstat(fd, &sb) == 0)
     {
@@ -126,7 +126,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
           {
           return false;
           }
-        assert( wr_off < rd_off );
+        gdcm_assert( wr_off < rd_off );
         if( FSeeko(pFile, wr_off, SEEK_SET) )
           {
           return false;
@@ -138,7 +138,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
         bytes_to_move -= bytes_this_time;
         read_start_offset += bytes_this_time;
         }
-      assert( read_start_offset == sb.st_size );
+      gdcm_assert( read_start_offset == sb.st_size );
       if( !FTruncate( fd, sb.st_size + inslen ) )
         {
         return false;
@@ -147,7 +147,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
     else
       {
 #if 0
-      assert(sb.st_size >= offset);
+      gdcm_assert(sb.st_size >= offset);
 #endif
       if (sb.st_size > offset)
         {
@@ -157,7 +157,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
           {
           const size_t bytes_this_time = static_cast<size_t>(std::min((off64_t)BUFFERSIZE, bytes_to_move));
           const off64_t rd_off = read_end_offset - bytes_this_time;
-          assert( (off64_t)rd_off >= offset );
+          gdcm_assert( (off64_t)rd_off >= offset );
           const off64_t wr_off = rd_off + inslen;
           if( FSeeko(pFile, rd_off, SEEK_SET) )
             {
@@ -178,7 +178,7 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
           bytes_to_move -= bytes_this_time;
           read_end_offset = rd_off;
           }
-        assert( read_end_offset == offset );
+        gdcm_assert( read_end_offset == offset );
         }
       }
     // easy case when sb.st_size == offset ...
@@ -269,7 +269,7 @@ public:
     {
     Self->InvokeEvent( StartEvent() );
     const char *outfilename = OutFilename.c_str();
-    assert( outfilename );
+    gdcm_assert( outfilename );
     actualde = 0;
       {
       std::ifstream is( outfilename, std::ios::binary );
@@ -305,7 +305,7 @@ public:
           {
           // if you trigger this assertion, this means we have been allocating
           // memory for an element when not needed.
-          assert( (de.GetByteValue() && de.GetByteValue()->GetPointer() == nullptr) || de.GetSequenceOfFragments() );
+          gdcm_assert( (de.GetByteValue() && de.GetByteValue()->GetPointer() == nullptr) || de.GetSequenceOfFragments() );
           }
         actualde = de.GetVL() + 2 * de.GetVR().GetLength() + 4;
         thepos -= actualde;
@@ -315,9 +315,9 @@ public:
         // no attribute found, easy case !
         }
       }
-    assert( pFile == nullptr );
+    gdcm_assert( pFile == nullptr );
     pFile = fopen(outfilename, "r+b");
-    assert( pFile );
+    gdcm_assert( pFile );
     CurrentDataLenth = 0;
     return true;
     }
@@ -330,11 +330,11 @@ public:
       if( TS.GetNegociatedType() == TransferSyntax::Explicit )
         dicomlen += 4;
       off64_t newlen = len;
-      assert( (size_t)newlen == len );
+      gdcm_assert( (size_t)newlen == len );
       newlen += dicomlen;
       newlen -= actualde;
       off64_t plength = newlen;
-      assert( ReservedDataLength >= 0 );
+      gdcm_assert( ReservedDataLength >= 0 );
       if( ReservedDataLength )
         {
         if( (newlen + ReservedDataLength) >= (off64_t)len )
@@ -346,7 +346,7 @@ public:
           plength = newlen + ReservedDataLength - len;
           }
         ReservedDataLength -= len;
-        assert( ReservedDataLength >= 0 );
+        gdcm_assert( ReservedDataLength >= 0 );
         }
       //if( !prepare_file( pFile, (off64_t)thepos + actualde, newlen ) )
       if( !prepare_file( pFile, (off64_t)thepos + actualde, plength ) )
@@ -357,14 +357,14 @@ public:
       const Tag tag = t;
       const VL vl = 0; // will be updated later (UpdateDataElement)
       const size_t ddsize = WriteHelper( thepos, tag, vl );
-      assert( ddsize == dicomlen ); (void)ddsize;
+      gdcm_assert( ddsize == dicomlen ); (void)ddsize;
       thepos += dicomlen;
       }
     else
       {
-      assert( pFile );
+      gdcm_assert( pFile );
       const off64_t curpos = FTello(pFile);
-      assert( curpos == thepos );
+      gdcm_assert( curpos == thepos );
       if( ReservedDataLength >= (off64_t)len )
         {
         // simply update remaining reserved buffer:
@@ -373,7 +373,7 @@ public:
       else
         {
         const off64_t plength = len - ReservedDataLength;
-        assert( plength >= 0 );
+        gdcm_assert( plength >= 0 );
         if( !prepare_file( pFile, (off64_t)curpos, plength) )
           {
           return false;
@@ -383,18 +383,18 @@ public:
       FSeeko(pFile, curpos, SEEK_SET);
       }
 
-    assert( ReservedDataLength >= 0 );
+    gdcm_assert( ReservedDataLength >= 0 );
     fwrite(data, 1, len, pFile);
     thepos += len;
     CurrentDataLenth += len;
-    assert( CurrentDataLenth < std::numeric_limits<uint32_t>::max() );
+    gdcm_assert( CurrentDataLenth < std::numeric_limits<uint32_t>::max() );
     return true;
     }
   bool StopDataElement( const Tag & t )
     {
     // Update DataElement:
     const size_t currentdatalenth = CurrentDataLenth;
-    assert( ReservedDataLength >= 0);
+    gdcm_assert( ReservedDataLength >= 0);
     //const off64_t refpos = FTello(pFile);
     if( !UpdateDataElement( t ) )
       {
@@ -409,7 +409,7 @@ public:
         }
       ReservedDataLength = 0;
       }
-    assert( ReservedDataLength == 0);
+    gdcm_assert( ReservedDataLength == 0);
     fclose(pFile);
     pFile = nullptr;
     // Do some extra work:
@@ -488,7 +488,7 @@ public:
     // mechanism we can simply append
     const char *outfilename = OutFilename.c_str();
     DataElement private_creator = ori_pt.GetAsDataElement();
-    assert( outfilename );
+    gdcm_assert( outfilename );
     Tag curtag = ori_pt;
       {
       bool cont = false;
@@ -534,7 +534,7 @@ public:
     std::string dicomdata;
       {
       std::stringstream ss;
-      assert( private_creator.GetTag().IsPrivateCreator() );
+      gdcm_assert( private_creator.GetTag().IsPrivateCreator() );
       if( TS.GetSwapCode() == SwapCode::BigEndian )
         {
         if( TS.GetNegociatedType() == TransferSyntax::Explicit )
@@ -565,7 +565,7 @@ public:
       {
       std::set<Tag> tagset;
       Tag prev = private_creator.GetTag();
-      //assert( prev.GetElement() );
+      //gdcm_assert( prev.GetElement() );
       prev.SetElement( (uint16_t)(prev.GetElement() - 0x1) );
       tagset.insert( prev );
 
@@ -583,9 +583,9 @@ public:
       }
 
     const size_t pclen = dicomdata.size();
-    assert( pFile == nullptr );
+    gdcm_assert( pFile == nullptr );
     pFile = fopen(outfilename, "r+b");
-    assert( pFile );
+    gdcm_assert( pFile );
 
     if( !prepare_file( pFile, (off64_t)thepcpos, pclen ) )
       {
@@ -621,22 +621,22 @@ public:
       {
       Self->InvokeEvent( IterationEvent() );
       const size_t len_this_time = std::min(MaxSizeDE - CurrentDataLenth, len_to_move);
-      assert( len_this_time % 2 == 0 );
+      gdcm_assert( len_this_time % 2 == 0 );
       if( !AppendToDataElement( CurrentGroupTag, data, len_this_time ) )
         {
         return false;
         }
-      assert( CurrentDataLenth <= MaxSizeDE );
+      gdcm_assert( CurrentDataLenth <= MaxSizeDE );
       len_to_move -= len_this_time;
       if( CurrentDataLenth == MaxSizeDE )
         {
         // flush
-        assert( CurrentDataLenth % 2 == 0 );
+        gdcm_assert( CurrentDataLenth % 2 == 0 );
         if( !UpdateDataElement( CurrentGroupTag ) )
           {
           return false;
           }
-        assert( CurrentDataLenth == 0 );
+        gdcm_assert( CurrentDataLenth == 0 );
         CurrentGroupTag.SetElement( (uint16_t)(CurrentGroupTag.GetElement() + 1) );
         const int lowbits = CurrentGroupTag.GetElement() & 0x00ff;
         if( lowbits == 0 )
@@ -701,10 +701,10 @@ private:
         FSeeko(pFile, curpos, SEEK_SET);
         int ret = fputc(0, pFile); // Set to NULL padding ?
         thepos += 1;
-        assert( ret != EOF ); (void)ret;
+        gdcm_assert( ret != EOF ); (void)ret;
         CurrentDataLenth += 1;
         }
-      assert( CurrentDataLenth % 2 == 0 );
+      gdcm_assert( CurrentDataLenth % 2 == 0 );
       off64_t vlpos = thepos;
       vlpos -= CurrentDataLenth;
       vlpos -= 4; // VL
@@ -801,8 +801,8 @@ bool FileStreamer::InitializeCopy()
       }
     else
       {
-      assert( filename );
-      assert( outfilename );
+      gdcm_assert( filename );
+      gdcm_assert( outfilename );
       std::ifstream is( filename, std::ios::binary );
       if( !is.good() ) return false;
       if( strcmp( filename, outfilename ) != 0 )

--- a/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmIPPSorter.cxx
@@ -255,7 +255,7 @@ bool IPPSorter::Sort(std::vector<std::string> const & filenames)
       }
     }
 }
-  assert( !sorted.empty() );
+  gdcm_assert( !sorted.empty() );
 {
   SortedFilenames::const_iterator it2 = sorted.begin();
   double prev = it2->first;
@@ -307,7 +307,7 @@ bool IPPSorter::Sort(std::vector<std::string> const & filenames)
         }
       gdcmDebugMacro( os.str() );
       }
-    assert( spacingisgood == false ||  (ComputeZSpacing ? (ZSpacing > ZTolerance && ZTolerance > 0) : ZTolerance > 0) );
+    gdcm_assert( spacingisgood == false ||  (ComputeZSpacing ? (ZSpacing > ZTolerance && ZTolerance > 0) : ZTolerance > 0) );
     }
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmIconImage.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmIconImage.cxx
@@ -53,7 +53,7 @@ IconImage::~IconImage() {}
 
 void IconImage::SetDimension(unsigned int idx, unsigned int dim)
 {
-  assert( idx < NumberOfDimensions );
+  gdcm_assert( idx < NumberOfDimensions );
   Dimensions.resize( NumberOfDimensions );
   // Can dim be 0 ??
   Dimensions[idx] = dim;
@@ -97,9 +97,9 @@ bool IconImage::GetBuffer(char *buffer) const
     buffer = 0;
     return false;
     }
-  assert( bv );
+  gdcm_assert( bv );
   RAWCodec codec;
-  //assert( GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
+  //gdcm_assert( GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
   //codec.SetPhotometricInterpretation( GetPhotometricInterpretation() );
   if( GetPhotometricInterpretation() != PhotometricInterpretation::MONOCHROME2 )
     {
@@ -110,9 +110,9 @@ bool IconImage::GetBuffer(char *buffer) const
   codec.SetPlanarConfiguration( 0 );
   DataElement out;
   bool r = codec.Decode(PixelData, out);
-  assert( r );
+  gdcm_assert( r );
   const ByteValue *outbv = out.GetByteValue();
-  assert( outbv );
+  gdcm_assert( outbv );
   //unsigned long check = outbv->GetLength();  // FIXME
   memcpy(buffer, outbv->GetPointer(), outbv->GetLength() );  // FIXME
   return r;

--- a/Source/MediaStorageAndFileFormat/gdcmIconImageFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmIconImageFilter.cxx
@@ -100,7 +100,7 @@ void IconImageFilter::ExtractIconImages()
       pixeldata.SetPixelFormat( pf );
       // D 0028|0004 [CS] [Photometric Interpretation] [MONOCHROME2 ]
       const Tag tphotometricinterpretation(0x0028, 0x0004);
-      assert( ds.FindDataElement( tphotometricinterpretation ) );
+      gdcm_assert( ds.FindDataElement( tphotometricinterpretation ) );
       const ByteValue *photometricinterpretation =
         ds.GetDataElement( tphotometricinterpretation ).GetByteValue();
       std::string photometricinterpretation_str(
@@ -109,7 +109,7 @@ void IconImageFilter::ExtractIconImages()
       PhotometricInterpretation pi(
         PhotometricInterpretation::GetPIType(
           photometricinterpretation_str.c_str()));
-      assert( pi != PhotometricInterpretation::UNKNOWN);
+      gdcm_assert( pi != PhotometricInterpretation::UNKNOWN);
       pixeldata.SetPhotometricInterpretation( pi );
 
       //
@@ -151,29 +151,29 @@ void IconImageFilter::ExtractIconImages()
           if( ds.FindDataElement( tlut ) )
             {
             const ByteValue *lut_raw = ds.GetDataElement( tlut ).GetByteValue();
-            assert( lut_raw );
+            gdcm_assert( lut_raw );
             // LookupTableType::RED == 0
             lut->SetLUT( LookupTable::LookupTableType(i),
               (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-            //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+            //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
 
             //unsigned long check =
             //  (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
             //  * el_us3.GetValue(2) / 8;
-            //assert( check == lut_raw->GetLength() ); (void)check;
+            //gdcm_assert( check == lut_raw->GetLength() ); (void)check;
             }
           else if( ds.FindDataElement( seglut ) )
             {
             const ByteValue *lut_raw = ds.GetDataElement( seglut ).GetByteValue();
-            assert( lut_raw );
+            gdcm_assert( lut_raw );
             lut->SetLUT( LookupTable::LookupTableType(i),
               (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-            //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+            //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
 
             //unsigned long check =
             //  (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
             //  * el_us3.GetValue(2) / 8;
-            //assert( check == lut_raw->GetLength() ); (void)check;
+            //gdcm_assert( check == lut_raw->GetLength() ); (void)check;
             }
           else
             {
@@ -216,7 +216,7 @@ void IconImageFilter::ExtractIconImages()
     //const SequenceOfItems* sq = iconimagesq.GetSequenceOfItems();
     SmartPointer<SequenceOfItems> sq = iconimagesq.GetValueAsSQ();
     // Is SQ empty ?
-    assert( sq );
+    gdcm_assert( sq );
     if( !sq ) return;
     SmartPointer< IconImage > si1 = new IconImage;
     IconImage &pixeldata = *si1;
@@ -279,7 +279,7 @@ void IconImageFilter::ExtractIconImages()
     pixeldata.SetPixelFormat( pf1 );
     // D 0028|0004 [CS] [Photometric Interpretation] [MONOCHROME2 ]
     const Tag tphotometricinterpretation(0x0028, 0x0004);
-    assert( ds.FindDataElement( tphotometricinterpretation ) );
+    gdcm_assert( ds.FindDataElement( tphotometricinterpretation ) );
     const ByteValue *photometricinterpretation = ds.GetDataElement( tphotometricinterpretation ).GetByteValue();
     std::string photometricinterpretation_str(
       photometricinterpretation->GetPointer(),
@@ -287,10 +287,10 @@ void IconImageFilter::ExtractIconImages()
     PhotometricInterpretation pi(
       PhotometricInterpretation::GetPIType(
         photometricinterpretation_str.c_str()));
-    assert( pi != PhotometricInterpretation::UNKNOWN);
+    gdcm_assert( pi != PhotometricInterpretation::UNKNOWN);
     pixeldata.SetPhotometricInterpretation( pi );
     const Tag tpixeldata = Tag(0x7fe0, 0x0010);
-    assert( ds.FindDataElement( tpixeldata ) );
+    gdcm_assert( ds.FindDataElement( tpixeldata ) );
       {
       const DataElement& de = ds.GetDataElement( tpixeldata );
 #if 0
@@ -319,7 +319,7 @@ void IconImageFilter::ExtractIconImages()
 #if 1
       std::istringstream is;
       const ByteValue *bv = de.GetByteValue();
-      assert( bv );
+      gdcm_assert( bv );
       is.str( std::string( bv->GetPointer(), bv->GetLength() ) );
       TransferSyntax jpegts;
       JPEGCodec jpeg;
@@ -327,7 +327,7 @@ void IconImageFilter::ExtractIconImages()
       bool b = jpeg.GetHeaderInfo( is, jpegts );
       if( !b )
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       //jpeg.GetPixelFormat().Print (std::cout);
       pixeldata.SetPixelFormat( jpeg.GetPixelFormat() );
@@ -353,7 +353,7 @@ void IconImageFilter::ExtractIconImages()
     //const SequenceOfItems* sq = iconimagesq.GetSequenceOfItems();
     SmartPointer<SequenceOfItems> sq = iconimagesq.GetValueAsSQ();
     // Is SQ empty ?
-    assert( sq );
+    gdcm_assert( sq );
     if( !sq ) return;
 
     SmartPointer< IconImage > si1 = new IconImage;
@@ -417,7 +417,7 @@ void IconImageFilter::ExtractIconImages()
     pixeldata.SetPixelFormat( pf );
     // D 0028|0004 [CS] [Photometric Interpretation] [MONOCHROME2 ]
     const Tag tphotometricinterpretation(0x0028, 0x0004);
-    assert( ds.FindDataElement( tphotometricinterpretation ) );
+    gdcm_assert( ds.FindDataElement( tphotometricinterpretation ) );
     const ByteValue *photometricinterpretation = ds.GetDataElement( tphotometricinterpretation ).GetByteValue();
     std::string photometricinterpretation_str(
       photometricinterpretation->GetPointer(),
@@ -425,11 +425,11 @@ void IconImageFilter::ExtractIconImages()
     PhotometricInterpretation pi(
       PhotometricInterpretation::GetPIType(
         photometricinterpretation_str.c_str()));
-    assert( pi != PhotometricInterpretation::UNKNOWN);
+    gdcm_assert( pi != PhotometricInterpretation::UNKNOWN);
     pixeldata.SetPhotometricInterpretation( pi );
     //const Tag tpixeldata = Tag(0x7fe0, 0x0010);
     const PrivateTag tpixeldata(0x6003,0x0011,"GEMS_Ultrasound_ImageGroup_001");
-    assert( ds.FindDataElement( tpixeldata ) );
+    gdcm_assert( ds.FindDataElement( tpixeldata ) );
       {
       const DataElement& de = ds.GetDataElement( tpixeldata );
       pixeldata.SetDataElement( de );
@@ -519,7 +519,7 @@ void IconImageFilter::ExtractVeproIconImages()
     dims[0] = data.Width;
     dims[1] = data.Height;
 
-    assert( dims[0] * dims[1] == len - sizeof(data) - offset );
+    gdcm_assert( dims[0] * dims[1] == len - sizeof(data) - offset );
 
     DataElement pd;
     pd.SetByteValue( raw + offset, (uint32_t)(len - sizeof(data) - offset) );
@@ -555,7 +555,7 @@ unsigned int IconImageFilter::GetNumberOfIconImages() const
 
 IconImage& IconImageFilter::GetIconImage( unsigned int i ) const
 {
-  assert( i < Internals->icons.size() );
+  gdcm_assert( i < Internals->icons.size() );
   return *Internals->icons[i];
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmIconImageGenerator.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmIconImageGenerator.cxx
@@ -140,7 +140,7 @@ Retrieved from: http://en.literateprograms.org/Median_cut_algorithm_(C_Plus_Plus
 
   Block::Block(Point* pts, std::ptrdiff_t ptslen)
     {
-    assert( ptslen > 0 );
+    gdcm_assert( ptslen > 0 );
     this->points = pts;
     this->pointsLength = (int)ptslen;
     for(int i=0; i < NUM_DIMENSIONS; i++)
@@ -207,16 +207,16 @@ Retrieved from: http://en.literateprograms.org/Median_cut_algorithm_(C_Plus_Plus
   std::list<Point> medianCut(DataElement const &PixelData, int numPoints, unsigned int desiredSize,
     std::vector<unsigned char> & outputimage )
     {
-    assert( numPoints > 0 );
+    gdcm_assert( numPoints > 0 );
     //Point* Points = (Point*)malloc(sizeof(Point) * numPoints);
     Point* Points = new Point[numPoints];
-    assert( Points );
+    gdcm_assert( Points );
     const ByteValue *bv = PixelData.GetByteValue();
-    assert( bv );
+    gdcm_assert( bv );
     const unsigned char *inbuffer = (const unsigned char*)bv->GetPointer();
-    assert( inbuffer );
+    gdcm_assert( inbuffer );
     size_t bvlen = bv->GetLength(); (void)bvlen;
-    assert( bvlen == (size_t) numPoints * 3 ); // only 8bits RGB please
+    gdcm_assert( bvlen == (size_t) numPoints * 3 ); // only 8bits RGB please
     for(int i = 0; i < numPoints; i++)
       {
 #if 0
@@ -289,19 +289,19 @@ Retrieved from: http://en.literateprograms.org/Median_cut_algorithm_(C_Plus_Plus
 
       //int index = std::distance(s.begin(), it.first);
       size_t index = result.size();
-      assert( index <= 256 );
+      gdcm_assert( index <= 256 );
 
       for(int i = 0; i < numPoints; i++)
         {
         const unsigned char *currentcolor = inbuffer + 3 * i;
         for(size_t j = 0; j < (size_t)block.numPoints(); j++)
           {
-          assert( currentcolor < inbuffer + bvlen );
-          assert( currentcolor + 3 <= inbuffer + bvlen );
+          gdcm_assert( currentcolor < inbuffer + bvlen );
+          gdcm_assert( currentcolor + 3 <= inbuffer + bvlen );
           if( std::equal( currentcolor, currentcolor + 3, points[j].x ) )
             {
-            //assert( outputimage[i] == 0 );
-            assert( index > 0 );
+            //gdcm_assert( outputimage[i] == 0 );
+            gdcm_assert( index > 0 );
             outputimage[i] = (unsigned char)(index - 1);
             }
           }
@@ -317,7 +317,7 @@ Retrieved from: http://en.literateprograms.org/Median_cut_algorithm_(C_Plus_Plus
 // Create LUT with a maximum number of color equal to \param maxcolor
 void IconImageGenerator::BuildLUT( Bitmap & bitmap, unsigned int maxcolor )
 {
-  assert( Internals->ConvertRGBToPaletteColor );
+  gdcm_assert( Internals->ConvertRGBToPaletteColor );
   using namespace quantization;
   const unsigned int *dims = bitmap.GetDimensions();
   unsigned int numPoints = dims[0]*dims[1];
@@ -349,7 +349,7 @@ void IconImageGenerator::BuildLUT( Bitmap & bitmap, unsigned int maxcolor )
     }
 
   bitmap.GetDataElement().SetByteValue( (char*)indeximage.data(), (uint32_t)indeximage.size() );
-  assert( lut.Initialized() );
+  gdcm_assert( lut.Initialized() );
 }
 
 void IconImageGenerator::SetOutsideValuePixel(double v)
@@ -381,9 +381,9 @@ void IconImageGenerator::SetPixelMinMax(double min, double max)
 template <typename TPixelType>
 void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &max, double discardvalue)
 {
-  assert( npixels );
+  gdcm_assert( npixels );
   const TPixelType discard = (TPixelType)discardvalue;
-  assert( (double)discard == discardvalue );
+  gdcm_assert( (double)discard == discardvalue );
   TPixelType lmin = std::numeric_limits< TPixelType>::max();
   TPixelType lmax = std::numeric_limits< TPixelType>::min();
   for( size_t i = 0; i < npixels; ++i )
@@ -397,8 +397,8 @@ void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &
       lmax = p[i];
       }
     }
-  //assert( lmin != std::numeric_limits< TPixelType>::max() );
-  //assert( lmax != std::numeric_limits< TPixelType>::min() );
+  //gdcm_assert( lmin != std::numeric_limits< TPixelType>::max() );
+  //gdcm_assert( lmax != std::numeric_limits< TPixelType>::min() );
 
   // what if lmin == lmax == 0 for example:
   // let's fake a slightly different min/max found:
@@ -407,7 +407,7 @@ void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &
     if( lmax == std::numeric_limits<TPixelType>::max() )
       {
       lmin--;
-      assert( lmin + 1 > lmin );
+      gdcm_assert( lmin + 1 > lmin );
       }
     else
       {
@@ -422,7 +422,7 @@ void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &
 template <typename TPixelType>
 void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &max)
 {
-  assert( npixels );
+  gdcm_assert( npixels );
   TPixelType lmin = std::numeric_limits< TPixelType>::max();
   TPixelType lmax = std::numeric_limits< TPixelType>::min();
   for( size_t i = 0; i < npixels; ++i )
@@ -436,8 +436,8 @@ void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &
       lmax = p[i];
       }
     }
-  //assert( lmin != std::numeric_limits< TPixelType>::max() );
-  //assert( lmax != std::numeric_limits< TPixelType>::min() );
+  //gdcm_assert( lmin != std::numeric_limits< TPixelType>::max() );
+  //gdcm_assert( lmax != std::numeric_limits< TPixelType>::min() );
 
   // what if lmin == lmax == 0 for example:
   // let's fake a slightly different min/max found:
@@ -446,7 +446,7 @@ void ComputeMinMax( const TPixelType *p, size_t npixels , double & min, double &
     if( lmax == std::numeric_limits<TPixelType>::max() )
       {
       lmin--;
-      assert( lmin + 1 > lmin );
+      gdcm_assert( lmin + 1 > lmin );
       }
     else
       {
@@ -521,7 +521,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
   else
     {
     I->SetPhotometricInterpretation( P->GetPhotometricInterpretation() );
-    assert( I->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( I->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
       || I->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2
       || I->GetPhotometricInterpretation() == PhotometricInterpretation::PALETTE_COLOR );
     if( !Internals->ConvertRGBToPaletteColor
@@ -531,7 +531,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       }
     }
 
-  assert( I->GetPlanarConfiguration() == 0 );
+  gdcm_assert( I->GetPlanarConfiguration() == 0 );
 
   // FIXME we should not retrieve the whole image, ideally we only need a
   // single 2D frame
@@ -540,7 +540,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
   if( P->GetNumberOfDimensions() == 3 )
     {
     const unsigned int *dims = P->GetDimensions();
-    assert( framelen % dims[2] == 0 );
+    gdcm_assert( framelen % dims[2] == 0 );
     framelen /= dims[2];
     }
   vbuffer.resize( P->GetBufferLength() );
@@ -573,8 +573,8 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
   for(unsigned int i = 0; i < Internals->dims[1]; ++i )
     for(unsigned int j = 0; j < Internals->dims[0]; ++j )
       {
-      assert( (i * Internals->dims[0] + j) * ps < I->GetBufferLength() );
-      assert( (i * imgdims[0] * stepj + j * stepi) * ps < framelen /*P->GetBufferLength()*/ );
+      gdcm_assert( (i * Internals->dims[0] + j) * ps < I->GetBufferLength() );
+      gdcm_assert( (i * imgdims[0] * stepj + j * stepi) * ps < framelen /*P->GetBufferLength()*/ );
       memcpy(iconb + (i * Internals->dims[0] + j) * ps,
         imgb + (i * imgdims[0] * stepj + j * stepi) * ps, ps );
       }
@@ -588,7 +588,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
 
     if( I->GetPixelFormat().GetBitsAllocated() == 16 )
       {
-      //assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
+      //gdcm_assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
       std::string s = ss.str();
       Rescaler r;
       r.SetPixelFormat( I->GetPixelFormat() );
@@ -605,8 +605,8 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       r.SetIntercept( 0 - step );
 
       // paranoid self check:
-      assert( r.GetIntercept() + r.GetSlope() * min == 0. );
-      assert( r.GetIntercept() + r.GetSlope() * max == 255. );
+      gdcm_assert( r.GetIntercept() + r.GetSlope() * min == 0. );
+      gdcm_assert( r.GetIntercept() + r.GetSlope() * max == 255. );
 
       r.SetTargetPixelType( PixelFormat::UINT8 );
       r.SetUseTargetPixelType(true);
@@ -615,7 +615,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       v8.resize( Internals->dims[0] * Internals->dims[1] * 3 );
       if( !r.Rescale(v8.data(),s.data(),s.size()) )
         {
-        assert( 0 ); // should not happen in real life
+        gdcm_assert( 0 ); // should not happen in real life
         gdcmErrorMacro( "Problem in the rescaler" );
         return false;
         }
@@ -644,7 +644,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       }
     else
       {
-      assert( I->GetPixelFormat() == PixelFormat::UINT8 );
+      gdcm_assert( I->GetPixelFormat() == PixelFormat::UINT8 );
       std::string s = ss.str();
       if( Internals->ConvertRGBToPaletteColor )
         {
@@ -675,7 +675,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
     if( P->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL
     || P->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL_422 )
       {
-      assert( I->GetPixelFormat() == PixelFormat::UINT8 );
+      gdcm_assert( I->GetPixelFormat() == PixelFormat::UINT8 );
       if( P->GetPlanarConfiguration() == 0 )
         {
         unsigned char *ybr = (unsigned char*)tempvbuf.data();
@@ -712,7 +712,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
     d.write( &tempvbuf[0], tempvbuf.size() );
     d.close();
 #endif
-        assert( ybr_out == ybr_end );
+        gdcm_assert( ybr_out == ybr_end );
         }
       else // ( P->GetPlanarConfiguration() == 1 )
         {
@@ -720,7 +720,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
 
         unsigned char *ybr = (unsigned char*)tempvbufybr.data();
         unsigned char *ybr_end = ybr + vbuffer2.size();
-        assert( vbuffer2.size() % 3 == 0 );
+        gdcm_assert( vbuffer2.size() % 3 == 0 );
         size_t ybrl = vbuffer2.size() / 3;
         unsigned char *ybra = ybr + 0 * ybrl;
         unsigned char *ybrb = ybr + 1 * ybrl;
@@ -754,21 +754,21 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
           *ybr_out = (unsigned char)G; ++ybr_out;
           *ybr_out = (unsigned char)B; ++ybr_out;
           }
-        assert( ybra + 2 * ybrl == ybr_end ); (void)ybr_end;
-        assert( ybrb + 1 * ybrl == ybr_end );
-        assert( ybrc + 0 * ybrl == ybr_end );
+        gdcm_assert( ybra + 2 * ybrl == ybr_end ); (void)ybr_end;
+        gdcm_assert( ybrb + 1 * ybrl == ybr_end );
+        gdcm_assert( ybrc + 0 * ybrl == ybr_end );
         }
       }
     else
       {
       if( P->GetPlanarConfiguration() == 1 )
         {
-        assert( I->GetPixelFormat() == PixelFormat::UINT8 );
+        gdcm_assert( I->GetPixelFormat() == PixelFormat::UINT8 );
         std::string tempvbufrgb = tempvbuf;
 
         unsigned char *rgb = (unsigned char*)tempvbufrgb.data();
         unsigned char *rgb_end = rgb + vbuffer2.size();
-        assert( vbuffer2.size() % 3 == 0 );
+        gdcm_assert( vbuffer2.size() % 3 == 0 );
         size_t rgbl = vbuffer2.size() / 3;
         unsigned char *rgba = rgb + 0 * rgbl;
         unsigned char *rgbb = rgb + 1 * rgbl;
@@ -786,9 +786,9 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
           *rgb_out = b; ++rgb_out;
           *rgb_out = c; ++rgb_out;
           }
-        assert( rgba + 2 * rgbl == rgb_end ); (void)rgb_end;
-        assert( rgbb + 1 * rgbl == rgb_end );
-        assert( rgbc + 0 * rgbl == rgb_end );
+        gdcm_assert( rgba + 2 * rgbl == rgb_end ); (void)rgb_end;
+        gdcm_assert( rgbb + 1 * rgbl == rgb_end );
+        gdcm_assert( rgbc + 0 * rgbl == rgb_end );
         }
       }
 
@@ -813,8 +813,8 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       }
     else
       {
-      assert( I->GetPixelFormat() == PixelFormat::UINT16 );
-      assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
+      gdcm_assert( I->GetPixelFormat() == PixelFormat::UINT16 );
+      gdcm_assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
       std::string s = is.str();
       Rescaler r;
       r.SetPixelFormat( I->GetPixelFormat() );
@@ -831,8 +831,8 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       r.SetIntercept( 0 - step );
 
       // paranoid self check:
-      assert( r.GetIntercept() + r.GetSlope() * min == 0. );
-      assert( r.GetIntercept() + r.GetSlope() * max == 255. );
+      gdcm_assert( r.GetIntercept() + r.GetSlope() * min == 0. );
+      gdcm_assert( r.GetIntercept() + r.GetSlope() * max == 255. );
 
       r.SetTargetPixelType( PixelFormat::UINT8 );
       r.SetUseTargetPixelType(true);
@@ -841,7 +841,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       v8.resize( Internals->dims[0] * Internals->dims[1] * 3 );
       if( !r.Rescale(v8.data(),s.data(),s.size()) )
         {
-        assert( 0 ); // should not happen in real life
+        gdcm_assert( 0 ); // should not happen in real life
         gdcmErrorMacro( "Problem in the rescaler" );
         return false;
         }
@@ -889,7 +889,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
       void *p = vbuffer2.data();
       size_t len = vbuffer2.size();
       const PixelFormat &pf = I->GetPixelFormat();
-      assert( pf.GetSamplesPerPixel() == 1 );
+      gdcm_assert( pf.GetSamplesPerPixel() == 1 );
       if( Internals->UseOutsideValuePixel )
         {
         const double d = Internals->OutsideValuePixel;
@@ -908,7 +908,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
           ComputeMinMax<int16_t>( (const int16_t*)p, len / sizeof( int16_t ), min, max, d);
           break;
         default:
-          assert( 0 ); // should not happen
+          gdcm_assert( 0 ); // should not happen
           break;
           }
         // ok we have found the min value, we should now be able to replace all value 'd' with this min now:
@@ -927,7 +927,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
           std::replace( (int16_t*)p, (int16_t*)p + len / sizeof( int16_t ), (int16_t)d, (int16_t)min);
           break;
         default:
-          assert( 0 ); // should not happen
+          gdcm_assert( 0 ); // should not happen
           break;
           }
         }
@@ -946,7 +946,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
         ComputeMinMax<int16_t>( (const int16_t*)p, len / sizeof( int16_t ), min, max);
         break;
       default:
-        assert( 0 ); // should not happen
+        gdcm_assert( 0 ); // should not happen
         break;
         }
       }
@@ -955,8 +955,8 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
     r.SetIntercept( 0 - step );
 
     // paranoid self check:
-    assert( (int)(0.5 + r.GetIntercept() + r.GetSlope() * min) == 0 );
-    assert( (int)(0.5 + r.GetIntercept() + r.GetSlope() * max) == 255 );
+    gdcm_assert( (int)(0.5 + r.GetIntercept() + r.GetSlope() * min) == 0 );
+    gdcm_assert( (int)(0.5 + r.GetIntercept() + r.GetSlope() * max) == 255 );
 
     r.SetTargetPixelType( PixelFormat::UINT8 );
     r.SetUseTargetPixelType(true);
@@ -965,7 +965,7 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
     v8.resize( Internals->dims[0] * Internals->dims[1] );
     if( !r.Rescale(v8.data(),vbuffer2.data(),vbuffer2.size()) )
       {
-      assert( 0 ); // should not happen in real life
+      gdcm_assert( 0 ); // should not happen in real life
       gdcmErrorMacro( "Problem in the rescaler" );
       return false;
       }
@@ -979,16 +979,16 @@ f. If a Palette Color lookup Table is used, an 8 Bit Allocated (0028,0100) shall
   if( !Internals->ConvertRGBToPaletteColor
     && I->GetPhotometricInterpretation() == PhotometricInterpretation::RGB )
     {
-    assert( I->GetPixelFormat().GetSamplesPerPixel() == 3 );
+    gdcm_assert( I->GetPixelFormat().GetSamplesPerPixel() == 3 );
     }
   else
     {
-    assert( I->GetPixelFormat().GetSamplesPerPixel() == 1 );
+    gdcm_assert( I->GetPixelFormat().GetSamplesPerPixel() == 1 );
     }
-  assert( I->GetPixelFormat().GetBitsAllocated() == 8 );
-  assert( I->GetPixelFormat().GetBitsStored() == 8 );
-  assert( I->GetPixelFormat().GetHighBit() == 7 );
-  assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
+  gdcm_assert( I->GetPixelFormat().GetBitsAllocated() == 8 );
+  gdcm_assert( I->GetPixelFormat().GetBitsStored() == 8 );
+  gdcm_assert( I->GetPixelFormat().GetHighBit() == 7 );
+  gdcm_assert( I->GetPixelFormat().GetPixelRepresentation() == 0 );
 
   return true;
 }

--- a/Source/MediaStorageAndFileFormat/gdcmImage.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImage.cxx
@@ -27,37 +27,37 @@ namespace gdcm
 
 const double *Image::GetSpacing() const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   return Spacing.data();
 }
 
 double Image::GetSpacing(unsigned int idx) const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   //if( idx < Spacing.size() )
     {
     return Spacing[idx];
     }
-  //assert( 0 && "Should not happen" );
+  //gdcm_assert( 0 && "Should not happen" );
   //return 1; // FIXME ???
 }
 
 void Image::SetSpacing(const double *spacing)
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   Spacing.assign(spacing, spacing+NumberOfDimensions);
 }
 
 void Image::SetSpacing(unsigned int idx, double spacing)
 {
-  //assert( spacing > 1.e3 );
+  //gdcm_assert( spacing > 1.e3 );
   Spacing.resize( 3 /*idx + 1*/ );
   Spacing[idx] = spacing;
 }
 
 const double *Image::GetOrigin() const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   if( !Origin.empty() )
     return Origin.data();
   return nullptr;
@@ -65,7 +65,7 @@ const double *Image::GetOrigin() const
 
 double Image::GetOrigin(unsigned int idx) const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   if( idx < Origin.size() )
     {
     return Origin[idx];
@@ -75,7 +75,7 @@ double Image::GetOrigin(unsigned int idx) const
 
 void Image::SetOrigin(const float *ori)
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   Origin.resize( NumberOfDimensions );
   for(unsigned int i = 0; i < NumberOfDimensions; ++i)
     {
@@ -85,7 +85,7 @@ void Image::SetOrigin(const float *ori)
 
 void Image::SetOrigin(const double *ori)
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   Origin.assign(ori, ori+NumberOfDimensions);
 }
 
@@ -97,14 +97,14 @@ void Image::SetOrigin(unsigned int idx, double ori)
 
 const double *Image::GetDirectionCosines() const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   if( !DirectionCosines.empty() )
     return DirectionCosines.data();
   return nullptr;
 }
 double Image::GetDirectionCosines(unsigned int idx) const
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   if( idx < DirectionCosines.size() )
     {
     return DirectionCosines[idx];
@@ -114,7 +114,7 @@ double Image::GetDirectionCosines(unsigned int idx) const
 
 void Image::SetDirectionCosines(const float *dircos)
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   DirectionCosines.resize( 6 );
   for(int i = 0; i < 6; ++i)
     {
@@ -124,7 +124,7 @@ void Image::SetDirectionCosines(const float *dircos)
 
 void Image::SetDirectionCosines(const double *dircos)
 {
-  assert( NumberOfDimensions );
+  gdcm_assert( NumberOfDimensions );
   DirectionCosines.assign(dircos, dircos+6);
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageApplyLookupTable.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageApplyLookupTable.cxx
@@ -80,7 +80,7 @@ bool ImageApplyLookupTable::Apply()
     lut.Decode8(v2.data(), v2.size(), v.data(), v.size());
   else
     lut.Decode(v2.data(), v2.size(), v.data(), v.size());
-  assert( v2.size() < (size_t)std::numeric_limits<uint32_t>::max() );
+  gdcm_assert( v2.size() < (size_t)std::numeric_limits<uint32_t>::max() );
   if( pimpl->rgb8 )
     de.SetByteValue( v2.data(), (uint32_t)v2.size() / 2);
   else
@@ -93,14 +93,14 @@ bool ImageApplyLookupTable::Apply()
     Output->GetPixelFormat().SetBitsAllocated(8);
   Output->SetPlanarConfiguration( 0 ); // FIXME OT-PAL-8-face.dcm has a PlanarConfiguration while being PALETTE COLOR...
   const TransferSyntax &ts = image.GetTransferSyntax();
-  //assert( ts == TransferSyntax::RLELossless );
+  //gdcm_assert( ts == TransferSyntax::RLELossless );
   if( ts.IsExplicit() )
     {
     Output->SetTransferSyntax( TransferSyntax::ExplicitVRLittleEndian );
     }
   else
     {
-    assert( ts.IsImplicit() );
+    gdcm_assert( ts.IsImplicit() );
     Output->SetTransferSyntax( TransferSyntax::ImplicitVRLittleEndian );
     }
   // I do not have access to the DataSet:

--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.cxx
@@ -77,14 +77,14 @@ bool ImageChangePhotometricInterpretation::ChangeMonochrome()
   //Output->GetPixelFormat().SetSamplesPerPixel( 3 );
   //Output->SetPlanarConfiguration( 0 ); // FIXME OT-PAL-8-face.dcm has a PlanarConfiguration while being PALETTE COLOR...
   //const TransferSyntax &ts = image.GetTransferSyntax();
-  ////assert( ts == TransferSyntax::RLELossless );
+  ////gdcm_assert( ts == TransferSyntax::RLELossless );
   //if( ts.IsExplicit() )
   //  {
   //  Output->SetTransferSyntax( TransferSyntax::ExplicitVRLittleEndian );
   //  }
   //else
   //  {
-  //  assert( ts.IsImplicit() );
+  //  gdcm_assert( ts.IsImplicit() );
   //  Output->SetTransferSyntax( TransferSyntax::ImplicitVRLittleEndian );
   //  }
 
@@ -101,7 +101,7 @@ bool ImageChangePhotometricInterpretation::ChangeYBR2RGB()
   // mistake. just like Largest Image Pixel Value and other would be wrong
   const Bitmap &image = *Input;
   PhotometricInterpretation pi = image.GetPhotometricInterpretation();
-  //assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
+  //gdcm_assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
   if( pi == PI )
   {
     return true;
@@ -153,14 +153,14 @@ bool ImageChangePhotometricInterpretation::ChangeYBR2RGB()
   //Output->GetPixelFormat().SetSamplesPerPixel( 3 );
   //Output->SetPlanarConfiguration( 0 ); // FIXME OT-PAL-8-face.dcm has a PlanarConfiguration while being PALETTE COLOR...
   //const TransferSyntax &ts = image.GetTransferSyntax();
-  ////assert( ts == TransferSyntax::RLELossless );
+  ////gdcm_assert( ts == TransferSyntax::RLELossless );
   //if( ts.IsExplicit() )
   //  {
   //  Output->SetTransferSyntax( TransferSyntax::ExplicitVRLittleEndian );
   //  }
   //else
   //  {
-  //  assert( ts.IsImplicit() );
+  //  gdcm_assert( ts.IsImplicit() );
   //  Output->SetTransferSyntax( TransferSyntax::ImplicitVRLittleEndian );
   //  }
 
@@ -178,7 +178,7 @@ bool ImageChangePhotometricInterpretation::ChangeRGB2YBR()
   // mistake. just like Largest Image Pixel Value and other would be wrong
   const Bitmap &image = *Input;
   PhotometricInterpretation pi = image.GetPhotometricInterpretation();
-  //assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
+  //gdcm_assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
   if( pi == PI )
   {
     return true;
@@ -230,14 +230,14 @@ bool ImageChangePhotometricInterpretation::ChangeRGB2YBR()
   //Output->GetPixelFormat().SetSamplesPerPixel( 3 );
   //Output->SetPlanarConfiguration( 0 ); // FIXME OT-PAL-8-face.dcm has a PlanarConfiguration while being PALETTE COLOR...
   //const TransferSyntax &ts = image.GetTransferSyntax();
-  ////assert( ts == TransferSyntax::RLELossless );
+  ////gdcm_assert( ts == TransferSyntax::RLELossless );
   //if( ts.IsExplicit() )
   //  {
   //  Output->SetTransferSyntax( TransferSyntax::ExplicitVRLittleEndian );
   //  }
   //else
   //  {
-  //  assert( ts.IsImplicit() );
+  //  gdcm_assert( ts.IsImplicit() );
   //  Output->SetTransferSyntax( TransferSyntax::ImplicitVRLittleEndian );
   //  }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePhotometricInterpretation.h
@@ -64,7 +64,7 @@ static inline int Round(T x)
 template <typename T>
 static inline T Clamp(int v)
 {
-  assert( std::numeric_limits<T>::min() == 0 );
+  gdcm_assert( std::numeric_limits<T>::min() == 0 );
   return v < 0 ? 0 : (v > std::numeric_limits<T>::max() ? std::numeric_limits<T>::max() : v);
 }
 
@@ -79,7 +79,7 @@ void ImageChangePhotometricInterpretation::RGB2YBR(T ybr[3], const T rgb[3], uns
   const double R = rgb[0];
   const double G = rgb[1];
   const double B = rgb[2];
-  assert( storedbits <= sizeof(T) * 8 );
+  gdcm_assert( storedbits <= sizeof(T) * 8 );
   const int halffullscale = 1 << (storedbits - 1);
   const int Y  = Round(  0.299 * R + 0.587 * G + 0.114 * B                       );
   const int CB = Round((-0.299 * R - 0.587 * G + 0.886 * B)/1.772 + halffullscale);
@@ -95,7 +95,7 @@ void ImageChangePhotometricInterpretation::YBR2RGB(T rgb[3], const T ybr[3], uns
   const double Y  = ybr[0];
   const double Cb = ybr[1];
   const double Cr = ybr[2];
-  assert( storedbits <= sizeof(T) * 8 );
+  gdcm_assert( storedbits <= sizeof(T) * 8 );
   const int halffullscale = 1 << (storedbits - 1);
   const int R = Round(Y                                       + 1.402 * (Cr-halffullscale)               );
   const int G = Round(Y -( 0.114 * 1.772 * (Cb-halffullscale) + 0.299 * 1.402 * (Cr-halffullscale))/0.587);

--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePlanarConfiguration.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePlanarConfiguration.cxx
@@ -35,7 +35,7 @@ bool ImageChangePlanarConfiguration::Change()
     {
     return true;
     }
-  assert( Input->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL
+  gdcm_assert( Input->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL
     || Input->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL_422
     || Input->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_PARTIAL_422
     || Input->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_RCT
@@ -52,11 +52,11 @@ bool ImageChangePlanarConfiguration::Change()
   char *p = new char[len];
   image.GetBuffer( p );
 
-  assert( len % 3 == 0 );
+  gdcm_assert( len % 3 == 0 );
   PixelFormat pf = Input->GetPixelFormat();
   const size_t ps = pf.GetPixelSize();
   const size_t framesize = dims[0] * dims[1] * ps;
-  assert( framesize * dims[2] == len );
+  gdcm_assert( framesize * dims[2] == len );
 
   char *copy = new char[len];
   size_t size = framesize / 3;
@@ -82,7 +82,7 @@ bool ImageChangePlanarConfiguration::Change()
     }
   else // User requested to do PlanarConfiguration == 1
     {
-    assert( PlanarConfiguration == 1 );
+    gdcm_assert( PlanarConfiguration == 1 );
     for(unsigned int z = 0; z < dims[2]; ++z)
       {
       const void *frame = p + z * framesize;
@@ -110,7 +110,7 @@ bool ImageChangePlanarConfiguration::Change()
   Output->SetPlanarConfiguration( PlanarConfiguration );
   if( Input->GetTransferSyntax().IsImplicit() )
     {
-    assert( Output->GetTransferSyntax().IsImplicit() );
+    gdcm_assert( Output->GetTransferSyntax().IsImplicit() );
     }
   else if( Input->GetTransferSyntax() == TransferSyntax::ExplicitVRBigEndian )
     {
@@ -120,8 +120,8 @@ bool ImageChangePlanarConfiguration::Change()
     {
     Output->SetTransferSyntax( TransferSyntax::ExplicitVRLittleEndian );
     }
-  //assert( Output->GetTransferSyntax().IsRaw() );
-  assert( Output->GetPhotometricInterpretation() == Input->GetPhotometricInterpretation() );
+  //gdcm_assert( Output->GetTransferSyntax().IsRaw() );
+  gdcm_assert( Output->GetPhotometricInterpretation() == Input->GetPhotometricInterpretation() );
 
   return true;
 }

--- a/Source/MediaStorageAndFileFormat/gdcmImageChangePlanarConfiguration.h
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangePlanarConfiguration.h
@@ -66,7 +66,7 @@ size_t ImageChangePlanarConfiguration::RGBPlanesToRGBPixels(T *out, const T *r, 
     *pout++ = *b++;
     }
 
-  assert( (size_t)(pout - out) == 3 * s );
+  gdcm_assert( (size_t)(pout - out) == 3 * s );
   return pout - out;
 }
 
@@ -80,7 +80,7 @@ size_t ImageChangePlanarConfiguration::RGBPixelsToRGBPlanes(T *r, T *g, T *b, co
     *g++ = *prgb++;
     *b++ = *prgb++;
     }
-  assert( (size_t)(prgb - rgb) == 3 * s );
+  gdcm_assert( (size_t)(prgb - rgb) == 3 * s );
   return prgb - rgb;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageChangeTransferSyntax.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageChangeTransferSyntax.cxx
@@ -30,7 +30,7 @@ namespace gdcm
 bool ImageChangeTransferSyntax::TryRAWCodecIcon(const DataElement &pixelde)
 {
   unsigned long len = Input->GetIconImage().GetBufferLength();
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   RAWCodec codec;
@@ -71,7 +71,7 @@ void UpdatePhotometricInterpretation( Bitmap const &input, Bitmap &output )
     {
     output.SetPhotometricInterpretation( PhotometricInterpretation::YBR_FULL );
     }
-  assert( output.GetPhotometricInterpretation() == PhotometricInterpretation::RGB
+  gdcm_assert( output.GetPhotometricInterpretation() == PhotometricInterpretation::RGB
     || output.GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL
     || output.GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
     || output.GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2
@@ -82,7 +82,7 @@ void UpdatePhotometricInterpretation( Bitmap const &input, Bitmap &output )
 bool ImageChangeTransferSyntax::TryRAWCodec(const DataElement &pixelde, Bitmap const &input, Bitmap &output)
 {
   unsigned long len = input.GetBufferLength(); (void)len;
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   RAWCodec codec;
@@ -112,7 +112,7 @@ bool ImageChangeTransferSyntax::TryRAWCodec(const DataElement &pixelde, Bitmap c
 bool ImageChangeTransferSyntax::TryRLECodec(const DataElement &pixelde, Bitmap const &input, Bitmap &output)
 {
   unsigned long len = input.GetBufferLength(); (void)len;
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   RLECodec codec;
@@ -151,7 +151,7 @@ bool ImageChangeTransferSyntax::TryRLECodec(const DataElement &pixelde, Bitmap c
 bool ImageChangeTransferSyntax::TryJPEGCodec(const DataElement &pixelde, Bitmap const &input, Bitmap &output)
 {
   unsigned long len = input.GetBufferLength(); (void)len;
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   JPEGCodec jpgcodec;
@@ -160,7 +160,7 @@ bool ImageChangeTransferSyntax::TryJPEGCodec(const DataElement &pixelde, Bitmap 
   // that can be both lossy and lossless:
   if( ts.IsLossy() )
     {
-    //assert( !ts.IsLossless() ); // I cannot do since since Try* functions are called with all TS, I could be receiving a JPEGLS TS...
+    //gdcm_assert( !ts.IsLossless() ); // I cannot do since since Try* functions are called with all TS, I could be receiving a JPEGLS TS...
     jpgcodec.SetLossless( false );
     }
 
@@ -224,7 +224,7 @@ bool ImageChangeTransferSyntax::TryJPEGCodec(const DataElement &pixelde, Bitmap 
       // HACK
       //Image *i = (Image*)this;
       //i->SetPhotometricInterpretation( codec.GetPhotometricInterpretation() );
-      assert(0);
+      gdcm_assert(0);
       }
     return true;
     }
@@ -234,7 +234,7 @@ bool ImageChangeTransferSyntax::TryJPEGCodec(const DataElement &pixelde, Bitmap 
 bool ImageChangeTransferSyntax::TryJPEGLSCodec(const DataElement &pixelde, Bitmap const &input, Bitmap &output)
 {
   unsigned long len = input.GetBufferLength(); (void)len;
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   JPEGLSCodec jlscodec;
@@ -259,7 +259,7 @@ bool ImageChangeTransferSyntax::TryJPEGLSCodec(const DataElement &pixelde, Bitma
     if( input.AreOverlaysInPixelData() || input.UnusedBitsPresentInPixelData() )
       {
       ByteValue *bv = const_cast<ByteValue*>(pixelde.GetByteValue());
-      assert( bv );
+      gdcm_assert( bv );
       gdcm::DataElement tmp;
       tmp.SetByteValue( bv->GetPointer(), bv->GetLength());
       bv = const_cast<ByteValue*>(tmp.GetByteValue());
@@ -294,7 +294,7 @@ bool ImageChangeTransferSyntax::TryJPEGLSCodec(const DataElement &pixelde, Bitma
 bool ImageChangeTransferSyntax::TryJPEG2000Codec(const DataElement &pixelde, Bitmap const &input, Bitmap &output)
 {
   unsigned long len = input.GetBufferLength(); (void)len;
-  //assert( len == pixelde.GetByteValue()->GetLength() );
+  //gdcm_assert( len == pixelde.GetByteValue()->GetLength() );
   const TransferSyntax &ts = GetTransferSyntax();
 
   JPEG2000Codec j2kcodec;
@@ -332,13 +332,13 @@ bool ImageChangeTransferSyntax::TryJPEG2000Codec(const DataElement &pixelde, Bit
           }
         else
           {
-          assert( ts == TransferSyntax::JPEG2000 );
+          gdcm_assert( ts == TransferSyntax::JPEG2000 );
           output.SetPhotometricInterpretation( PhotometricInterpretation::YBR_ICT );
           }
         }
       else
         {
-        assert( input.GetPhotometricInterpretation().IsSameColorSpace( PhotometricInterpretation::YBR_FULL ) );
+        gdcm_assert( input.GetPhotometricInterpretation().IsSameColorSpace( PhotometricInterpretation::YBR_FULL ) );
         if( ts == TransferSyntax::JPEG2000Lossless )
           {
           output.SetPhotometricInterpretation( PhotometricInterpretation::YBR_FULL );
@@ -348,7 +348,7 @@ bool ImageChangeTransferSyntax::TryJPEG2000Codec(const DataElement &pixelde, Bit
           }
         else
           {
-          assert( ts == TransferSyntax::JPEG2000 );
+          gdcm_assert( ts == TransferSyntax::JPEG2000 );
           //output.SetPhotometricInterpretation( PhotometricInterpretation::YBR_ICT );
           // FIXME: technically when doing lossy we could be standard compliant and first convert to
           // RGB THEN compress to YBR_ICT. For now produce improper j2k image
@@ -358,7 +358,7 @@ bool ImageChangeTransferSyntax::TryJPEG2000Codec(const DataElement &pixelde, Bit
       }
     else
       {
-      assert( input.GetPixelFormat().GetSamplesPerPixel() == 1 );
+      gdcm_assert( input.GetPixelFormat().GetSamplesPerPixel() == 1 );
       }
 
     if( !r ) return false;
@@ -435,7 +435,7 @@ bool ImageChangeTransferSyntax::Change()
     Output->SetTransferSyntax( TS );
     if( !success )
       {
-      //assert(0);
+      //gdcm_assert(0);
       return false;
       }
 
@@ -446,7 +446,7 @@ bool ImageChangeTransferSyntax::Change()
       {
       Bitmap &outbitmap = *Output;
       Pixmap *outpixmap = dynamic_cast<Pixmap*>( &outbitmap );
-      assert( outpixmap != nullptr );
+      gdcm_assert( outpixmap != nullptr );
       if( !pixmap->GetIconImage().IsEmpty() )
         {
         // same goes for icon
@@ -469,16 +469,16 @@ bool ImageChangeTransferSyntax::Change()
         outpixmap->GetIconImage().SetTransferSyntax( TS );
         if( !success )
           {
-          //assert(0);
+          //gdcm_assert(0);
           return false;
           }
-        assert( outpixmap->GetIconImage().GetTransferSyntax() == TS );
+        gdcm_assert( outpixmap->GetIconImage().GetTransferSyntax() == TS );
         }
       }
 
     //Output->ComputeLossyFlag();
-    assert( Output->GetTransferSyntax() == TS );
-    //if( TS.IsLossy() ) assert( Output->IsLossy() );
+    gdcm_assert( Output->GetTransferSyntax() == TS );
+    //if( TS.IsLossy() ) gdcm_assert( Output->IsLossy() );
     return success;
     }
 
@@ -492,7 +492,7 @@ bool ImageChangeTransferSyntax::Change()
   Output->SetTransferSyntax( TS );
   if( !success )
     {
-    //assert(0);
+    //gdcm_assert(0);
     return false;
     }
 
@@ -514,16 +514,16 @@ bool ImageChangeTransferSyntax::Change()
       outpixmap->GetIconImage().SetTransferSyntax( TS );
       if( !success )
         {
-        //assert(0);
+        //gdcm_assert(0);
         return false;
         }
-      assert( outpixmap->GetIconImage().GetTransferSyntax() == TS );
+      gdcm_assert( outpixmap->GetIconImage().GetTransferSyntax() == TS );
       }
     }
 
   //Output->ComputeLossyFlag();
 
-  assert( Output->GetTransferSyntax() == TS );
+  gdcm_assert( Output->GetTransferSyntax() == TS );
   return success;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageCodec.cxx
@@ -53,7 +53,7 @@ ImageCodec::~ImageCodec()
 bool ImageCodec::GetHeaderInfo(std::istream &, TransferSyntax &)
 {
   // This function should really be virtual pure.
-  assert( 0 );
+  gdcm_assert( 0 );
   return false;
 }
 
@@ -98,17 +98,17 @@ bool ImageCodec::DoByteSwap(std::istream &is, std::ostream &os)
 {
   // FIXME: Do some stupid work:
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(start, std::ios::beg);
   is.read( dummy_buffer, buf_size);
   is.seekg(start, std::ios::beg); // reset
   //SwapCode sc = is.GetSwapCode();
 
-  assert( !(buf_size % 2) );
+  gdcm_assert( !(buf_size % 2) );
 #ifdef GDCM_WORDS_BIGENDIAN
   if( PF.GetBitsAllocated() == 16 )
     {
@@ -117,7 +117,7 @@ bool ImageCodec::DoByteSwap(std::istream &is, std::ostream &os)
     }
 #else
   // GE_DLX-8-MONO2-PrivateSyntax.dcm is 8bits
-  //  assert( PF.GetBitsAllocated() == 16 );
+  //  gdcm_assert( PF.GetBitsAllocated() == 16 );
   if ( PF.GetBitsAllocated() == 16 )
     {
     ByteSwap<uint16_t>::SwapRangeFromSwapCodeIntoSystem((uint16_t*)
@@ -133,10 +133,10 @@ bool ImageCodec::DoYBR(std::istream &is, std::ostream &os)
 {
   // FIXME: Do some stupid work:
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(start, std::ios::beg);
   is.read( dummy_buffer, buf_size);
@@ -145,12 +145,12 @@ bool ImageCodec::DoYBR(std::istream &is, std::ostream &os)
 
   // Code is coming from:
   // http://lestourtereaux.free.fr/papers/data/yuvrgb.pdf
-  assert( !(buf_size % 3) );
+  gdcm_assert( !(buf_size % 3) );
   unsigned long size = (unsigned long)buf_size/3;
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   unsigned char *copy = new unsigned char[ (unsigned int)buf_size ];
   memmove( copy, dummy_buffer, (size_t)buf_size);
-assert(0); // Do not use this code !
+gdcm_assert(0); // Do not use this code !
   // FIXME FIXME FIXME
   // The following is bogus: we are doing two operation at once:
   // Planar configuration AND YBR... doh !
@@ -194,7 +194,7 @@ bool ImageCodec::DoYBRFull422(std::istream &is, std::ostream &os)
 {
   // FIXME: Do some stupid work:
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   const size_t buf_size = (size_t)is.tellg();
   const size_t rgb_buf_size = buf_size * 3 / 2;
@@ -203,8 +203,8 @@ bool ImageCodec::DoYBRFull422(std::istream &is, std::ostream &os)
   is.read( (char*)dummy_buffer, buf_size);
   is.seekg(start, std::ios::beg); // reset
 
-  assert( !(rgb_buf_size % 3) );
-  assert( !(buf_size % 2) );
+  gdcm_assert( !(rgb_buf_size % 3) );
+  gdcm_assert( !(buf_size % 2) );
   unsigned char *copy = new unsigned char[ rgb_buf_size ];
   const size_t size = buf_size/4;
 
@@ -251,10 +251,10 @@ bool ImageCodec::DoPlanarConfiguration(std::istream &is, std::ostream &os)
 {
   // FIXME: Do some stupid work:
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(start, std::ios::beg);
   is.read( dummy_buffer, buf_size);
@@ -262,8 +262,8 @@ bool ImageCodec::DoPlanarConfiguration(std::istream &is, std::ostream &os)
   //SwapCode sc = is.GetSwapCode();
 
   // US-RGB-8-epicard.dcm
-  //assert( image.GetNumberOfDimensions() == 3 );
-  assert( buf_size % 3 == 0 );
+  //gdcm_assert( image.GetNumberOfDimensions() == 3 );
+  gdcm_assert( buf_size % 3 == 0 );
   unsigned long size = (unsigned long)buf_size/3;
   char *copy = new char[ (unsigned int)buf_size ];
   //memmove( copy, dummy_buffer, buf_size);
@@ -290,10 +290,10 @@ bool ImageCodec::DoSimpleCopy(std::istream &is, std::ostream &os)
 {
 #if 1
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(start, std::ios::beg);
   is.read( dummy_buffer, buf_size);
@@ -313,17 +313,17 @@ bool ImageCodec::DoPaddedCompositePixelCode(std::istream &is, std::ostream &os)
 {
   // FIXME: Do some stupid work:
   std::streampos start = is.tellg();
-  assert( 0 - start == 0 );
+  gdcm_assert( 0 - start == 0 );
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(start, std::ios::beg);
   is.read( dummy_buffer, buf_size);
   is.seekg(start, std::ios::beg); // reset
   //SwapCode sc = is.GetSwapCode();
 
-  assert( !(buf_size % 2) );
+  gdcm_assert( !(buf_size % 2) );
   bool ret = true;
   if( GetPixelFormat().GetBitsAllocated() == 16 )
     {
@@ -340,7 +340,7 @@ bool ImageCodec::DoPaddedCompositePixelCode(std::istream &is, std::ostream &os)
     }
   else if( GetPixelFormat().GetBitsAllocated() == 32 )
     {
-  assert( !(buf_size % 4) );
+  gdcm_assert( !(buf_size % 4) );
     for(size_t i = 0; i < buf_size/4; ++i)
       {
 #ifdef GDCM_WORDS_BIGENDIAN
@@ -379,7 +379,7 @@ bool ImageCodec::DoInvertMonochrome(std::istream &is, std::ostream &os)
       }
     else if ( PF.GetBitsAllocated() == 16 )
       {
-      assert( PF.GetBitsStored() != 12 );
+      gdcm_assert( PF.GetBitsStored() != 12 );
       uint16_t smask16 = 65535;
       uint16_t c;
       while( is.read((char*)&c,2) )
@@ -421,9 +421,9 @@ bool ImageCodec::DoInvertMonochrome(std::istream &is, std::ostream &os)
             << " results will be truncated. Use at own risk");
           c = mask;
           }
-        assert( c <= mask );
+        gdcm_assert( c <= mask );
         c = (uint16_t)(mask - c);
-        assert( c <= mask );
+        gdcm_assert( c <= mask );
         os.write((char*)&c, 2);
         }
       }
@@ -436,7 +436,7 @@ bool ImageCodec::CleanupUnusedBits(char * data8, size_t datalen)
 {
   if( !NeedOverlayCleanup ) return true;
   void * data = data8;
-  assert( PF.GetBitsAllocated() > 8 );
+  gdcm_assert( PF.GetBitsAllocated() > 8 );
   if( PF.GetBitsAllocated() == 16 )
     {
     // pmask : to mask the 'unused bits' (may contain overlays)
@@ -520,7 +520,7 @@ bool ImageCodec::CleanupUnusedBits(char * data8, size_t datalen)
   }
   else
     {
-    assert(0); // TODO
+    gdcm_assert(0); // TODO
     return false;
     }
   return true;
@@ -529,7 +529,7 @@ bool ImageCodec::CleanupUnusedBits(char * data8, size_t datalen)
 // Cleanup the unused bits
 bool ImageCodec::DoOverlayCleanup(std::istream &is, std::ostream &os)
 {
-  assert( PF.GetBitsAllocated() > 8 );
+  gdcm_assert( PF.GetBitsAllocated() > 8 );
   if( PF.GetBitsAllocated() == 16 )
     {
     // pmask : to mask the 'unused bits' (may contain overlays)
@@ -628,7 +628,7 @@ bool ImageCodec::DoOverlayCleanup(std::istream &is, std::ostream &os)
   }
   else
     {
-    assert(0); // TODO
+    gdcm_assert(0); // TODO
     return false;
     }
   return true;
@@ -641,8 +641,8 @@ bool ImageCodec::Decode(DataElement const &, DataElement &)
 
 bool ImageCodec::DecodeByStreams(std::istream &is, std::ostream &os)
 {
-  assert( PlanarConfiguration == 0 || PlanarConfiguration == 1);
-  assert( PI != PhotometricInterpretation::UNKNOWN );
+  gdcm_assert( PlanarConfiguration == 0 || PlanarConfiguration == 1);
+  gdcm_assert( PI != PhotometricInterpretation::UNKNOWN );
   std::stringstream bs_os; // ByteSwap
   std::stringstream pcpc_os; // Padded Composite Pixel Code
   //std::stringstream pi_os; // PhotometricInterpretation
@@ -693,7 +693,7 @@ bool ImageCodec::DecodeByStreams(std::istream &is, std::ostream &os)
     }
     break;
   case PhotometricInterpretation::PALETTE_COLOR:
-    //assert( LUT );
+    //gdcm_assert( LUT );
     // Nothing needs to be done
     break;
   case PhotometricInterpretation::YBR_FULL_422:
@@ -751,7 +751,7 @@ bool ImageCodec::DecodeByStreams(std::istream &is, std::ostream &os)
     }
   else
     {
-    assert( PF.GetBitsAllocated() == PF.GetBitsStored() );
+    gdcm_assert( PF.GetBitsAllocated() == PF.GetBitsStored() );
     copySuccess = DoSimpleCopy(*cur_is, os);
     }
 
@@ -773,7 +773,7 @@ void ImageCodec::SetDimensions(const unsigned int d[3])
 void ImageCodec::SetDimensions(const std::vector<unsigned int> & d)
 {
   size_t theSize = d.size();
-  assert(theSize<= 3);
+  gdcm_assert(theSize<= 3);
   for (size_t i = 0; i < 3; i++)
     {
     if (i < theSize)
@@ -785,7 +785,7 @@ void ImageCodec::SetDimensions(const std::vector<unsigned int> & d)
 
 bool ImageCodec::StartEncode( std::ostream & )
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 bool ImageCodec::IsRowEncoder()
@@ -798,19 +798,19 @@ bool ImageCodec::IsFrameEncoder()
 }
 bool ImageCodec::AppendRowEncode( std::ostream & , const char * , size_t )
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 // TODO: technically the frame encoder could use the row encoder when present
 // this could reduce code duplication
 bool ImageCodec::AppendFrameEncode( std::ostream & , const char * , size_t )
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 bool ImageCodec::StopEncode( std::ostream & )
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageCodec.h
+++ b/Source/MediaStorageAndFileFormat/gdcmImageCodec.h
@@ -55,7 +55,7 @@ public:
     }
   void SetPlanarConfiguration(unsigned int pc)
     {
-    assert( pc == 0 || pc == 1 );
+    gdcm_assert( pc == 0 || pc == 1 );
     PlanarConfiguration = pc;
     }
 

--- a/Source/MediaStorageAndFileFormat/gdcmImageFragmentSplitter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageFragmentSplitter.cxx
@@ -43,7 +43,7 @@ bool ImageFragmentSplitter::Split()
     return false;
     }
 
-  //assert( sqf->GetNumberOfFragments() == 1 );
+  //gdcm_assert( sqf->GetNumberOfFragments() == 1 );
 
   // WARNING do not keep the same Basic Offset Table...
   const Fragment& frag = sqf->GetFragment(0);
@@ -77,7 +77,7 @@ bool ImageFragmentSplitter::Split()
     {
     Fragment splitfrag;
     splitfrag.SetByteValue( p + nfrags * FragmentSizeMax, (uint32_t)lastfrag );
-    assert( nfrags * FragmentSizeMax + lastfrag == len );
+    gdcm_assert( nfrags * FragmentSizeMax + lastfrag == len );
     sq->AddFragment( splitfrag );
     }
   Output->GetDataElement().SetValue( *sq );
@@ -107,7 +107,7 @@ void ImageFragmentSplitter::SetFragmentSizeMax(unsigned int fragsize)
     FragmentSizeMax = 2;
     }
   // \postcondition:
-  assert( FragmentSizeMax >= 2 && (FragmentSizeMax % 2) == 0 );
+  gdcm_assert( FragmentSizeMax >= 2 && (FragmentSizeMax % 2) == 0 );
 }
 
 } // end namespace gdcm

--- a/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
@@ -74,7 +74,7 @@ static bool GetOriginValueFromSequence(const DataSet& ds, const Tag& tfgs, std::
   const Tag tps(0x0020,0x0032);
   if( !subds2.FindDataElement(tps) ) return false;
   const DataElement &de = subds2.GetDataElement( tps );
-  //assert( bv );
+  //gdcm_assert( bv );
   Attribute<0x0020,0x0032> at;
   at.SetFromDataElement( de );
   //at.Print( std::cout );
@@ -103,7 +103,7 @@ static bool GetDirectionCosinesValueFromSequence(const DataSet& ds, const Tag& t
   //const SequenceOfItems * sqi2 = subds.GetDataElement( tpms ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi2 = subds.GetDataElement( tpms ).GetValueAsSQ();
   if( !(sqi2 && sqi2->GetNumberOfItems()) ) return false;
-  assert( sqi2 && sqi2->GetNumberOfItems() );
+  gdcm_assert( sqi2 && sqi2->GetNumberOfItems() );
   // Take it from the first item
   const Item &item2 = sqi2->GetItem(1);
   const DataSet & subds2 = item2.GetNestedDataSet();
@@ -111,7 +111,7 @@ static bool GetDirectionCosinesValueFromSequence(const DataSet& ds, const Tag& t
   const Tag tps(0x0020,0x0037);
   if( !subds2.FindDataElement(tps) ) return false;
   const DataElement &de = subds2.GetDataElement( tps );
-  //assert( bv );
+  //gdcm_assert( bv );
   Attribute<0x0020,0x0037> at;
   at.SetFromDataElement( de );
   dircos.push_back( at.GetValue(0) );
@@ -139,7 +139,7 @@ static bool GetInterceptSlopeValueFromSequence(const DataSet& ds, const Tag& tfg
   if( !subds.FindDataElement(tpms) ) return false;
   //const SequenceOfItems * sqi2 = subds.GetDataElement( tpms ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi2 = subds.GetDataElement( tpms ).GetValueAsSQ();
-  assert( sqi2 );
+  gdcm_assert( sqi2 );
   const Item &item2 = sqi2->GetItem(1);
   const DataSet & subds2 = item2.GetNestedDataSet();
   double intercept;
@@ -148,7 +148,7 @@ static bool GetInterceptSlopeValueFromSequence(const DataSet& ds, const Tag& tfg
     const Tag tps(0x0028,0x1052);
     if( !subds2.FindDataElement(tps) ) return false;
     const DataElement &de = subds2.GetDataElement( tps );
-    //assert( bv );
+    //gdcm_assert( bv );
     Attribute<0x0028,0x1052> at;
     at.SetFromDataElement( de );
     //at.Print( std::cout );
@@ -160,7 +160,7 @@ static bool GetInterceptSlopeValueFromSequence(const DataSet& ds, const Tag& tfg
     const Tag tps(0x0028,0x1053);
     if( !subds2.FindDataElement(tps) ) return false;
     const DataElement &de = subds2.GetDataElement( tps );
-    //assert( bv );
+    //gdcm_assert( bv );
     Attribute<0x0028,0x1053> at;
     at.SetFromDataElement( de );
     //at.Print( std::cout );
@@ -169,7 +169,7 @@ static bool GetInterceptSlopeValueFromSequence(const DataSet& ds, const Tag& tfg
   intslope.push_back( intercept );
   intslope.push_back( slope );
 
-  assert( intslope.size() == 2 );
+  gdcm_assert( intslope.size() == 2 );
   return true;
 }
 
@@ -203,14 +203,14 @@ static bool ComputeZSpacingFromIPP(const DataSet &ds, double &zspacing)
       cosines[5] = 0;
       }
     }
-  assert( b1 && cosines.size() == 6 ); // yeah we really need that
+  gdcm_assert( b1 && cosines.size() == 6 ); // yeah we really need that
 
   const Tag tfgs(0x5200,0x9230);
   if( !ds.FindDataElement( tfgs ) ) return false;
   //const SequenceOfItems * sqi = ds.GetDataElement( tfgs ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tfgs ).GetValueAsSQ();
   if( !sqi ) return false;
-  assert( sqi );
+  gdcm_assert( sqi );
   double normal[3];
   DirectionCosines dc( cosines.data() );
   dc.Cross( normal );
@@ -230,13 +230,13 @@ static bool ComputeZSpacingFromIPP(const DataSet &ds, double &zspacing)
     if( !subds.FindDataElement(tpms) ) return false;
     //const SequenceOfItems * sqi2 = subds.GetDataElement( tpms ).GetSequenceOfItems();
     SmartPointer<SequenceOfItems> sqi2 = subds.GetDataElement( tpms ).GetValueAsSQ();
-    assert( sqi2 );
+    gdcm_assert( sqi2 );
     const Item &item2 = sqi2->GetItem(1);
     const DataSet & subds2 = item2.GetNestedDataSet();
     // Check Image Orientation (Patient)
     if( ImageHelper::GetDirectionCosinesFromDataSet(subds2, dircos_subds2) )
       {
-      assert( dircos_subds2 == cosines );
+      gdcm_assert( dircos_subds2 == cosines );
       }
     // (0020,0032) DS [-82.5\-82.5\1153.75]                    #  20, 3 ImagePositionPatient
     const Tag tps(0x0020,0x0032);
@@ -248,7 +248,7 @@ static bool ComputeZSpacingFromIPP(const DataSet &ds, double &zspacing)
     for (int i = 0; i < 3; ++i) dist += normal[i]*ipp[i];
     distances.push_back( dist );
     }
-  assert( distances.size() == nitems );
+  gdcm_assert( distances.size() == nitems );
   double meanspacing = 0;
   double prev = distances[0];
   for(unsigned int i = 1; i < nitems; ++i)
@@ -272,7 +272,7 @@ static bool ComputeZSpacingFromIPP(const DataSet &ds, double &zspacing)
 
   zspacing = meanspacing;
   if( nitems > 1 )
-    assert( zspacing != 0.0 ); // technically this should not happen
+    gdcm_assert( zspacing != 0.0 ); // technically this should not happen
 
   if( !timeseries )
     {
@@ -306,7 +306,7 @@ static bool ComputeZSpacingFromIPP(const DataSet &ds, double &zspacing)
     if( !subds.FindDataElement(tpms) ) return true;
     //const SequenceOfItems * sqi2 = subds.GetDataElement( tpms ).GetSequenceOfItems();
     SmartPointer<SequenceOfItems> sqi2 = subds.GetDataElement( tpms ).GetValueAsSQ();
-    assert( sqi2 );
+    gdcm_assert( sqi2 );
     const Item &item2 = sqi2->GetItem(1);
     const DataSet & subds2 = item2.GetNestedDataSet();
     // <entry group="0028" element="0030" vr="DS" vm="2" name="Pixel Spacing"/>
@@ -330,7 +330,7 @@ static bool GetSpacingValueFromSequence(const DataSet& ds, const Tag& tfgs, std:
   // <entry group="5200" element="9229" vr="SQ" vm="1" name="Shared Functional Groups Sequence"/>
   //const Tag tfgs(0x5200,0x9229);
   //const Tag tfgs(0x5200,0x9230);
-  //assert( ds.FindDataElement( tfgs ) );
+  //gdcm_assert( ds.FindDataElement( tfgs ) );
   if( !ds.FindDataElement( tfgs ) ) return false;
   //const SequenceOfItems * sqi = ds.GetDataElement( tfgs ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tfgs ).GetValueAsSQ();
@@ -343,14 +343,14 @@ static bool GetSpacingValueFromSequence(const DataSet& ds, const Tag& tfgs, std:
   if( !subds.FindDataElement(tpms) ) return false;
   //const SequenceOfItems * sqi2 = subds.GetDataElement( tpms ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi2 = subds.GetDataElement( tpms ).GetValueAsSQ();
-  assert( sqi2 );
+  gdcm_assert( sqi2 );
   const Item &item2 = sqi2->GetItem(1);
   const DataSet & subds2 = item2.GetNestedDataSet();
   // <entry group="0028" element="0030" vr="DS" vm="2" name="Pixel Spacing"/>
   const Tag tps(0x0028,0x0030);
   if( !subds2.FindDataElement(tps) ) return false;
   const DataElement &de = subds2.GetDataElement( tps );
-  //assert( bv );
+  //gdcm_assert( bv );
   Attribute<0x0028,0x0030> at;
   at.SetFromDataElement( de );
   //at.Print( std::cout );
@@ -389,7 +389,7 @@ static SmartPointer<SequenceOfItems> InsertOrReplaceSQ( DataSet & ds, const Tag 
     DataElement de( tag );
     de.SetVR( VR::SQ );
     de.SetValue( *sqi );
-    assert( de.GetVL().IsUndefined() );
+    gdcm_assert( de.GetVL().IsUndefined() );
     de.SetVLToUndefined();
     ds.Insert( de );
   }
@@ -431,7 +431,7 @@ static bool GetUltraSoundSpacingValueFromSequence(const DataSet& ds, std::vector
   //const SequenceOfItems * sqi = ds.GetDataElement( tsqusreg ).GetSequenceOfItems();
   SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tsqusreg ).GetValueAsSQ();
   if( !sqi ) return false;
-  assert( sqi );
+  gdcm_assert( sqi );
   // Get first item:
   const Item &item = sqi->GetItem(1);
   const DataSet & subds = item.GetNestedDataSet();
@@ -441,10 +441,10 @@ static bool GetUltraSoundSpacingValueFromSequence(const DataSet& ds, std::vector
   Attribute<0x0018,0x602e> at2;
   const DataElement &de1 = subds.GetDataElement( at1.GetTag() );
   at1.SetFromDataElement( de1 );
-  assert( at1.GetNumberOfValues() == 1 );
+  gdcm_assert( at1.GetNumberOfValues() == 1 );
   const DataElement &de2 = subds.GetDataElement( at2.GetTag() );
   at2.SetFromDataElement( de2 );
-  assert( at2.GetNumberOfValues() == 1 );
+  gdcm_assert( at2.GetNumberOfValues() == 1 );
   sp.push_back( at1.GetValue() );
   sp.push_back( at2.GetValue() );
 
@@ -549,7 +549,7 @@ std::vector<double> ImageHelper::GetOriginValue(File const & f)
     if( GetOriginValueFromSequence(ds,t1, ori)
      || GetOriginValueFromSequence(ds, t2, ori) )
       {
-      assert( ori.size() == 3 );
+      gdcm_assert( ori.size() == 3 );
       return ori;
       }
     ori.resize( 3 );
@@ -568,7 +568,7 @@ std::vector<double> ImageHelper::GetOriginValue(File const & f)
         const Item &item = sqi->GetItem(1);
         const DataSet & subds = item.GetNestedDataSet();
         const Tag timagepositionpatient(0x0020, 0x0032);
-        assert( subds.FindDataElement( timagepositionpatient ) );
+        gdcm_assert( subds.FindDataElement( timagepositionpatient ) );
         Attribute<0x0020,0x0032> at = {{0,0,0}}; // default value if empty
         at.SetFromDataSet( subds );
         ori.resize( at.GetNumberOfValues() );
@@ -603,7 +603,7 @@ std::vector<double> ImageHelper::GetOriginValue(File const & f)
     ori[1] = 0;
     ori[2] = 0;
     }
-  assert( ori.size() == 3 );
+  gdcm_assert( ori.size() == 3 );
   return ori;
 }
 
@@ -682,7 +682,7 @@ std::vector<double> ImageHelper::GetDirectionCosinesValue(File const & f)
     if( GetDirectionCosinesValueFromSequence(ds,t1, dircos)
      || GetDirectionCosinesValueFromSequence(ds, t2, dircos) )
       {
-      assert( dircos.size() == 6 );
+      gdcm_assert( dircos.size() == 6 );
       return dircos;
       }
     else
@@ -749,7 +749,7 @@ std::vector<double> ImageHelper::GetDirectionCosinesValue(File const & f)
     dircos[5] = 0;
     }
 
-  assert( dircos.size() == 6 );
+  gdcm_assert( dircos.size() == 6 );
   return dircos;
 }
 
@@ -960,7 +960,7 @@ void ImageHelper::SetDimensionsValue(File& f, const Pixmap & img)
   MediaStorage ms;
   ms.SetFromFile(f);
   DataSet& ds = f.GetDataSet();
-  assert( MediaStorage::IsImage( ms ) );
+  gdcm_assert( MediaStorage::IsImage( ms ) );
   {
     Attribute<0x0028,0x0010> rows;
     rows.SetValue( (uint16_t)dims[1] );
@@ -1031,7 +1031,7 @@ void ImageHelper::SetDimensionsValue(File& f, const Pixmap & img)
       {
         const DataElement &de = ds.GetDataElement( tfgs );
         SmartPointer<SequenceOfItems> sqi = de.GetValueAsSQ();
-        assert( sqi );
+        gdcm_assert( sqi );
         sqi->SetNumberOfItems( dims[2] );
         {
           // Simple mechanism to avoid recomputation of Sequence Length: make
@@ -1085,7 +1085,7 @@ std::vector<double> ImageHelper::GetRescaleInterceptSlopeValue(File const & f)
     if( GetInterceptSlopeValueFromSequence(ds,t1, interceptslope)
      || GetInterceptSlopeValueFromSequence(ds,t2, interceptslope) )
       {
-      assert( interceptslope.size() == 2 );
+      gdcm_assert( interceptslope.size() == 2 );
       return interceptslope;
       }
 
@@ -1273,7 +1273,7 @@ std::vector<double> ImageHelper::GetRescaleInterceptSlopeValue(File const & f)
     }
 
   // \post condition slope can never be 0:
-  assert( interceptslope[1] != 0. );
+  gdcm_assert( interceptslope[1] != 0. );
   return interceptslope;
 }
 
@@ -1357,7 +1357,7 @@ Tag ImageHelper::GetSpacingTagFromMediaStorage(MediaStorage const &ms)
   case MediaStorage::UltrasoundMultiFrameImageStorage:
     // gdcmData/US-MONO2-8-8x-execho.dcm
     // this should be handled somewhere else
-    //assert(0);
+    //gdcm_assert(0);
     gdcmWarningMacro( "FIXME" );
     t = Tag(0xffff,0xffff);
     break;
@@ -1496,7 +1496,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
     if( GetSpacingValueFromSequence(ds,t1, sp)
       || GetSpacingValueFromSequence(ds, t2, sp) )
       {
-      assert( sp.size() == 3 );
+      gdcm_assert( sp.size() == 3 );
       return sp;
       }
     // Else.
@@ -1557,7 +1557,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
     const Dicts &dicts = g.GetDicts();
     const DictEntry &entry = dicts.GetDictEntry(de.GetTag());
     const VR & vr = entry.GetVR();
-    assert( vr.Compatible( de.GetVR() ) );
+    gdcm_assert( vr.Compatible( de.GetVR() ) );
     switch(vr)
       {
     case VR::DS:
@@ -1565,7 +1565,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
         Element<VR::DS,VM::VM1_n> el;
         std::stringstream ss;
         const ByteValue *bv = de.GetByteValue();
-        assert( bv );
+        gdcm_assert( bv );
         std::string s = std::string( bv->GetPointer(), bv->GetLength() );
         ss.str( s );
         // Stupid file: CT-MONO2-8-abdo.dcm
@@ -1576,7 +1576,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
         if( found != std::string::npos )
           {
           el.Read( ss );
-          assert( el.GetLength() == 2 );
+          gdcm_assert( el.GetLength() == 2 );
           for(unsigned int i = 0; i < el.GetLength(); ++i)
             {
             if( el.GetValue(i) )
@@ -1602,7 +1602,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
           sp.push_back( singleval );
           sp.push_back( singleval );
           }
-        assert( sp.size() == (unsigned int)entry.GetVM() );
+        gdcm_assert( sp.size() == (unsigned int)entry.GetVM() );
         }
       break;
     case VR::IS:
@@ -1610,7 +1610,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
         Element<VR::IS,VM::VM1_n> el;
         std::stringstream ss;
         const ByteValue *bv = de.GetByteValue();
-        assert( bv );
+        gdcm_assert( bv );
         std::string s = std::string( bv->GetPointer(), bv->GetLength() );
         ss.str( s );
         el.SetLength( entry.GetVM().GetLength() * entry.GetVR().GetSizeof() );
@@ -1626,11 +1626,11 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
             }
         }
         std::swap( sp[0], sp[1]);
-        assert( sp.size() == (unsigned int)entry.GetVM() );
+        gdcm_assert( sp.size() == (unsigned int)entry.GetVM() );
         }
       break;
     default:
-      assert(0);
+      gdcm_assert(0);
       break;
       }
     }
@@ -1639,7 +1639,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
     sp.push_back( 1.0 );
     sp.push_back( 1.0 );
     }
-  assert( sp.size() == 2 );
+  gdcm_assert( sp.size() == 2 );
   // Make sure multiframe:
   std::vector<unsigned int> dims = ImageHelper::GetDimensionsValue( f );
 
@@ -1658,7 +1658,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
       const Dicts &dicts = g.GetDicts();
       const DictEntry &entry = dicts.GetDictEntry(de.GetTag());
       const VR & vr = entry.GetVR();
-      assert( de.GetVR() == vr || de.GetVR() == VR::INVALID || de.GetVR() == VR::UN );
+      gdcm_assert( de.GetVR() == vr || de.GetVR() == VR::INVALID || de.GetVR() == VR::UN );
       if( entry.GetVM() == VM::VM1 )
         {
         switch(vr)
@@ -1668,7 +1668,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
             Element<VR::DS,VM::VM1_n> el;
             std::stringstream ss;
             const ByteValue *bv = de.GetByteValue();
-            assert( bv );
+            gdcm_assert( bv );
             std::string s = std::string( bv->GetPointer(), bv->GetLength() );
             ss.str( s );
             el.SetLength( entry.GetVM().GetLength() * entry.GetVR().GetSizeof() );
@@ -1678,18 +1678,18 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
               const double value = el.GetValue(i);
               sp.push_back( value );
               }
-            //assert( sp.size() == entry.GetVM() );
+            //gdcm_assert( sp.size() == entry.GetVM() );
             }
           break;
         default:
-          assert(0);
+          gdcm_assert(0);
           break;
           }
         }
       else
         {
-        assert( entry.GetVM() == VM::VM2_n );
-        assert( vr == VR::DS );
+        gdcm_assert( entry.GetVM() == VM::VM2_n );
+        gdcm_assert( vr == VR::DS );
         Attribute<0x28,0x8> numberoframes;
         const DataElement& de1 = ds.GetDataElement( numberoframes.GetTag() );
         numberoframes.SetFromDataElement( de1 );
@@ -1708,7 +1708,7 @@ std::vector<double> ImageHelper::GetSpacingValue(File const & f)
     const DataElement& de = ds.GetDataElement( Tag(0x0028,0x0009) );
     Attribute<0x0028,0x0009,VR::AT,VM::VM1> at;
     at.SetFromDataElement( de );
-    assert( ds.FindDataElement( at.GetTag() ) );
+    gdcm_assert( ds.FindDataElement( at.GetTag() ) );
     if( ds.FindDataElement( at.GetValue() ) )
       {
 /*
@@ -1755,11 +1755,11 @@ $ dcmdump D_CLUNIE_NM1_JPLL.dcm" | grep 0028,0009
     sp.push_back( 1.0 );
     }
 
-  assert( sp.size() == 3 );
-  assert( sp[0] != 0. );
-  assert( sp[1] != 0. );
+  gdcm_assert( sp.size() == 3 );
+  gdcm_assert( sp[0] != 0. );
+  gdcm_assert( sp[1] != 0. );
   //if( ms != MediaStorage::MRImageStorage )
-  //  assert( sp[2] != 0. );
+  //  gdcm_assert( sp[2] != 0. );
   return sp;
 }
 
@@ -1767,7 +1767,7 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
 {
   MediaStorage ms;
   ms.SetFromDataSet(ds);
-  assert( MediaStorage::IsImage( ms ) );
+  gdcm_assert( MediaStorage::IsImage( ms ) );
   if( ms == MediaStorage::SecondaryCaptureImageStorage )
     {
     Tag pixelspacing(0x0028,0x0030);
@@ -1778,7 +1778,7 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
     //ds.Remove( spacingbetweenslice );
     //return;
     }
-  assert( spacing.size() == 3 );
+  gdcm_assert( spacing.size() == 3 );
 
   if( ms == MediaStorage::EnhancedCTImageStorage
    || ms == MediaStorage::EnhancedMRImageStorage
@@ -1889,21 +1889,21 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
       const DictEntry &entry = dicts.GetDictEntry(de.GetTag());
       const VR & vr = entry.GetVR();
       const VM & vm = entry.GetVM(); (void)vm;
-      assert( de.GetVR() == vr || de.GetVR() == VR::INVALID );
+      gdcm_assert( de.GetVR() == vr || de.GetVR() == VR::INVALID );
       switch(vr)
         {
       case VR::DS:
           {
           Element<VR::DS,VM::VM1_n> el;
           el.SetLength( entry.GetVM().GetLength() * vr.GetSizeof() );
-          assert( entry.GetVM() == VM::VM2 );
+          gdcm_assert( entry.GetVM() == VM::VM2 );
           for( unsigned int i = 0; i < entry.GetVM().GetLength(); ++i)
             {
             el.SetValue( spacing[i], i );
             }
           el.SetValue( spacing[1], 0 );
           el.SetValue( spacing[0], 1 );
-          //assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
+          //gdcm_assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
           std::stringstream os;
           el.Write( os );
           de.SetVR( VR::DS );
@@ -1917,12 +1917,12 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
           {
           Element<VR::IS,VM::VM1_n> el;
           el.SetLength( entry.GetVM().GetLength() * vr.GetSizeof() );
-          assert( entry.GetVM() == VM::VM2 );
+          gdcm_assert( entry.GetVM() == VM::VM2 );
           for( unsigned int i = 0; i < entry.GetVM().GetLength(); ++i)
             {
             el.SetValue( (int)spacing[i], i );
             }
-          //assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
+          //gdcm_assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
           std::stringstream os;
           el.Write( os );
           de.SetVR( VR::IS );
@@ -1933,7 +1933,7 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
           }
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
         }
       }
     }
@@ -1947,11 +1947,11 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
       const DictEntry &entry = dicts.GetDictEntry(de.GetTag());
       const VR & vr = entry.GetVR();
       const VM & vm = entry.GetVM(); (void)vm;
-      assert( de.GetVR() == vr || de.GetVR() == VR::INVALID );
+      gdcm_assert( de.GetVR() == vr || de.GetVR() == VR::INVALID );
       if( entry.GetVM() == VM::VM2_n )
         {
-        assert( vr == VR::DS );
-        assert( de.GetTag() == Tag(0x3004,0x000c) );
+        gdcm_assert( vr == VR::DS );
+        gdcm_assert( de.GetTag() == Tag(0x3004,0x000c) );
         Attribute<0x28,0x8> numberoframes;
         // Make we are multiframes:
         if( ds.FindDataElement( numberoframes.GetTag() ) )
@@ -1961,15 +1961,15 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
 
           Element<VR::DS,VM::VM2_n> el;
           el.SetLength( numberoframes.GetValue() * vr.GetSizeof() );
-          assert( entry.GetVM() == VM::VM2_n );
+          gdcm_assert( entry.GetVM() == VM::VM2_n );
           double spacing_start = 0;
-          assert( 0 < numberoframes.GetValue() );
+          gdcm_assert( 0 < numberoframes.GetValue() );
           for( int i = 0; i < numberoframes.GetValue(); ++i)
             {
             el.SetValue( spacing_start, i );
             spacing_start += spacing[2];
             }
-          //assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
+          //gdcm_assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
           std::stringstream os;
           el.Write( os );
           de.SetVR( VR::DS );
@@ -1987,12 +1987,12 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
             {
             Element<VR::DS,VM::VM1_n> el;
             el.SetLength( entry.GetVM().GetLength() * vr.GetSizeof() );
-            assert( entry.GetVM() == VM::VM1 );
+            gdcm_assert( entry.GetVM() == VM::VM1 );
             for( unsigned int i = 0; i < entry.GetVM().GetLength(); ++i)
               {
               el.SetValue( spacing[i+2], i );
               }
-            //assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
+            //gdcm_assert( el.GetValue(0) == spacing[0] && el.GetValue(1) == spacing[1] );
             std::stringstream os;
             el.Write( os );
             de.SetVR( VR::DS );
@@ -2003,7 +2003,7 @@ void ImageHelper::SetSpacingValue(DataSet & ds, const std::vector<double> & spac
             }
           break;
         default:
-          assert(0);
+          gdcm_assert(0);
           }
         }
       }
@@ -2045,10 +2045,10 @@ static void SetDataElementInSQAsItemNumber(DataSet & ds, DataElement const & de,
 void ImageHelper::SetOriginValue(DataSet & ds, const Image & image)
 {
   const double *origin = image.GetOrigin();
-  //assert( origin.size() == 3 );
+  //gdcm_assert( origin.size() == 3 );
   MediaStorage ms;
   ms.SetFromDataSet(ds);
-  assert( MediaStorage::IsImage( ms ) );
+  gdcm_assert( MediaStorage::IsImage( ms ) );
 
   if( ms == MediaStorage::SecondaryCaptureImageStorage && !ImageHelper::SecondaryCaptureImagePlaneModule )
     {
@@ -2149,7 +2149,7 @@ void ImageHelper::SetOriginValue(DataSet & ds, const Image & image)
       if( ds.FindDataElement( tfgs0 ) )
       {
         SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tfgs0 ).GetValueAsSQ();
-        assert( sqi );
+        gdcm_assert( sqi );
         SequenceOfItems::SizeType nitems = sqi->GetNumberOfItems();
         for(SequenceOfItems::SizeType i0 = 1; i0 <= nitems; ++i0)
         {
@@ -2200,7 +2200,7 @@ void ImageHelper::SetDirectionCosinesValue(DataSet & ds, const std::vector<doubl
 {
   MediaStorage ms;
   ms.SetFromDataSet(ds);
-  assert( MediaStorage::IsImage( ms ) );
+  gdcm_assert( MediaStorage::IsImage( ms ) );
 
   if( ms == MediaStorage::SecondaryCaptureImageStorage && !ImageHelper::SecondaryCaptureImagePlaneModule )
     {
@@ -2243,7 +2243,7 @@ void ImageHelper::SetDirectionCosinesValue(DataSet & ds, const std::vector<doubl
   // Image Orientation (Patient)
   Attribute<0x0020,0x0037> iop = {{1,0,0,0,1,0}}; // default value
 
-  assert( dircos.size() == 6 );
+  gdcm_assert( dircos.size() == 6 );
   DirectionCosines dc( dircos.data() );
   if( !dc.IsValid() )
     {
@@ -2316,7 +2316,7 @@ void ImageHelper::SetDirectionCosinesValue(DataSet & ds, const std::vector<doubl
       if( ds.FindDataElement( tfgs ) )
       {
         SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tfgs ).GetValueAsSQ();
-        assert( sqi );
+        gdcm_assert( sqi );
         SequenceOfItems::SizeType nitems = sqi->GetNumberOfItems();
         for(SequenceOfItems::SizeType i0 = 1; i0 <= nitems; ++i0)
         {
@@ -2346,7 +2346,7 @@ void ImageHelper::SetRescaleInterceptSlopeValue(File & f, const Image & img)
   MediaStorage ms;
   // SetFromFile is required here, SetFromDataSet is not enough for all cases
   ms.SetFromFile(f);
-  assert( MediaStorage::IsImage( ms ) );
+  gdcm_assert( MediaStorage::IsImage( ms ) );
   DataSet &ds = f.GetDataSet();
 
   // FIXME Hardcoded
@@ -2441,7 +2441,7 @@ void ImageHelper::SetRescaleInterceptSlopeValue(File & f, const Image & img)
       if( ds.FindDataElement( tfgs ) )
       {
         SmartPointer<SequenceOfItems> sqi = ds.GetDataElement( tfgs ).GetValueAsSQ();
-        assert( sqi );
+        gdcm_assert( sqi );
         SequenceOfItems::SizeType nitems = sqi->GetNumberOfItems();
         for(SequenceOfItems::SizeType i0 = 1; i0 <= nitems; ++i0)
         {
@@ -2860,7 +2860,7 @@ SmartPointer<LookupTable> ImageHelper::GetLUT(File const& f)
         // LookupTableType::RED == 0
         lut->SetLUT( LookupTable::LookupTableType(i),
           (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-        //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+        //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
         }
       else
         {
@@ -2870,7 +2870,7 @@ SmartPointer<LookupTable> ImageHelper::GetLUT(File const& f)
       unsigned long check =
         (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
         * el_us3.GetValue(2) / 8;
-      assert( !lut->Initialized() || check == lut_raw->GetLength() ); (void)check;
+      gdcm_assert( !lut->Initialized() || check == lut_raw->GetLength() ); (void)check;
       }
     else if( ds.FindDataElement( seglut ) )
       {
@@ -2879,7 +2879,7 @@ SmartPointer<LookupTable> ImageHelper::GetLUT(File const& f)
         {
         lut->SetLUT( LookupTable::LookupTableType(i),
           (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-        //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+        //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
         }
       else
         {
@@ -2889,11 +2889,11 @@ SmartPointer<LookupTable> ImageHelper::GetLUT(File const& f)
       //unsigned long check =
       //  (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
        // * el_us3.GetValue(2) / 8;
-      //assert( check == lut_raw->GetLength() ); (void)check;
+      //gdcm_assert( check == lut_raw->GetLength() ); (void)check;
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
   if( ! lut->Initialized() ) {

--- a/Source/MediaStorageAndFileFormat/gdcmImageReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageReader.cxx
@@ -67,7 +67,7 @@ bool ImageReader::ReadImage(MediaStorage const &ms)
   // FIXME: Only SC is allowed not to have spacing:
   if( !spacing.empty() )
     {
-    assert( spacing.size() >= pixeldata.GetNumberOfDimensions() ); // In MR, you can have a Z spacing, but store a 2D image
+    gdcm_assert( spacing.size() >= pixeldata.GetNumberOfDimensions() ); // In MR, you can have a Z spacing, but store a 2D image
     pixeldata.SetSpacing( spacing.data() );
     if( spacing.size() > pixeldata.GetNumberOfDimensions() ) // FIXME HACK
       {

--- a/Source/MediaStorageAndFileFormat/gdcmImageRegionReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageRegionReader.cxx
@@ -41,7 +41,7 @@ public:
     {
     delete TheRegion;
     TheRegion = r.Clone();
-    assert( TheRegion );
+    gdcm_assert( TheRegion );
     Modified = true;
     }
   Region *GetRegion() const
@@ -144,7 +144,7 @@ bool ImageRegionReader::ReadInformation()
     return false;
     }
   std::streampos fileoffset = GetStreamPtr()->tellg();
-  assert( fileoffset != std::streampos(-1) );
+  gdcm_assert( fileoffset != std::streampos(-1) );
   Internals->SetFileOffset( fileoffset );
 
   const File &file = GetFile();
@@ -153,7 +153,7 @@ bool ImageRegionReader::ReadInformation()
 
   MediaStorage ms;
   ms.SetFromFile(file);
-  assert( ms != MediaStorage::VLWholeSlideMicroscopyImageStorage );
+  gdcm_assert( ms != MediaStorage::VLWholeSlideMicroscopyImageStorage );
   if( !MediaStorage::IsImage( ms ) )
     {
     gdcmDebugMacro( "Not an image recognized. Giving up");
@@ -173,7 +173,7 @@ bool ImageRegionReader::ReadInformation()
   // FIXME: Only SC is allowed not to have spacing:
   if( !spacing.empty() )
     {
-    assert( spacing.size() >= pixeldata.GetNumberOfDimensions() ); // In MR, you can have a Z spacing, but store a 2D image
+    gdcm_assert( spacing.size() >= pixeldata.GetNumberOfDimensions() ); // In MR, you can have a Z spacing, but store a 2D image
     pixeldata.SetSpacing( spacing.data() );
     if( spacing.size() > pixeldata.GetNumberOfDimensions() ) // FIXME HACK
       {
@@ -252,8 +252,8 @@ bool ImageRegionReader::ReadRAWIntoBuffer(char *buffer, size_t buflen)
   unsigned int ymax = boundingbox.GetYMax();
   unsigned int zmin = boundingbox.GetZMin();
   unsigned int zmax = boundingbox.GetZMax();
-  assert( xmax >= xmin );
-  assert( ymax >= ymin );
+  gdcm_assert( xmax >= xmin );
+  gdcm_assert( ymax >= ymin );
   unsigned int rowsize = xmax - xmin + 1;
   unsigned int colsize = ymax - ymin + 1;
   unsigned int bytesPerPixel = pixelInfo.GetPixelSize();
@@ -281,8 +281,8 @@ bool ImageRegionReader::ReadRAWIntoBuffer(char *buffer, size_t buflen)
         }
 #if 0
       const char * check = &(buffer[((z-zmin)*rowsize*colsize + (y-ymin)*rowsize)*bytesPerPixel]);
-      assert( check >= buffer && check < buffer + buflen );
-      assert( check + rowsize*bytesPerPixel <= buffer + buflen );
+      gdcm_assert( check >= buffer && check < buffer + buflen );
+      gdcm_assert( check + rowsize*bytesPerPixel <= buffer + buflen );
 #endif
       memcpy(&(buffer[((z-zmin)*rowsize*colsize + (y-ymin)*rowsize)*bytesPerPixel]),
         tmpBuffer2, rowsize*bytesPerPixel);
@@ -326,8 +326,8 @@ bool ImageRegionReader::ReadRLEIntoBuffer(char *buffer, size_t buflen)
   unsigned int zmin = boundingbox.GetZMin();
   unsigned int zmax = boundingbox.GetZMax();
 
-  assert( xmax >= xmin );
-  assert( ymax >= ymin );
+  gdcm_assert( xmax >= xmin );
+  gdcm_assert( ymax >= ymin );
 
   bool ret = theCodec.DecodeExtent(
     buffer,
@@ -375,8 +375,8 @@ bool ImageRegionReader::ReadJPEG2000IntoBuffer(char *buffer, size_t buflen)
   unsigned int zmin = boundingbox.GetZMin();
   unsigned int zmax = boundingbox.GetZMax();
 
-  assert( xmax >= xmin );
-  assert( ymax >= ymin );
+  gdcm_assert( xmax >= xmin );
+  gdcm_assert( ymax >= ymin );
 
   bool ret = theCodec.DecodeExtent(
     buffer,
@@ -425,8 +425,8 @@ bool ImageRegionReader::ReadJPEGIntoBuffer(char *buffer, size_t buflen)
   unsigned int zmin = boundingbox.GetZMin();
   unsigned int zmax = boundingbox.GetZMax();
 
-  assert( xmax >= xmin );
-  assert( ymax >= ymin );
+  gdcm_assert( xmax >= xmin );
+  gdcm_assert( ymax >= ymin );
 
   bool ret = theCodec.DecodeExtent(
     buffer,
@@ -474,8 +474,8 @@ bool ImageRegionReader::ReadJPEGLSIntoBuffer(char *buffer, size_t buflen)
   unsigned int zmin = boundingbox.GetZMin();
   unsigned int zmax = boundingbox.GetZMax();
 
-  assert( xmax >= xmin );
-  assert( ymax >= ymin );
+  gdcm_assert( xmax >= xmin );
+  gdcm_assert( ymax >= ymin );
 
   bool ret = theCodec.DecodeExtent(
     buffer,
@@ -502,7 +502,7 @@ bool ImageRegionReader::ReadIntoBuffer(char *buffer, size_t buflen)
     gdcmDebugMacro( "buffer cannot be smaller than computed buffer length" );
     return false;
     }
-  assert( Internals->GetFileOffset() != std::streampos(-1) );
+  gdcm_assert( Internals->GetFileOffset() != std::streampos(-1) );
   gdcmDebugMacro( "Using FileOffset: " << Internals->GetFileOffset() );
   std::istream* theStream = GetStreamPtr();
   theStream->seekg( Internals->GetFileOffset() );

--- a/Source/MediaStorageAndFileFormat/gdcmImageWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageWriter.cxx
@@ -77,7 +77,7 @@ bool ImageWriter::Write()
   const MediaStorage ms = ComputeTargetMediaStorage();
   if( !PrepareWrite( ms ) ) return false;
 
-  //assert( Stream.is_open() );
+  //gdcm_assert( Stream.is_open() );
   File& file = GetFile();
   DataSet& ds = file.GetDataSet();
 
@@ -121,7 +121,7 @@ bool ImageWriter::Write()
   char date[22];
   const size_t datelen = 8;
   int res = System::GetCurrentDateTime(date);
-  assert( res );
+  gdcm_assert( res );
   (void)res;//warning removal
   if( !ds.FindDataElement( Tag(0x0008,0x0020) ) )
     {
@@ -177,7 +177,7 @@ bool ImageWriter::Write()
     ds.Insert( de );
     }
 
-  assert( ms != MediaStorage::MS_END );
+  gdcm_assert( ms != MediaStorage::MS_END );
 
   // Patient Orientation
   if( ms == MediaStorage::SecondaryCaptureImageStorage && !ds.FindDataElement( Tag(0x0020,0x0020) ) )
@@ -204,18 +204,18 @@ bool ImageWriter::Write()
     if( bv )
       {
       modality2 = std::string( bv->GetPointer(), bv->GetLength() );
-      //assert( modality2.find( ' ' ) == std::string::npos ); // no space ...
+      //gdcm_assert( modality2.find( ' ' ) == std::string::npos ); // no space ...
       }
     else
       {
       // remove empty Modality, and set a new one...
       ds.Remove( Tag(0x0008, 0x0060 ) ); // Modality is Type 1 !
-      assert( ms != MediaStorage::MS_END );
+      gdcm_assert( ms != MediaStorage::MS_END );
       }
 /*
     if( modality2 != ms.GetModality() )
       {
-      assert( std::string(ms.GetModality()).find( ' ' ) == std::string::npos ); // no space ...
+      gdcm_assert( std::string(ms.GetModality()).find( ' ' ) == std::string::npos ); // no space ...
       DataElement de( Tag(0x0008, 0x0060 ) );
       de.SetByteValue( ms.GetModality(), strlen(ms.GetModality()) );
       de.SetVR( Attribute<0x0008, 0x0060>::GetVR() );
@@ -246,7 +246,7 @@ bool ImageWriter::Write()
   // Do the Rescale Intercept & Slope
   if( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 )
   {
-    assert( pf.GetSamplesPerPixel() == 1 );
+    gdcm_assert( pf.GetSamplesPerPixel() == 1 );
     ImageHelper::SetRescaleInterceptSlopeValue(GetFile(), pixeldata);
     if( ms == MediaStorage::RTDoseStorage && pixeldata.GetIntercept() != 0 )
     {
@@ -282,8 +282,8 @@ bool ImageWriter::Write()
     if ( pi == PhotometricInterpretation::PALETTE_COLOR )
       {
       const LookupTable &lut = PixelData->GetLUT();
-      assert( lut.Initialized() );
-//      assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
+      gdcm_assert( lut.Initialized() );
+//      gdcm_assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
 //           || (pf.GetBitsAllocated() == 16 && pf.GetPixelRepresentation() == 0) );
       // lut descriptor:
       // (0028,1101) US 256\0\16                                 #   6, 3 RedPaletteColorLookupTableDescriptor
@@ -415,7 +415,7 @@ Attribute<0x0028,0x0004> piat;
     ImageHelper::SetOriginValue(ds, pixeldata);
     }
 
-  assert( Stream );
+  gdcm_assert( Stream );
   if( !Writer::Write() )
     {
     return false;

--- a/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEG2000Codec.cxx
@@ -209,7 +209,7 @@ static bool parsejp2_imp( const char * const stream, const size_t file_size, boo
     if( len32 == 1 ) /* 64bits ? */
       {
       bool b = read64(&cur, &cur_size, &len64);
-      assert( b ); (void)b;
+      gdcm_assert(b); (void)b;
       len64 -= 8;
       }
     if( marker == JP2C )
@@ -219,7 +219,7 @@ static bool parsejp2_imp( const char * const stream, const size_t file_size, boo
         {
         len64 = (size_t)(file_size - start + 8);
         }
-      assert( len64 >= 8 );
+      gdcm_assert( len64 >= 8 );
       return parsej2k_imp( cur, (size_t)(len64 - 8), lossless, mct );
       }
       const size_t lenmarker = (size_t)(len64 - 8);
@@ -293,11 +293,11 @@ OPJ_SIZE_T opj_read_from_memory(void * p_buffer, OPJ_SIZE_T p_nb_bytes, myfile* 
   else
     {
     l_nb_read = (OPJ_SIZE_T)(p_file->mem + p_file->len - p_file->cur);
-    assert( l_nb_read < p_nb_bytes );
+    gdcm_assert( l_nb_read < p_nb_bytes );
     }
   memcpy(p_buffer,p_file->cur,l_nb_read);
   p_file->cur += l_nb_read;
-  assert( p_file->cur <= p_file->mem + p_file->len );
+  gdcm_assert( p_file->cur <= p_file->mem + p_file->len );
   //std::cout << "l_nb_read: " << l_nb_read << std::endl;
   return l_nb_read ? l_nb_read : ((OPJ_SIZE_T)-1);
 }
@@ -313,12 +313,12 @@ OPJ_SIZE_T opj_write_from_memory (void * p_buffer, OPJ_SIZE_T p_nb_bytes, myfile
   //else
   //  {
   //  l_nb_write = p_file->mem + p_file->len - p_file->cur;
-  //  assert( l_nb_write < p_nb_bytes );
+  //  gdcm_assert( l_nb_write < p_nb_bytes );
   //  }
   memcpy(p_file->cur,p_buffer,l_nb_write);
   p_file->cur += l_nb_write;
   p_file->len += l_nb_write;
-  //assert( p_file->cur < p_file->mem + p_file->len );
+  //gdcm_assert( p_file->cur < p_file->mem + p_file->len );
   return l_nb_write;
   //return p_nb_bytes;
 }
@@ -346,7 +346,7 @@ OPJ_BOOL opj_seek_from_memory (OPJ_OFF_T p_nb_bytes, myfile * p_file)
   //  return false;
   //  }
   //return true;
-  assert( p_nb_bytes >= 0 );
+  gdcm_assert( p_nb_bytes >= 0 );
   if( (size_t)p_nb_bytes <= p_file->len )
     {
     p_file->cur = p_file->mem + p_nb_bytes;
@@ -376,7 +376,7 @@ opj_stream_t* OPJ_CALLCONV opj_stream_create_memory_stream (myfile* p_mem,OPJ_SI
   opj_stream_set_write_function(l_stream, (opj_stream_write_fn) opj_write_from_memory);
   opj_stream_set_skip_function(l_stream, (opj_stream_skip_fn) opj_skip_from_memory);
   opj_stream_set_seek_function(l_stream, (opj_stream_seek_fn) opj_seek_from_memory);
-  opj_stream_set_user_data_length(l_stream, p_mem->len /* p_size*/); /* important to avoid an assert() */
+  opj_stream_set_user_data_length(l_stream, p_mem->len /* p_size*/); /* important to avoid an gdcm_assert() */
   return l_stream;
 }
 
@@ -528,7 +528,7 @@ bool JPEG2000Codec::Decode(DataElement const &in, DataElement &out)
     if ( j2kbv )
       {
       gdcmWarningMacro( "Pixel Data is not encapsulated correctly. Continuing anyway" );
-      assert( !sf );
+      gdcm_assert( !sf );
       std::stringstream is;
       size_t j2kbv_len = j2kbv->GetLength();
       char *mybuffer = new char[j2kbv_len];
@@ -591,10 +591,10 @@ bool JPEG2000Codec::Decode(DataElement const &in, DataElement &out)
       delete[] mybuffer;
       bool r = DecodeByStreams(is, os);
       if(!r) return false;
-      assert( r == true );
+      gdcm_assert( r == true );
       }
     std::string str = os.str();
-    assert( !str.empty() );
+    gdcm_assert( !str.empty() );
     out.SetByteValue( str.data(), (uint32_t)str.size() );
 
     return true;
@@ -664,16 +664,16 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
     // gdcmData/MAROTECH_CT_JP2Lossy.dcm
     gdcmWarningMacro( "J2K start like JPEG-2000 compressed image data instead of codestream" );
     parameters.decod_format = JP2_CFMT;
-    assert(parameters.decod_format == JP2_CFMT);
+    gdcm_assert(parameters.decod_format == JP2_CFMT);
     }
   else
     {
     /* JPEG-2000 codestream */
     parameters.decod_format = J2K_CFMT;
-    assert(parameters.decod_format == J2K_CFMT);
+    gdcm_assert(parameters.decod_format == J2K_CFMT);
     }
   parameters.cod_format = PGX_DFMT;
-  assert(parameters.cod_format == PGX_DFMT);
+  gdcm_assert(parameters.cod_format == PGX_DFMT);
 
   /* get a decoder handle */
   switch(parameters.decod_format)
@@ -763,17 +763,17 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
     {
     if( image->color_space == CLRSPC_GRAY )
       {
-      assert( this->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2
+      gdcm_assert( this->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2
         || this->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
         || this->GetPhotometricInterpretation() == PhotometricInterpretation::PALETTE_COLOR );
       }
     else if( image->color_space == CLRSPC_SRGB )
       {
-      assert( this->GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
+      gdcm_assert( this->GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
       }
     else
       {
-      assert(0);
+      gdcm_assert(0);
       }
     }
 #endif
@@ -792,8 +792,8 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
   }
   LossyFlag = !reversible;
 
-  assert( image->numcomps == this->GetPixelFormat().GetSamplesPerPixel() );
-  assert( image->numcomps == this->GetPhotometricInterpretation().GetSamplesPerPixel() );
+  gdcm_assert( image->numcomps == this->GetPixelFormat().GetSamplesPerPixel() );
+  gdcm_assert( image->numcomps == this->GetPhotometricInterpretation().GetSamplesPerPixel() );
   if( this->GetPhotometricInterpretation() == PhotometricInterpretation::RGB
    || this->GetPhotometricInterpretation() == PhotometricInterpretation::YBR_FULL )
   {
@@ -815,7 +815,7 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
   // Copy buffer
   unsigned long len = Dimensions[0]*Dimensions[1] * (PF.GetBitsAllocated() / 8) * image->numcomps;
   char *raw = new char[len];
-  //assert( len == fsrc->len );
+  //gdcm_assert( len == fsrc->len );
   for (unsigned int compno = 0; compno < (unsigned int)image->numcomps; compno++)
     {
     opj_image_comp_t *comp = &image->comps[compno];
@@ -825,7 +825,7 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
 
     //int h = image.comps[compno].h;
     int hr = int_ceildivpow2(image->comps[compno].h, image->comps[compno].factor);
-    //assert(  wr * hr * 1 * image->numcomps * (comp->prec/8) == len );
+    //gdcm_assert(  wr * hr * 1 * image->numcomps * (comp->prec/8) == len );
 
     // ELSCINT1_JP2vsJ2K.dcm
     // -> prec = 12, bpp = 0, sgnd = 0
@@ -841,10 +841,10 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
       PF.SetPixelRepresentation( (uint16_t)comp->sgnd );
       }
 #ifndef GDCM_SUPPORT_BROKEN_IMPLEMENTATION
-    assert( comp->prec == PF.GetBitsStored()); // D_CLUNIE_RG3_JPLY.dcm
-    assert( comp->prec - 1 == PF.GetHighBit());
+    gdcm_assert( comp->prec == PF.GetBitsStored()); // D_CLUNIE_RG3_JPLY.dcm
+    gdcm_assert( comp->prec - 1 == PF.GetHighBit());
 #endif
-    //assert( comp->prec >= PF.GetBitsStored());
+    //gdcm_assert( comp->prec >= PF.GetBitsStored());
     if( comp->prec != PF.GetBitsStored() )
       {
       if( comp->prec <= 8 )
@@ -856,8 +856,8 @@ std::pair<char *, size_t> JPEG2000Codec::DecodeByStreamsCommon(char *dummy_buffe
       PF.SetBitsStored( (unsigned short)comp->prec );
       PF.SetHighBit( (unsigned short)(comp->prec - 1) ); // ??
       }
-    assert( PF.IsValid() );
-    assert( comp->prec <= 32 );
+    gdcm_assert( PF.IsValid() );
+    gdcm_assert( comp->prec <= 32 );
 
     if (comp->prec <= 8)
       {
@@ -1064,7 +1064,7 @@ opj_image_t* rawtoimage(const char *inputbuffer8, opj_cparameters_t *parameters,
   opj_image_t * image = nullptr;
   const void * inputbuffer = inputbuffer8;
 
-  assert( sample_pixel == 1 || sample_pixel == 3 );
+  gdcm_assert( sample_pixel == 1 || sample_pixel == 3 );
   if( sample_pixel == 1 )
     {
     numcomps = 1;
@@ -1081,9 +1081,9 @@ opj_image_t* rawtoimage(const char *inputbuffer8, opj_cparameters_t *parameters,
     gdcmDebugMacro( "BitsAllocated is not % 8" );
     return nullptr;
     }
-  assert( bitsallocated % 8 == 0 );
+  gdcm_assert( bitsallocated % 8 == 0 );
   // eg. fragment_size == 63532 and 181 * 117 * 3 * 8 == 63531 ...
-  assert( ((fragment_size + 1)/2 ) * 2 == (((size_t)image_height * image_width * numcomps * (bitsallocated/8) + 1)/ 2 )* 2 );
+  gdcm_assert( ((fragment_size + 1)/2 ) * 2 == (((size_t)image_height * image_width * numcomps * (bitsallocated/8) + 1)/ 2 )* 2 );
   int subsampling_dx = parameters->subsampling_dx;
   int subsampling_dy = parameters->subsampling_dy;
 
@@ -1093,7 +1093,7 @@ opj_image_t* rawtoimage(const char *inputbuffer8, opj_cparameters_t *parameters,
 
   /* initialize image components */
   memset(&cmptparm[0], 0, 3 * sizeof(opj_image_cmptparm_t));
-  //assert( bitsallocated == 8 );
+  //gdcm_assert( bitsallocated == 8 );
   for(int i = 0; i < numcomps; i++) {
     cmptparm[i].prec = bitsstored;
     cmptparm[i].prec = bitsallocated; // FIXME
@@ -1118,7 +1118,7 @@ opj_image_t* rawtoimage(const char *inputbuffer8, opj_cparameters_t *parameters,
 
   /* set image data */
 
-  //assert( fragment_size == numcomps*w*h*(bitsallocated/8) );
+  //gdcm_assert( fragment_size == numcomps*w*h*(bitsallocated/8) );
   if (bitsallocated <= 8)
     {
     if( sign )
@@ -1392,12 +1392,12 @@ bool JPEG2000Codec::Code(DataElement const &in, DataElement &out)
     if( !b ) return false;
 
     Fragment frag;
-    assert( cbyteCompressed <= rgbyteCompressed.size() ); // default alloc would be bogus
+    gdcm_assert( cbyteCompressed <= rgbyteCompressed.size() ); // default alloc would be bogus
     frag.SetByteValue( rgbyteCompressed.data(), (uint32_t)cbyteCompressed );
     sq->AddFragment( frag );
     }
 
-  assert( sq->GetNumberOfFragments() == dims[2] );
+  gdcm_assert( sq->GetNumberOfFragments() == dims[2] );
   out.SetValue( *sq );
 
   return true;
@@ -1435,16 +1435,16 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     // gdcmData/ELSCINT1_JP2vsJ2K.dcm
     gdcmWarningMacro( "J2K start like JPEG-2000 compressed image data instead of codestream" );
     parameters.decod_format = JP2_CFMT;
-    assert(parameters.decod_format == JP2_CFMT);
+    gdcm_assert(parameters.decod_format == JP2_CFMT);
     }
   else
     {
     /* JPEG-2000 codestream */
     parameters.decod_format = J2K_CFMT;
-    assert(parameters.decod_format == J2K_CFMT);
+    gdcm_assert(parameters.decod_format == J2K_CFMT);
     }
   parameters.cod_format = PGX_DFMT;
-  assert(parameters.cod_format == PGX_DFMT);
+  gdcm_assert(parameters.cod_format == PGX_DFMT);
 
   /* get a decoder handle */
   switch(parameters.decod_format )
@@ -1506,9 +1506,9 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
   int mct = 0;
 #if 0
   reversible = opj_get_reversible(dinfo, &parameters );
-  assert( reversible == 0 || reversible == 1 );
+  gdcm_assert( reversible == 0 || reversible == 1 );
   // FIXME
-  assert( mct == 0 || mct == 1 );
+  gdcm_assert( mct == 0 || mct == 1 );
 #else
   bool b = false;
   bool lossless = false;
@@ -1569,13 +1569,13 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     // color space info:
     // - gdcmData/MAROTECH_CT_JP2Lossy.dcm
     // - gdcmData/D_CLUNIE_CT1_J2KI.dcm -> color_space = 32767
-    //assert( image->color_space == 0 || image->color_space == CLRSPC_GRAY );
+    //gdcm_assert( image->color_space == 0 || image->color_space == CLRSPC_GRAY );
     PI = PhotometricInterpretation::MONOCHROME2;
     this->PF.SetSamplesPerPixel( 1 );
     }
   else if( image->numcomps == 3 )
     {
-    //assert( image->color_space == 0 );
+    //gdcm_assert( image->color_space == 0 );
     //PI = PhotometricInterpretation::RGB;
     /*
     8.2.4 JPEG 2000 IMAGE COMPRESSION
@@ -1626,7 +1626,7 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
     return false;
     }
 
-  assert( PI != PhotometricInterpretation::UNKNOWN );
+  gdcm_assert( PI != PhotometricInterpretation::UNKNOWN );
 
   bool bmct = false;
   if( bmct )
@@ -1662,15 +1662,15 @@ bool JPEG2000Codec::GetHeaderInfo(const char * dummy_buffer, size_t buf_size, Tr
       }
     }
 
-  //assert( ts.IsLossy() == this->GetPhotometricInterpretation().IsLossy() );
-  //assert( ts.IsLossless() == this->GetPhotometricInterpretation().IsLossless() );
+  //gdcm_assert( ts.IsLossy() == this->GetPhotometricInterpretation().IsLossy() );
+  //gdcm_assert( ts.IsLossless() == this->GetPhotometricInterpretation().IsLossless() );
   if( this->GetPhotometricInterpretation().IsLossy() )
     {
-    assert( ts.IsLossy() );
+    gdcm_assert( ts.IsLossy() );
     }
   if( ts.IsLossless() && !ts.IsLossy() )
     {
-    assert( this->GetPhotometricInterpretation().IsLossless() );
+    gdcm_assert( this->GetPhotometricInterpretation().IsLossless() );
     }
 
   /* close the byte stream */
@@ -1702,9 +1702,9 @@ bool JPEG2000Codec::DecodeExtent(
   const unsigned int * dimensions = this->GetDimensions();
   // retrieve pixel format *after* DecodeByStreamsCommon !
   const PixelFormat pf = this->GetPixelFormat(); // make a copy !
-  assert( pf.GetBitsAllocated() % 8 == 0 );
-  assert( pf != PixelFormat::SINGLEBIT );
-  assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
+  gdcm_assert( pf.GetBitsAllocated() % 8 == 0 );
+  gdcm_assert( pf != PixelFormat::SINGLEBIT );
+  gdcm_assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
 
   if( NumberOfDimensions == 2 )
     {
@@ -1727,9 +1727,9 @@ bool JPEG2000Codec::DecodeExtent(
       // read J2K
       is.read( &vdummybuffer[oldlen], fraglen );
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
-    assert( zmin == zmax );
-    assert( zmin == 0 );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( zmin == zmax );
+    gdcm_assert( zmin == 0 );
 
     std::pair<char*,size_t> raw_len = this->DecodeByStreamsCommon(dummy_buffer, buf_size);
     if( !raw_len.first || !raw_len.second ) return false;
@@ -1775,14 +1775,14 @@ bool JPEG2000Codec::DecodeExtent(
     while( frag.ReadPreValue<SwapperNoOp>(is) && frag.GetTag() != seqDelItem )
       {
       //std::streamoff relstart = is.tellg();
-      //assert( relstart - thestart == 8 );
+      //gdcm_assert( relstart - thestart == 8 );
       std::streamoff off = frag.GetVL();
       offsets.push_back( (size_t)off );
       is.seekg( off, std::ios::cur );
       ++numfrags;
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
-    assert( numfrags == offsets.size() );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( numfrags == offsets.size() );
     if( numfrags != Dimensions[2] )
       {
       gdcmErrorMacro( "Not handled" );
@@ -1862,7 +1862,7 @@ bool JPEG2000Codec::AppendFrameEncode( std::ostream & out, const char * data, si
 {
   const unsigned int * dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat();
-  assert( datalen == dimensions[0] * dimensions[1] * pf.GetPixelSize() ); (void)pf;
+  gdcm_assert( datalen == dimensions[0] * dimensions[1] * pf.GetPixelSize() ); (void)pf;
 
   std::vector<char> rgbyteCompressed;
   rgbyteCompressed.resize(dimensions[0] * dimensions[1] * 4);

--- a/Source/MediaStorageAndFileFormat/gdcmJPEGBITSCodec.hxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGBITSCodec.hxx
@@ -130,7 +130,7 @@ fill_input_buffer (j_decompress_ptr cinfo)
     }
 
   std::streamsize gcount = src->infile->gcount();
-  assert(gcount < INT_MAX);
+  gdcm_assert(gcount < INT_MAX);
   nbytes = (size_t)gcount;
 
   if (gcount <= 0) {
@@ -341,8 +341,8 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
       if ( jerr.pub.msg_code == JERR_BAD_PRECISION /* 18 */ )
         {
         this->BitSample = jerr.pub.msg_parm.i[0];
-        assert( this->BitSample == 1 || this->BitSample == 8 || this->BitSample == 12 || this->BitSample == 16 );
-        assert( this->BitSample == cinfo.data_precision );
+        gdcm_assert( this->BitSample == 1 || this->BitSample == 8 || this->BitSample == 12 || this->BitSample == 16 );
+        gdcm_assert( this->BitSample == cinfo.data_precision );
         }
       jpeg_destroy_decompress(&cinfo);
       // TODO: www.dcm4che.org/jira/secure/attachment/10185/ct-implicit-little.dcm
@@ -383,7 +383,7 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
         }
       else
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       }
     this->Dimensions[1] = cinfo.image_height;  /* Number of rows in image */
@@ -413,11 +413,11 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
       }
     else
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
     this->PF.SetPixelRepresentation( (uint16_t)prep );
     this->PF.SetBitsStored( (uint16_t)precision );
-    assert( (precision - 1) >= 0 );
+    gdcm_assert( (precision - 1) >= 0 );
     this->PF.SetHighBit( (uint16_t)(precision - 1) );
 
   this->PlanarConfiguration = 0;
@@ -444,24 +444,24 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
         }
       else
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       }
     else if( cinfo.jpeg_color_space == JCS_GRAYSCALE )
       {
-      assert( cinfo.num_components == 1 );
+      gdcm_assert( cinfo.num_components == 1 );
       PI = PhotometricInterpretation::MONOCHROME2;
       this->PF.SetSamplesPerPixel( 1 );
       }
     else if( cinfo.jpeg_color_space == JCS_RGB )
       {
-      assert( cinfo.num_components == 3 );
+      gdcm_assert( cinfo.num_components == 3 );
       PI = PhotometricInterpretation::RGB;
       this->PF.SetSamplesPerPixel( 3 );
       }
     else if( cinfo.jpeg_color_space == JCS_YCbCr )
       {
-      assert( cinfo.num_components == 3 );
+      gdcm_assert( cinfo.num_components == 3 );
       PI = PhotometricInterpretation::YBR_FULL_422;
       if( cinfo.process == JPROC_LOSSLESS )
         PI = PhotometricInterpretation::RGB; // wotsit ?
@@ -470,20 +470,20 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
       }
     else if( cinfo.jpeg_color_space == JCS_CMYK )
       {
-      assert( cinfo.num_components == 4 );
+      gdcm_assert( cinfo.num_components == 4 );
       PI = PhotometricInterpretation::CMYK;
       this->PF.SetSamplesPerPixel( 4 );
       }
     else if( cinfo.jpeg_color_space == JCS_YCCK )
       {
-      assert( cinfo.num_components == 4 );
+      gdcm_assert( cinfo.num_components == 4 );
       gdcmWarningMacro( "JCS_YCCK is not handled. Setting to CMYK for now." );
       PI = PhotometricInterpretation::CMYK; // non-sense...oh well
       this->PF.SetSamplesPerPixel( 4 );
       }
     else
       {
-      assert( 0 ); //TODO
+      gdcm_assert( 0 ); //TODO
       }
     }
   if( cinfo.process == JPROC_LOSSLESS )
@@ -519,13 +519,13 @@ bool JPEGBITSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
       }
     else
       {
-      assert(0); // TODO
+      gdcm_assert(0); // TODO
       return false;
       }
     }
   else
     {
-    assert(0); // TODO
+    gdcm_assert(0); // TODO
     return false;
     }
   if( cinfo.process == JPROC_LOSSLESS )
@@ -573,7 +573,7 @@ UINT16 Y_density
         }
       break;
     case JCS_RGB:
-      assert( GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
+      gdcm_assert( GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
       break;
     case JCS_YCbCr:
       if( GetPhotometricInterpretation() != PhotometricInterpretation::YBR_FULL &&
@@ -597,11 +597,11 @@ UINT16 Y_density
         }
       break;
     default:
-      assert(0);
+      gdcm_assert(0);
       return false;
       }
-    //assert( cinfo.data_precision == BITS_IN_JSAMPLE );
-    //assert( cinfo.data_precision == this->BitSample );
+    //gdcm_assert( cinfo.data_precision == BITS_IN_JSAMPLE );
+    //gdcm_assert( cinfo.data_precision == this->BitSample );
 
     /* Step 4: set parameters for decompression */
     /* no op */
@@ -731,7 +731,7 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
       if ( jerr.pub.msg_code == JERR_BAD_PRECISION /* 18 */ )
         {
         this->BitSample = jerr.pub.msg_parm.i[0];
-        //assert( this->BitSample == 8 || this->BitSample == 12 || this->BitSample == 16 );
+        //gdcm_assert( this->BitSample == 8 || this->BitSample == 12 || this->BitSample == 16 );
         }
       jpeg_destroy_decompress(&cinfo);
       // TODO: www.dcm4che.org/jira/secure/attachment/10185/ct-implicit-little.dcm
@@ -773,13 +773,13 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         // LJPEG_BuginGDCM12.dcm
         gdcmDebugMacro( "JWRN_MUST_DOWNSCALE" );
         this->BitSample = jerr.pub.msg_parm.i[0];
-        assert( cinfo.data_precision == this->BitSample );
+        gdcm_assert( cinfo.data_precision == this->BitSample );
         jpeg_destroy_decompress(&cinfo);
         return false;
         }
       else
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       }
     // Let's check the color space:
@@ -806,8 +806,8 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
        */
       return false;
       }
-    assert( cinfo.image_width == dims[0] );
-    assert( cinfo.image_height == dims[1] );
+    gdcm_assert( cinfo.image_width == dims[0] );
+    gdcm_assert( cinfo.image_height == dims[1] );
 
     switch ( cinfo.jpeg_color_space )
       {
@@ -823,7 +823,7 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         }
       break;
     case JCS_RGB:
-      //assert( GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
+      //gdcm_assert( GetPhotometricInterpretation() == PhotometricInterpretation::RGB );
         if ( cinfo.process == JPROC_LOSSLESS )
           {
           cinfo.jpeg_color_space = JCS_UNKNOWN;
@@ -866,7 +866,7 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         }
       break;
     case JCS_CMYK:
-      assert( GetPhotometricInterpretation() == PhotometricInterpretation::CMYK );
+      gdcm_assert( GetPhotometricInterpretation() == PhotometricInterpretation::CMYK );
       if ( cinfo.process == JPROC_LOSSLESS )
         {
         cinfo.jpeg_color_space = JCS_UNKNOWN;
@@ -881,11 +881,11 @@ bool JPEGBITSCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         }
       break;
     default:
-      assert(0);
+      gdcm_assert(0);
       return false;
       }
-    //assert( cinfo.data_precision == BITS_IN_JSAMPLE );
-    //assert( cinfo.data_precision == this->BitSample );
+    //gdcm_assert( cinfo.data_precision == BITS_IN_JSAMPLE );
+    //gdcm_assert( cinfo.data_precision == this->BitSample );
 
     /* Step 4: set parameters for decompression */
     /* no op */
@@ -1264,7 +1264,7 @@ bool JPEGBITSCodec::InternalCode(const char* input, unsigned long len, std::ostr
   //  {
   //  cinfo.in_color_space = JCS_UNKNOWN;
   //  }
-  //assert( cinfo.image_height * cinfo.image_width * cinfo.input_components * sizeof(JSAMPLE) == len );
+  //gdcm_assert( cinfo.image_height * cinfo.image_width * cinfo.input_components * sizeof(JSAMPLE) == len );
 
   /* Now use the library's routine to set default compression parameters.
    * (You must set at least cinfo.in_color_space before calling this,
@@ -1290,7 +1290,7 @@ bool JPEGBITSCodec::InternalCode(const char* input, unsigned long len, std::ostr
    */
   if( !LossyFlag )
     {
-    assert( Quality == 100 );
+    gdcm_assert( Quality == 100 );
     }
   jpeg_set_quality(&cinfo, Quality, TRUE /* limit to baseline-JPEG values */);
 
@@ -1339,7 +1339,7 @@ bool JPEGBITSCodec::InternalCode(const char* input, unsigned long len, std::ostr
     row_pointer[0] = tempbuffer;
     int offset = image_height * image_width;
     while (cinfo.next_scanline < cinfo.image_height) {
-      assert( row_stride % 3 == 0 );
+      gdcm_assert( row_stride % 3 == 0 );
       JSAMPLE* ptempbuffer = tempbuffer;
       JSAMPLE* red   = image_buffer + cinfo.next_scanline * row_stride / 3;
       JSAMPLE* green = image_buffer + cinfo.next_scanline * row_stride / 3 + offset;
@@ -1486,7 +1486,7 @@ bool JPEGBITSCodec::EncodeBuffer(std::ostream &os, const char *data, size_t data
   //  {
   //  cinfo.in_color_space = JCS_UNKNOWN;
   //  }
-  //assert( cinfo.image_height * cinfo.image_width * cinfo.input_components * sizeof(JSAMPLE) == len );
+  //gdcm_assert( cinfo.image_height * cinfo.image_width * cinfo.input_components * sizeof(JSAMPLE) == len );
 
   /* Now use the library's routine to set default compression parameters.
    * (You must set at least cinfo.in_color_space before calling this,
@@ -1518,7 +1518,7 @@ bool JPEGBITSCodec::EncodeBuffer(std::ostream &os, const char *data, size_t data
    */
   if( !LossyFlag )
     {
-    assert( Quality == 100 );
+    gdcm_assert( Quality == 100 );
     }
   if( Internals->StateSuspension == 0 )
     {
@@ -1559,8 +1559,8 @@ bool JPEGBITSCodec::EncodeBuffer(std::ostream &os, const char *data, size_t data
 
   if ( Internals->StateSuspension == 1 )
     {
-    assert( this->GetPlanarConfiguration() == 0 );
-    assert( row_stride * sizeof(JSAMPLE) == datalen );
+    gdcm_assert( this->GetPlanarConfiguration() == 0 );
+    gdcm_assert( row_stride * sizeof(JSAMPLE) == datalen );
       {
       //while (cinfo.next_scanline < cinfo.image_height) {
       /* jpeg_write_scanlines expects an array of pointers to scanlines.
@@ -1569,8 +1569,8 @@ bool JPEGBITSCodec::EncodeBuffer(std::ostream &os, const char *data, size_t data
        */
       row_pointer[0] = & image_buffer[cinfo.next_scanline * row_stride * 0];
       const JDIMENSION nscanline = jpeg_write_scanlines(&cinfo, row_pointer, 1);
-      assert( nscanline == 1 ); (void)nscanline;
-      assert(cinfo.next_scanline <= cinfo.image_height);
+      gdcm_assert( nscanline == 1 ); (void)nscanline;
+      gdcm_assert(cinfo.next_scanline <= cinfo.image_height);
       //}
       }
     if(cinfo.next_scanline == cinfo.image_height)

--- a/Source/MediaStorageAndFileFormat/gdcmJPEGCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGCodec.cxx
@@ -146,7 +146,7 @@ Interchange Format shall be used (the table specification shall be included).
 */
 bool JPEGCodec::Decode(DataElement const &in, DataElement &out)
 {
-  assert( Internal );
+  gdcm_assert( Internal );
   out = in;
   // Fragments...
   const SequenceOfFragments *sf0 = in.GetSequenceOfFragments();
@@ -164,7 +164,7 @@ bool JPEGCodec::Decode(DataElement const &in, DataElement &out)
       size_t bv_len = bv.GetLength();
       char *mybuffer = new char[bv_len];
       bool b = bv.GetBuffer(mybuffer, bv.GetLength());
-      assert( b ); (void)b;
+      gdcm_assert(b); (void)b;
       is.write(mybuffer, bv.GetLength());
       delete[] mybuffer;
       bool r = DecodeByStreams(is, os);
@@ -197,7 +197,7 @@ bool JPEGCodec::Decode(DataElement const &in, DataElement &out)
     size_t jpegbv_len = jpegbv->GetLength();
     char *mybuffer0 = new char[jpegbv_len];
     bool b0 = jpegbv->GetBuffer(mybuffer0, jpegbv->GetLength());
-    assert( b0 ); (void)b0;
+    gdcm_assert( b0 ); (void)b0;
     is0.write(mybuffer0, jpegbv->GetLength());
     delete[] mybuffer0;
     bool r = DecodeByStreams(is0, os);
@@ -223,7 +223,7 @@ bool JPEGCodec::Decode(DataElement const &in, DataElement &out)
         size_t bv_len = bv.GetLength();
         char *mybuffer = new char[bv_len];
         bool b = bv.GetBuffer(mybuffer, bv.GetLength());
-        assert( b ); (void)b;
+        gdcm_assert(b); (void)b;
         is.write(mybuffer, bv.GetLength());
         delete[] mybuffer;
         bool r2 = DecodeByStreams(is, os);
@@ -235,7 +235,7 @@ bool JPEGCodec::Decode(DataElement const &in, DataElement &out)
 
       }
     }
-  //assert( pos == len );
+  //gdcm_assert( pos == len );
   const size_t sizeOfOs = (size_t)os.tellp();
   os.seekp( 0, std::ios::beg );
   ByteValue * bv = new ByteValue;
@@ -250,12 +250,12 @@ void JPEGCodec::ComputeOffsetTable(bool b)
 {
   (void)b;
   // Not implemented
-  assert(0);
+  gdcm_assert(0);
 }
 
 bool JPEGCodec::GetHeaderInfo( std::istream & is, TransferSyntax &ts )
 {
-  assert( Internal );
+  gdcm_assert( Internal );
   if ( !Internal->GetHeaderInfo(is, ts) )
     {
     // let's check if this is one of those buggy lossless JPEG
@@ -267,7 +267,7 @@ bool JPEGCodec::GetHeaderInfo( std::istream & is, TransferSyntax &ts )
         " but JPEG header says it's: " << Internal->BitSample );
       if( this->BitSample < Internal->BitSample )
         {
-        //assert(0); // Outside buffer will be too small
+        //gdcm_assert(0); // Outside buffer will be too small
         }
       is.seekg(0, std::ios::beg);
       SetupJPEGBitCodec( Internal->BitSample );
@@ -284,7 +284,7 @@ bool JPEGCodec::GetHeaderInfo( std::istream & is, TransferSyntax &ts )
         }
       else
         {
-        //assert(0); // FATAL ERROR
+        //gdcm_assert(0); // FATAL ERROR
         gdcmErrorMacro( "Do not support this JPEG Type" );
         return false;
         }
@@ -341,7 +341,7 @@ bool JPEGCodec::Code(DataElement const &in, DataElement &out)
       }
 
     std::string str = os.str();
-    assert( !str.empty() );
+    gdcm_assert( !str.empty() );
     Fragment frag;
     //frag.SetTag( itemStart );
     VL::Type strSize = (VL::Type)str.size();
@@ -350,7 +350,7 @@ bool JPEGCodec::Code(DataElement const &in, DataElement &out)
 
     }
   //unsigned int n = sq->GetNumberOfFragments();
-  assert( sq->GetNumberOfFragments() == dims[2] );
+  gdcm_assert( sq->GetNumberOfFragments() == dims[2] );
   out.SetValue( *sq );
 
   return true;
@@ -372,7 +372,7 @@ bool JPEGCodec::DecodeByStreams(std::istream &is, std::ostream &os)
         " but JPEG header says it's: " << Internal->BitSample );
       if( this->BitSample < Internal->BitSample )
         {
-        //assert(0); // Outside buffer will be too small
+        //gdcm_assert(0); // Outside buffer will be too small
         }
       is.seekg(0, std::ios::beg);
       SetupJPEGBitCodec( Internal->BitSample );
@@ -456,9 +456,9 @@ bool JPEGCodec::DecodeExtent(
 
   const unsigned int * dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat();
-  //assert( pf.GetBitsAllocated() % 8 == 0 );
-  assert( pf != PixelFormat::SINGLEBIT );
-  //assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
+  //gdcm_assert( pf.GetBitsAllocated() % 8 == 0 );
+  gdcm_assert( pf != PixelFormat::SINGLEBIT );
+  //gdcm_assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
 
   if( NumberOfDimensions == 2 )
     {
@@ -483,7 +483,7 @@ bool JPEGCodec::DecodeExtent(
         // read J2K
         is.read( &vdummybuffer[oldlen], fraglen );
         }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
       }
     catch(Exception &ex)
       {
@@ -503,12 +503,12 @@ bool JPEGCodec::DecodeExtent(
       // 2. GENESIS_SIGNA-JPEG-CorruptFrag.dcm
       else if ( frag.GetTag() == Tag(0xddff,0x00e0) )
         {
-        assert( nfrags == 1 );
+        gdcm_assert( nfrags == 1 );
         const ByteValue *bv = frag.GetByteValue();
-        assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
+        gdcm_assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
         // Yes this is an extra copy, this is a bug anyway, go fix YOUR code
         frag.SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
-        assert( 0 );
+        gdcm_assert( 0 );
         gdcmWarningMacro( "JPEG Fragment length was declared with an extra byte"
           " at the end: stripped !" );
         is.clear(); // clear the error bit
@@ -523,21 +523,21 @@ bool JPEGCodec::DecodeExtent(
 #endif /* GDCM_SUPPORT_BROKEN_IMPLEMENTATION */
       }
 
-    assert( zmin == zmax );
-    assert( zmin == 0 );
+    gdcm_assert( zmin == zmax );
+    gdcm_assert( zmin == 0 );
 
     std::stringstream iis;
     iis.write( vdummybuffer.data(), vdummybuffer.size() );
     std::stringstream os;
     bool b = DecodeByStreams(iis,os);
     if(!b) return false;
-    assert( b );
+    gdcm_assert(b);
 
     const unsigned int rowsize = xmax - xmin + 1;
     const unsigned int colsize = ymax - ymin + 1;
     const unsigned int bytesPerPixel = pf.GetPixelSize();
     os.seekg(0, std::ios::beg );
-    assert( os.good() );
+    gdcm_assert( os.good() );
     std::istream *theStream = &os;
     std::vector<char> buffer1;
     buffer1.resize( rowsize*bytesPerPixel );
@@ -568,14 +568,14 @@ bool JPEGCodec::DecodeExtent(
     while( frag.ReadPreValue<SwapperNoOp>(is) && frag.GetTag() != seqDelItem )
       {
       //std::streamoff relstart = is.tellg();
-      //assert( relstart - thestart == 8 );
+      //gdcm_assert( relstart - thestart == 8 );
       const std::streamoff off = frag.GetVL();
       offsets.push_back( (size_t)off );
       is.seekg( off, std::ios::cur );
       ++numfrags;
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
-    assert( numfrags == offsets.size() );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( numfrags == offsets.size() );
     if( numfrags != Dimensions[2] )
       {
       gdcmErrorMacro( "Not handled" );
@@ -594,12 +594,12 @@ bool JPEGCodec::DecodeExtent(
 
       std::stringstream os;
       const bool b = DecodeByStreams(is, os); (void)b;
-      assert( b );
+      gdcm_assert(b);
       /* free the memory containing the code-stream */
       //delete[] dummy_buffer;
 
       os.seekg(0, std::ios::beg );
-      assert( os.good() );
+      gdcm_assert( os.good() );
       std::istream *theStream = &os;
 
       unsigned int rowsize = xmax - xmin + 1;
@@ -628,7 +628,7 @@ bool JPEGCodec::DecodeExtent(
 
 bool JPEGCodec::IsStateSuspension() const
 {
-  assert( 0 );
+  gdcm_assert( 0 );
   return false;
 }
 
@@ -637,10 +637,10 @@ ImageCodec * JPEGCodec::Clone() const
   JPEGCodec *copy = new JPEGCodec;
   ImageCodec &ic = *copy;
   ic = *this;
-  assert( copy->PF == PF );
+  gdcm_assert( copy->PF == PF );
   //copy->SetupJPEGBitCodec( BitSample );
   copy->SetPixelFormat( GetPixelFormat() );
-  assert( copy->BitSample == BitSample || BitSample == 0 );
+  gdcm_assert( copy->BitSample == BitSample || BitSample == 0 );
   //copy->Lossless = Lossless;
   copy->Quality = Quality;
 
@@ -650,7 +650,7 @@ ImageCodec * JPEGCodec::Clone() const
 bool JPEGCodec::EncodeBuffer( std::ostream & out,
     const char *inbuffer, size_t inlen)
 {
-  assert( Internal );
+  gdcm_assert( Internal );
   return Internal->EncodeBuffer(out, inbuffer, inlen);
 }
 
@@ -664,7 +664,7 @@ bool JPEGCodec::IsRowEncoder()
 }
 bool JPEGCodec::IsFrameEncoder()
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 bool JPEGCodec::AppendRowEncode( std::ostream & os, const char * data, size_t datalen)
@@ -675,7 +675,7 @@ bool JPEGCodec::AppendRowEncode( std::ostream & os, const char * data, size_t da
 // this could reduce code duplication
 bool JPEGCodec::AppendFrameEncode( std::ostream & , const char * , size_t )
 {
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 bool JPEGCodec::StopEncode( std::ostream & )

--- a/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJPEGLSCodec.cxx
@@ -56,7 +56,7 @@ bool JPEGLSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
   using namespace charls;
   is.seekg( 0, std::ios::end);
   size_t buf_size = (size_t)is.tellg();
-  //assert(buf_size < INT_MAX);
+  //gdcm_assert(buf_size < INT_MAX);
   char *dummy_buffer = new char[(unsigned int)buf_size];
   is.seekg(0, std::ios::beg);
   is.read( dummy_buffer, buf_size);
@@ -78,15 +78,15 @@ bool JPEGLSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
     }
   else if( metadata.bitsPerSample <= 16 )
     {
-    assert( metadata.bitsPerSample > 8 );
+    gdcm_assert( metadata.bitsPerSample > 8 );
     this->PF = PixelFormat( PixelFormat::UINT16 );
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     }
   this->PF.SetBitsStored( (uint16_t)metadata.bitsPerSample );
-  assert( this->PF.IsValid() );
+  gdcm_assert( this->PF.IsValid() );
 //  switch( metadata.bitspersample )
 //    {
 //  case 8:
@@ -100,7 +100,7 @@ bool JPEGLSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
 //    this->PF = PixelFormat( PixelFormat::UINT16 );
 //    break;
 //  default:
-//    assert(0);
+//    gdcm_assert(0);
 //    }
   if( metadata.components == 1 )
     {
@@ -113,7 +113,7 @@ bool JPEGLSCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
     PlanarConfiguration = 0; // CP-1843
     this->PF.SetSamplesPerPixel( 3 );
     }
-  else assert(0);
+  else gdcm_assert(0);
 
   // allowedlossyerror == 0 => Lossless
   LossyFlag = metadata.allowedLossyError != 0;
@@ -155,9 +155,9 @@ template<typename T>
 static void ConvPlanar(std::vector<unsigned char> &input)
 {
   size_t buf_size = input.size();
-  assert( buf_size % sizeof(T) == 0 );
+  gdcm_assert( buf_size % sizeof(T) == 0 );
   size_t npixels = buf_size / sizeof( T );
-  assert( npixels % 3 == 0 );
+  gdcm_assert( npixels % 3 == 0 );
   size_t size = npixels / 3;
   T* buffer = (T*)input.data();
 
@@ -211,7 +211,7 @@ bool JPEGLSCodec::DecodeByStreamsCommon(const char *buffer, size_t totalLen, std
       else if(nBytes == 2 )
         ConvPlanar<unsigned short>(rgbyteOut);
       else
-        assert(0);
+        gdcm_assert(0);
       }
     }
 
@@ -271,7 +271,7 @@ bool JPEGLSCodec::Decode(DataElement const &in, DataElement &out)
         totalLen--;
         }
       // what if 0xd9 is never found ?
-      assert( totalLen > 0 && pbyteCompressed[totalLen-1] == 0xd9 );
+      gdcm_assert( totalLen > 0 && pbyteCompressed[totalLen-1] == 0xd9 );
 
       size_t cbyteCompressed = totalLen;
 
@@ -299,10 +299,10 @@ bool JPEGLSCodec::Decode(DataElement const &in, DataElement &out)
       os.write( (const char*)rgbyteOut.data(), rgbyteOut.size() );
 
       if(!r) return false;
-      assert( r == true );
+      gdcm_assert( r == true );
       }
     std::string str = os.str();
-    assert( !str.empty() );
+    gdcm_assert( !str.empty() );
     out.SetByteValue( str.data(), (uint32_t)str.size() );
 
     return true;
@@ -397,7 +397,7 @@ bool JPEGLSCodec::CodeFrameIntoBuffer(char * outdata, size_t outlen, size_t & co
     return false;
     }
 
-  assert( complen < outlen );
+  gdcm_assert( complen < outlen );
 
   return true;
 #endif
@@ -440,7 +440,7 @@ bool JPEGLSCodec::Code(DataElement const &in, DataElement &out)
     sq->AddFragment( frag );
     }
 
-  assert( sq->GetNumberOfFragments() == dims[2] );
+  gdcm_assert( sq->GetNumberOfFragments() == dims[2] );
   out.SetValue( *sq );
 
   return true;
@@ -473,9 +473,9 @@ bool JPEGLSCodec::DecodeExtent(
 
   const unsigned int * dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat();
-  assert( pf.GetBitsAllocated() % 8 == 0 );
-  assert( pf != PixelFormat::SINGLEBIT );
-  assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
+  gdcm_assert( pf.GetBitsAllocated() % 8 == 0 );
+  gdcm_assert( pf != PixelFormat::SINGLEBIT );
+  gdcm_assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
 
   if( NumberOfDimensions == 2 )
     {
@@ -496,9 +496,9 @@ bool JPEGLSCodec::DecodeExtent(
       // read J2K
       is.read( &vdummybuffer[oldlen], fraglen );
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
-    assert( zmin == zmax );
-    assert( zmin == 0 );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( zmin == zmax );
+    gdcm_assert( zmin == 0 );
 
     std::vector <unsigned char> outv;
     bool b = DecodeByStreamsCommon(dummy_buffer, buf_size, outv);
@@ -536,14 +536,14 @@ bool JPEGLSCodec::DecodeExtent(
     while( frag.ReadPreValue<SwapperNoOp>(is) && frag.GetTag() != seqDelItem )
       {
       //std::streamoff relstart = is.tellg();
-      //assert( relstart - thestart == 8 );
+      //gdcm_assert( relstart - thestart == 8 );
       std::streamoff off = frag.GetVL();
       offsets.push_back( (size_t)off );
       is.seekg( off, std::ios::cur );
       ++numfrags;
       }
-    assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
-    assert( numfrags == offsets.size() );
+    gdcm_assert( frag.GetTag() == seqDelItem && frag.GetVL() == 0 );
+    gdcm_assert( numfrags == offsets.size() );
     if( numfrags != Dimensions[2] )
       {
       gdcmErrorMacro( "Not handled" );
@@ -620,7 +620,7 @@ bool JPEGLSCodec::AppendFrameEncode( std::ostream & out, const char * data, size
 {
   const unsigned int * dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat(); (void)pf;
-  assert( datalen == dimensions[0] * dimensions[1] * pf.GetPixelSize() );
+  gdcm_assert( datalen == dimensions[0] * dimensions[1] * pf.GetPixelSize() );
 
   std::vector<unsigned char> rgbyteCompressed;
   rgbyteCompressed.resize(dimensions[0] * dimensions[1] * 4);

--- a/Source/MediaStorageAndFileFormat/gdcmJSON.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmJSON.cxx
@@ -78,7 +78,7 @@ static inline void wstrim(std::string& str)
 
 static inline bool CanContainBackslash( const VR::VRType vrtype )
 {
-  assert( VR::IsASCII( vrtype ) );
+  gdcm_assert( VR::IsASCII( vrtype ) );
   // PS 3.5-2011 / Table 6.2-1 DICOM VALUE REPRESENTATIONS
   switch( vrtype )
     {
@@ -110,7 +110,7 @@ static inline bool CanContainBackslash( const VR::VRType vrtype )
     //case VR::UN: // binary
     //case VR::US: // binary
     //case VR::UT: // VM1
-    assert( !(vrtype & VR::VR_VM1) );
+    gdcm_assert( !(vrtype & VR::VR_VM1) );
     return true;
   default:
     ;
@@ -179,7 +179,7 @@ static void DataElementToJSONArray( const VR::VRType vr, const DataElement & de,
     return;
     }
   // else
-  assert( !de.IsEmpty() );
+  gdcm_assert( !de.IsEmpty() );
   const bool checkbackslash = CanContainBackslash( vr );
   const ByteValue * bv = de.GetByteValue();
   const char * value = bv->GetPointer();
@@ -199,7 +199,7 @@ static void DataElementToJSONArray( const VR::VRType vr, const DataElement & de,
       {
       len--;
       }
-    assert( str1 );
+    gdcm_assert( str1 );
     std::stringstream ss;
     static const char *Keys[] = {
       "Alphabetic",
@@ -208,21 +208,21 @@ static void DataElementToJSONArray( const VR::VRType vr, const DataElement & de,
     };
     while (1)
       {
-      assert( str1 && (size_t)(str1 - value) <= len );
+      gdcm_assert( str1 && (size_t)(str1 - value) <= len );
       const char * sep = strchr(str1, '\\');
       const size_t llen = (sep != NULL) ? (sep - str1) : (value + len - str1);
       const std::string component(str1, llen);
 
       const char *str2 = component.c_str();
-      assert( str2 );
+      gdcm_assert( str2 );
       const size_t len2 = component.size();
-      assert( len2 == llen );
+      gdcm_assert( len2 == llen );
 
       int idx = 0;
       json_object *my_object_comp = json_object_new_object();
       while (1)
         {
-        assert( str2 && (size_t)(str2 - component.c_str() ) <= len2 );
+        gdcm_assert( str2 && (size_t)(str2 - component.c_str() ) <= len2 );
         const char * sep2 = strchr(str2, '=');
         const size_t llen2 = (sep2 != NULL) ? (sep2 - str2) : (component.c_str() + len2 - str2);
         const std::string group(str2, llen2);
@@ -236,19 +236,19 @@ static void DataElementToJSONArray( const VR::VRType vr, const DataElement & de,
       json_object_array_add(my_array, my_object_comp);
       if (sep == NULL) break;
       str1 = sep + 1;
-      assert( checkbackslash );
+      gdcm_assert( checkbackslash );
       }
     }
   else if( vr == VR::DS || vr == VR::IS )
     {
     const char *str1 = value;
-    assert( str1 );
+    gdcm_assert( str1 );
     VRToType<VR::IS>::Type vris;
     VRToType<VR::DS>::Type vrds;
     while (1)
       {
       std::stringstream ss;
-      assert( str1 && (size_t)(str1 - value) <= len );
+      gdcm_assert( str1 && (size_t)(str1 - value) <= len );
       const char * sep = strchr(str1, '\\');
       const size_t llen = (sep != NULL) ? (sep - str1) : (value + len - str1);
       // This is complex, IS/DS should not be stored as string anymore
@@ -265,20 +265,20 @@ static void DataElementToJSONArray( const VR::VRType vr, const DataElement & de,
         json_object_array_add(my_array, json_object_new_double(vrds));
         break;
       default:
-        assert( 0 ); // programmer error
+        gdcm_assert( 0 ); // programmer error
         }
       if (sep == NULL) break;
       str1 = sep + 1;
-      assert( checkbackslash );
+      gdcm_assert( checkbackslash );
       }
     }
   else if( checkbackslash )
     {
     const char *str1 = value;
-    assert( str1 );
+    gdcm_assert( str1 );
     while (1)
       {
-      assert( str1 && (size_t)(str1 - value) <= len );
+      gdcm_assert( str1 && (size_t)(str1 - value) <= len );
       const char * sep = strchr(str1, '\\');
       const size_t llen = (sep != NULL) ? (sep - str1) : (value + len - str1);
       json_object_array_add(my_array, json_object_new_string_len(str1, llen));
@@ -324,7 +324,7 @@ static void ProcessNestedDataSet( const DataSet & ds, json_object *my_object, co
     else if( isprivatecreator ) vr = VR::LO; // always prefer VR::LO (over invalid/UN)
     else if( vr == VR::INVALID ) vr = VR::UN;
     const char * vr_str = VR::GetVRString(vr);
-    assert( VR::GetVRTypeFromFile(vr_str) != VR::INVALID );
+    gdcm_assert( VR::GetVRTypeFromFile(vr_str) != VR::INVALID );
 
     json_object *my_object_cur;
     my_object_cur = json_object_new_object();
@@ -363,11 +363,11 @@ static void ProcessNestedDataSet( const DataSet & ds, json_object *my_object, co
       else if( const SequenceOfFragments *sqf = de.GetSequenceOfFragments() )
         {
         json_object_array_add(my_array, NULL ); // FIXME
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       else
         {
-        assert( de.IsEmpty() );
+        gdcm_assert( de.IsEmpty() );
         //json_object_array_add(my_array, NULL ); // F.2.5 req ?
         }
       //json_object_object_add(my_object_cur, "Sequence", my_array );
@@ -481,29 +481,29 @@ static void ProcessNestedDataSet( const DataSet & ds, json_object *my_object, co
       case VR::OB:
       case VR::OW:
           {
-          assert( !de.IsUndefinedLength() ); // handled before
+          gdcm_assert( !de.IsUndefinedLength() ); // handled before
           const ByteValue * bv = de.GetByteValue();
           wheretostore = "InlineBinary";
           if( bv )
             {
             const char *src = bv->GetPointer();
             const size_t len = bv->GetLength();
-            assert( len % 2 == 0 );
+            gdcm_assert( len % 2 == 0 );
             const size_t len64 = Base64::GetEncodeLength(src, len);
             buffer.resize( len64 );
             const size_t ret = Base64::Encode( &buffer[0], len64, src, len );
-            assert( ret != 0 );
+            gdcm_assert( ret != 0 );
             json_object_array_add(my_array, json_object_new_string_len(&buffer[0], len64));
             }
           }
         break;
       default:
-        assert( 0 ); // programmer error
+        gdcm_assert( 0 ); // programmer error
         }
       json_object_object_add(my_object_cur, wheretostore, my_array );
       }
     //const char *keyword = entry.GetKeyword();
-    //assert( keyword && *keyword );
+    //gdcm_assert( keyword && *keyword );
     //if( preferkeyword && keyword && *keyword && !t.IsPrivateCreator() )
     //  {
     //  json_object_object_add(my_object, keyword, my_object_cur );
@@ -552,14 +552,14 @@ bool JSON::Code(DataSet const & ds, std::ostream & os)
 static inline bool CheckTagKeywordConsistency( const char *name, const Tag & thetag )
 {
   // Can be keyword or tag
-  assert( name );
+  gdcm_assert( name );
 
   // start with easy one:
   // only test first string character:
   bool istag = *name >= '0' && *name <= '9'; // should be relatively efficient
   if( istag )
     {
-    assert( strlen(name) == 8 );
+    gdcm_assert( strlen(name) == 8 );
     Tag t;
     t.ReadFromContinuousString( name );
     return t == thetag;
@@ -575,7 +575,7 @@ static inline bool CheckTagKeywordConsistency( const char *name, const Tag & the
     return true;
     }
   // else
-  assert( strcmp( name, keyword ) == 0 );
+  gdcm_assert( strcmp( name, keyword ) == 0 );
   return strcmp( name, keyword ) == 0;
 }
 #endif
@@ -585,7 +585,7 @@ static inline bool CheckTagKeywordConsistency( const char *name, const Tag & the
 static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElement & de )
 {
   json_type jtype = json_object_get_type( obj );
-  assert( jtype == json_type_object );
+  gdcm_assert( jtype == json_type_object );
   json_object * jvr = json_object_object_get_old(obj, "VR");
 
   const char * vr_str = json_object_get_string ( jvr );
@@ -595,23 +595,23 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
     {
     json_object * jprivatecreator = json_object_object_get_old(obj, "PrivateCreator");
     pc_str = json_object_get_string ( jprivatecreator );
-    assert( pc_str );
+    gdcm_assert( pc_str );
     }
 
   VR::VRType vrtype = VR::GetVRTypeFromFile( vr_str );
-  assert( vrtype != VR::INVALID );
-  assert( vrtype != VR::VR_END );
+  gdcm_assert( vrtype != VR::INVALID );
+  gdcm_assert( vrtype != VR::VR_END );
   de.SetVR( vrtype );
 
   if( vrtype == VR::SQ )
     {
     json_object * jvalue = json_object_object_get_old(obj, "Value");
     json_type jvaluetype = json_object_get_type( jvalue );
-    assert( jvaluetype != json_type_null && jvaluetype == json_type_array  );
+    gdcm_assert( jvaluetype != json_type_null && jvaluetype == json_type_array  );
 #ifndef NDEBUG
     json_object * jseq = json_object_object_get_old(obj, "Sequence");
     json_type jsqtype = json_object_get_type( jseq );
-    assert( jsqtype == json_type_null );
+    gdcm_assert( jsqtype == json_type_null );
 #endif
     if( jvaluetype == json_type_array )
       {
@@ -624,7 +624,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
         {
         json_object * jitem = json_object_array_get_idx ( jvalue, itemidx );
         json_type jitemtype = json_object_get_type( jitem );
-        assert( jitemtype == json_type_object );
+        gdcm_assert( jitemtype == json_type_object );
         //const char * dummy = json_object_to_json_string ( jitem );
 
         // Create an item
@@ -641,7 +641,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
         while (!json_object_iter_equal(&it, &itEnd))
           {
           const char *name = json_object_iter_peek_name(&it);
-          assert( name );
+          gdcm_assert( name );
           json_object * value = json_object_iter_peek_value (&it);
           DataElement lde;
           ProcessJSONElement( name, value, lde );
@@ -669,14 +669,14 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
 #ifndef NDEBUG
     json_object * jpn = json_object_object_get_old(obj, "PersonName");
     json_type jpntype = json_object_get_type( jpn );
-    assert( jpntype == json_type_null );
+    gdcm_assert( jpntype == json_type_null );
 #endif
     json_type jvaluetype = json_object_get_type( jvalue );
     //const char * dummy = json_object_to_json_string ( jvalue );
-    assert( jvaluetype == json_type_null || jvaluetype == json_type_array );
+    gdcm_assert( jvaluetype == json_type_null || jvaluetype == json_type_array );
     if( jvaluetype == json_type_array )
       {
-      //assert( vrtype != VR::PN );
+      //gdcm_assert( vrtype != VR::PN );
       const int valuelen = json_object_array_length ( jvalue );
       std::string str;
       for( int validx = 0; validx < valuelen; ++validx )
@@ -686,7 +686,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
         json_type valuetype = json_object_get_type( value );
         if( value )
           {
-          assert( valuetype != json_type_null );
+          gdcm_assert( valuetype != json_type_null );
           std::string value_str;
           std::stringstream ss;
           VRToType<VR::IS>::Type vris;
@@ -728,8 +728,8 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
         else
           {
           // We have a [ null ] array, so at most there is a single item:
-          assert( valuelen == 1 );
-          assert( valuetype == json_type_null );
+          gdcm_assert( valuelen == 1 );
+          gdcm_assert( valuetype == json_type_null );
           }
         }
       if( str.size() % 2 )
@@ -744,7 +744,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
 #ifndef NDEBUG
     else if( jpntype == json_type_array )
       {
-      assert( 0 );
+      gdcm_assert( 0 );
       }
 #endif
     }
@@ -755,7 +755,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
     json_object * jvalue = json_object_object_get_old(obj, "Value");
     json_type jvaluetype = json_object_get_type( jvalue );
     //const char * dummy = json_object_to_json_string ( jvalue );
-    assert( jvaluetype == json_type_array || jvaluetype == json_type_null );
+    gdcm_assert( jvaluetype == json_type_array || jvaluetype == json_type_null );
     if( jvaluetype == json_type_array )
       {
       DataElement locde;
@@ -770,7 +770,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_double );
+            gdcm_assert( json_object_get_type( value ) == json_type_double );
             const double v = json_object_get_double ( value );
             el.SetValue(v, validx);
             }
@@ -784,7 +784,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_double );
+            gdcm_assert( json_object_get_type( value ) == json_type_double );
             const double v = json_object_get_double ( value );
             el.SetValue(v, validx);
             }
@@ -798,7 +798,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_int );
+            gdcm_assert( json_object_get_type( value ) == json_type_int );
             const int v = json_object_get_int( value );
             el.SetValue(v, validx);
             }
@@ -812,7 +812,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_int );
+            gdcm_assert( json_object_get_type( value ) == json_type_int );
             const int v = json_object_get_int( value );
             el.SetValue(v, validx);
             }
@@ -826,7 +826,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_int );
+            gdcm_assert( json_object_get_type( value ) == json_type_int );
             const int v = json_object_get_int( value );
             el.SetValue(v, validx);
             }
@@ -840,7 +840,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_int );
+            gdcm_assert( json_object_get_type( value ) == json_type_int );
             const int v = json_object_get_int( value );
             el.SetValue(v, validx);
             }
@@ -854,7 +854,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           for( int validx = 0; validx < valuelen; ++validx )
             {
             json_object * value = json_object_array_get_idx ( jvalue, validx );
-            assert( json_object_get_type( value ) == json_type_string );
+            gdcm_assert( json_object_get_type( value ) == json_type_string );
             const char *atstr = json_object_get_string( value );
             Tag t;
             t.ReadFromContinuousString( atstr );
@@ -864,7 +864,7 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
           }
         break;
       default:
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       if( !locde.IsEmpty() )
         de.SetValue( locde.GetValue() );
@@ -882,43 +882,43 @@ static void ProcessJSONElement( const char *tag_str, json_object * obj, DataElem
       case VR::OF:
       case VR::OW:
           {
-          assert( valuelen == 1 || valuelen == 0 );
+          gdcm_assert( valuelen == 1 || valuelen == 0 );
           if( valuelen )
             {
             json_object * value = json_object_array_get_idx ( jvaluebin, 0 );
             json_type valuetype = json_object_get_type( value );
             if( value )
               {
-              assert( valuetype != json_type_null );
+              gdcm_assert( valuetype != json_type_null );
               const char * value_str = json_object_get_string ( value );
-              assert( value_str );
+              gdcm_assert( value_str );
               const size_t len64 = strlen( value_str );
               const size_t len = Base64::GetDecodeLength( value_str, len64 );
               std::vector<char> buffer;
               buffer.resize( len );
               const size_t ret = Base64::Decode( &buffer[0], len,
                 value_str, len64 );
-              assert( ret != 0 );
+              gdcm_assert( ret != 0 );
               locde.SetByteValue( &buffer[0], len );
               }
             else
               {
               // We have a [ null ] array, so at most there is a single item:
-              assert( valuelen == 1 );
-              assert( valuetype == json_type_null );
+              gdcm_assert( valuelen == 1 );
+              gdcm_assert( valuetype == json_type_null );
               }
             }
           }
         break;
       default:
-        assert( 0 );
+        gdcm_assert( 0 );
         }
       if( !locde.IsEmpty() )
         de.SetValue( locde.GetValue() );
       }
     else
       {
-      assert( jvaluebintype == json_type_null && jvaluetype == json_type_null );
+      gdcm_assert( jvaluebintype == json_type_null && jvaluetype == json_type_null );
       }
     }
 }
@@ -949,7 +949,7 @@ bool JSON::Decode(std::istream & is, DataSet & ds)
     {
     fprintf(stderr, "Error: %s\n", json_tokener_error_desc(jerr));
     // Handle errors, as appropriate for your application.
-    assert( 0 );
+    gdcm_assert( 0 );
     }
   if (tok->char_offset < stringlen) // XXX shouldn't access internal fields
     {
@@ -979,7 +979,7 @@ bool JSON::Decode(std::istream & is, DataSet & ds)
   while (!json_object_iter_equal(&it, &itEnd))
     {
     const char *name = json_object_iter_peek_name(&it);
-    assert( name );
+    gdcm_assert( name );
     json_object * value = json_object_iter_peek_value (&it);
     DataElement de;
     ProcessJSONElement( name, value, de );

--- a/Source/MediaStorageAndFileFormat/gdcmKAKADUCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmKAKADUCodec.cxx
@@ -155,9 +155,9 @@ bool KAKADUCodec::Decode(DataElement const &in, DataElement &out)
 
       std::ofstream outfile(input.c_str(), std::ios::binary);
       const Fragment &frag = sf->GetFragment(i);
-      assert( !frag.IsEmpty() );
+      gdcm_assert( !frag.IsEmpty() );
       const ByteValue *bv = frag.GetByteValue();
-      assert( bv );
+      gdcm_assert( bv );
       //sf->WriteBuffer(outfile);
       bv->WriteBuffer( outfile );
       outfile.close(); // flush !
@@ -203,7 +203,7 @@ bool KAKADUCodec::Decode(DataElement const &in, DataElement &out)
       free(tempoutput);
       }
     std::string str = os.str();
-    assert( str.size() );
+    gdcm_assert( str.size() );
     out.SetTag( Tag(0x7fe0,0x0010) );
     out.SetByteValue( &str[0], str.size() );
     }

--- a/Source/MediaStorageAndFileFormat/gdcmLookupTable.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmLookupTable.cxx
@@ -93,9 +93,9 @@ void LookupTable::InitializeLUT(LookupTableType type, unsigned short length,
     {
     return;
     }
-  assert( type >= RED && type <= BLUE );
-  assert( subscript == 0 );
-  assert( bitsize == 8 || bitsize == 16 );
+  gdcm_assert( type >= RED && type <= BLUE );
+  gdcm_assert( subscript == 0 );
+  gdcm_assert( bitsize == 8 || bitsize == 16 );
   if( length == 0 )
     {
     Internal->Length[type] = 65536;
@@ -142,11 +142,11 @@ void LookupTable::SetLUT(LookupTableType type, const unsigned char *array,
     {
       const unsigned int mult = Internal->BitSize[type]/8;
       const unsigned int mult2 = length / Internal->Length[type];
-      assert( Internal->Length[type] * mult2 == length );
+      gdcm_assert( Internal->Length[type] * mult2 == length );
       if( Internal->Length[type]*mult == length
           || Internal->Length[type]*mult + 1 == length )
       {
-        assert( mult2 == 1 || mult2 == 2 );
+        gdcm_assert( mult2 == 1 || mult2 == 2 );
         unsigned int offset = 0;
         if( mult == 2 )
         {
@@ -154,32 +154,32 @@ void LookupTable::SetLUT(LookupTableType type, const unsigned char *array,
         }
         for( unsigned int i = 0; i < Internal->Length[type]; ++i)
         {
-          assert( i*mult+offset < length );
-          assert( 3*i+type < Internal->RGB.size() );
+          gdcm_assert( i*mult+offset < length );
+          gdcm_assert( 3*i+type < Internal->RGB.size() );
           Internal->RGB[3*i+type] = array[i*mult+offset];
         }
       }
       else
       {
         unsigned int offset = 0;
-        assert( mult2 == 2 );
+        gdcm_assert( mult2 == 2 );
         for( unsigned int i = 0; i < Internal->Length[type]; ++i)
         {
-          assert( i*mult2+offset < length );
-          assert( 3*i+type < Internal->RGB.size() );
+          gdcm_assert( i*mult2+offset < length );
+          gdcm_assert( 3*i+type < Internal->RGB.size() );
           Internal->RGB[3*i+type] = array[i*mult2+offset];
         }
       }
     }
   else if( BitSample == 16 )
     {
-    assert( Internal->Length[type]*(BitSample/8) == length );
+    gdcm_assert( Internal->Length[type]*(BitSample/8) == length );
     uint16_t *uchar16 = (uint16_t*)(void*)Internal->RGB.data();
     const uint16_t *array16 = (const uint16_t*)(const void*)array;
     for( unsigned int i = 0; i < Internal->Length[type]; ++i)
       {
-      assert( 2*i < length );
-      assert( 2*(3*i+type) < Internal->RGB.size() );
+      gdcm_assert( 2*i < length );
+      gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
       uchar16[3*i+type] = array16[i];
       }
     }
@@ -198,8 +198,8 @@ void LookupTable::GetLUT(LookupTableType type, unsigned char *array, unsigned in
       }
     for( unsigned int i = 0; i < Internal->Length[type]; ++i)
       {
-      assert( i*mult+offset < length );
-      assert( 3*i+type < Internal->RGB.size() );
+      gdcm_assert( i*mult+offset < length );
+      gdcm_assert( 3*i+type < Internal->RGB.size() );
       array[i*mult+offset] = Internal->RGB[3*i+type];
       }
     }
@@ -210,8 +210,8 @@ void LookupTable::GetLUT(LookupTableType type, unsigned char *array, unsigned in
     uint16_t *array16 = (uint16_t*)(void*)array;
     for( unsigned int i = 0; i < Internal->Length[type]; ++i)
       {
-      assert( 2*i < length );
-      assert( 2*(3*i+type) < Internal->RGB.size() );
+      gdcm_assert( 2*i < length );
+      gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
       array16[i] = uchar16[3*i+type];
       }
     }
@@ -220,7 +220,7 @@ void LookupTable::GetLUT(LookupTableType type, unsigned char *array, unsigned in
 void LookupTable::GetLUTDescriptor(LookupTableType type, unsigned short &length,
   unsigned short &subscript, unsigned short &bitsize) const
 {
-  assert( type >= RED && type <= BLUE );
+  gdcm_assert( type >= RED && type <= BLUE );
   if( Internal->Length[type] == 65536 )
     {
     length = 0;
@@ -233,8 +233,8 @@ void LookupTable::GetLUTDescriptor(LookupTableType type, unsigned short &length,
   bitsize = Internal->BitSize[type];
 
   // postcondition
-  assert( subscript == 0 );
-  assert( bitsize == 8 || bitsize == 16 );
+  gdcm_assert( subscript == 0 );
+  gdcm_assert( bitsize == 8 || bitsize == 16 );
 }
 
 void LookupTable::InitializeRedLUT(unsigned short length,
@@ -324,15 +324,15 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U8 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3);
-      assert( u.rgb[3] == 0 );
-      //assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
+      gdcm_assert( u.rgb[3] == 0 );
+      //gdcm_assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
       std::pair<RGBColorIndexer::iterator,bool> it = s.insert( u );
       if( it.second ) ++count;
       int d = std::distance(s.begin(), it.first);
       //std::cout << count << " Index: " << d << " -> "; printrgb( u.rgb ); std::cout << "\n";
-      //assert( s.size() < 256 );
-      assert( d < s.size() );
-      //assert( d < 256 && d >= 0 );
+      //gdcm_assert( s.size() < 256 );
+      gdcm_assert( d < s.size() );
+      //gdcm_assert( d < 256 && d >= 0 );
       }
 
     // now generate output image
@@ -344,13 +344,13 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U8 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3);
-      assert( u.rgb[3] == 0 );
-      //assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
+      gdcm_assert( u.rgb[3] == 0 );
+      //gdcm_assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
       std::pair<RGBColorIndexer::iterator,bool> it = s.insert( u );
       int d = std::distance(s.begin(), it.first);
       //std::cout << "Index: " << d << " -> "; printrgb( u.rgb ); std::cout << "\n";
-      assert( d < s.size() );
-      //assert( d < 256 && d >= 0 );
+      gdcm_assert( d < s.size() );
+      //gdcm_assert( d < 256 && d >= 0 );
       os.put( d );
       }
 
@@ -362,11 +362,11 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
     InitializeGreenLUT(ncolor, 0, 8);
     InitializeBlueLUT(ncolor, 0, 8);
     //int i = Internal->RGB.size();
-    //assert( Internal->RGB.size() == 5 );
+    //gdcm_assert( Internal->RGB.size() == 5 );
     int idx = 0;
     for( RGBColorIndexer::const_iterator it = s.begin(); it != s.end() && idx < 256; ++it, ++idx )
       {
-      assert( idx == std::distance( s.begin(), it ) );
+      gdcm_assert( idx == std::distance( s.begin(), it ) );
       //std::cout << "Index: " << idx << " -> "; printrgb( it->rgb ); std::cout << "\n";
       Internal->RGB[3*idx+RED]   = it->rgb[RED];
       Internal->RGB[3*idx+GREEN] = it->rgb[GREEN];
@@ -378,9 +378,9 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U8 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3);
-      assert( u.rgb[3] == 0 );
+      gdcm_assert( u.rgb[3] == 0 );
       int d = 0;
-      assert( d < 256 && d >= 0 );
+      gdcm_assert( d < 256 && d >= 0 );
       os.put( (char)d );
       }
 #endif
@@ -396,13 +396,13 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U16 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3*2);
-      assert( u.rgb[3] == 0 );
-      //assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
+      gdcm_assert( u.rgb[3] == 0 );
+      //gdcm_assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
       std::pair<RGBColorIndexer::iterator,bool> it = s.insert( u );
       int d = std::distance(s.begin(), it.first);
       //std::cout << "Index: " << d << " -> "; printrgb( u.rgb ); std::cout << "\n";
-      assert( d < s.size() );
-      assert( d < 65536 && d >= 0 );
+      gdcm_assert( d < s.size() );
+      gdcm_assert( d < 65536 && d >= 0 );
       }
 
     // now generate output image
@@ -414,13 +414,13 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U16 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3*2);
-      assert( u.rgb[3] == 0 );
-      //assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
+      gdcm_assert( u.rgb[3] == 0 );
+      //gdcm_assert( u.rgb[0] == u.rgb[1] && u.rgb[1] == u.rgb[2] );
       std::pair<RGBColorIndexer::iterator,bool> it = s.insert( u );
       unsigned short d = std::distance(s.begin(), it.first);
       //std::cout << "Index: " << d << " -> "; printrgb( u.rgb ); std::cout << "\n";
-      assert( d < s.size() );
-      assert( d < 65536 && d >= 0 );
+      gdcm_assert( d < s.size() );
+      gdcm_assert( d < 65536 && d >= 0 );
       os.write( (const char*)&d , 2 );
       }
 
@@ -430,12 +430,12 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
     InitializeGreenLUT(ncolor, 0, 16);
     InitializeBlueLUT(ncolor, 0, 16);
     //int i = Internal->RGB.size();
-    //assert( Internal->RGB.size() == 5 );
+    //gdcm_assert( Internal->RGB.size() == 5 );
     int idx = 0;
     uint16_t *rgb16 = (uint16_t*)&Internal->RGB[0];
     for( RGBColorIndexer::const_iterator it = s.begin(); it != s.end(); ++it, ++idx )
       {
-      assert( idx == std::distance( s.begin(), it ) );
+      gdcm_assert( idx == std::distance( s.begin(), it ) );
       //std::cout << "Index: " << idx << " -> "; printrgb( it->rgb ); std::cout << "\n";
       rgb16[3*idx+RED]   = it->rgb[RED];
       rgb16[3*idx+GREEN] = it->rgb[GREEN];
@@ -447,9 +447,9 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
       U16 u;
       u.rgb[3] = 0;
       is.read( (char*)u.rgb, 3*2);
-      assert( u.rgb[3] == 0 );
+      gdcm_assert( u.rgb[3] == 0 );
       int d = 0;
-      assert( d < 65536 && d >= 0 );
+      gdcm_assert( d < 65536 && d >= 0 );
       os.write( (const char*)&d , 2 );
       }
 #endif
@@ -458,7 +458,7 @@ void LookupTable::Encode(std::istream &is, std::ostream &os)
 
 void LookupTable::Decode(std::istream &is, std::ostream &os) const
 {
-  assert( Initialized() );
+  gdcm_assert( Initialized() );
   if ( BitSample == 8 )
     {
     unsigned char idx;
@@ -469,9 +469,9 @@ void LookupTable::Decode(std::istream &is, std::ostream &os) const
       if( is.eof() || !is.good() ) break;
       if( IncompleteLUT )
         {
-        assert( idx < Internal->Length[RED] );
-        assert( idx < Internal->Length[GREEN] );
-        assert( idx < Internal->Length[BLUE] );
+        gdcm_assert( idx < Internal->Length[RED] );
+        gdcm_assert( idx < Internal->Length[GREEN] );
+        gdcm_assert( idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = Internal->RGB[3*idx+RED];
       rgb[GREEN] = Internal->RGB[3*idx+GREEN];
@@ -491,9 +491,9 @@ void LookupTable::Decode(std::istream &is, std::ostream &os) const
       if( is.eof() || !is.good() ) break;
       if( IncompleteLUT )
         {
-        assert( idx < Internal->Length[RED] );
-        assert( idx < Internal->Length[GREEN] );
-        assert( idx < Internal->Length[BLUE] );
+        gdcm_assert( idx < Internal->Length[RED] );
+        gdcm_assert( idx < Internal->Length[GREEN] );
+        gdcm_assert( idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = rgb16[3*idx+RED];
       rgb[GREEN] = rgb16[3*idx+GREEN];
@@ -524,9 +524,9 @@ bool LookupTable::Decode(char *output, size_t outlen, const char *input, size_t 
       {
       if( IncompleteLUT )
         {
-        assert( *idx < Internal->Length[RED] );
-        assert( *idx < Internal->Length[GREEN] );
-        assert( *idx < Internal->Length[BLUE] );
+        gdcm_assert( *idx < Internal->Length[RED] );
+        gdcm_assert( *idx < Internal->Length[GREEN] );
+        gdcm_assert( *idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = Internal->RGB[3 * *idx+RED];
       rgb[GREEN] = Internal->RGB[3 * *idx+GREEN];
@@ -538,16 +538,16 @@ bool LookupTable::Decode(char *output, size_t outlen, const char *input, size_t 
   else if ( BitSample == 16 )
     {
     const uint16_t *rgb16 = (const uint16_t*)(void*)Internal->RGB.data();
-    assert( inlen % 2 == 0 );
+    gdcm_assert( inlen % 2 == 0 );
     const uint16_t * end = (const uint16_t*)(const void*)(input + inlen);
     uint16_t * rgb = (uint16_t*)(void*)output;
     for( const uint16_t * idx = (const uint16_t*)(const void*)input; idx != end; ++idx )
       {
       if( IncompleteLUT )
         {
-        assert( *idx < Internal->Length[RED] );
-        assert( *idx < Internal->Length[GREEN] );
-        assert( *idx < Internal->Length[BLUE] );
+        gdcm_assert( *idx < Internal->Length[RED] );
+        gdcm_assert( *idx < Internal->Length[GREEN] );
+        gdcm_assert( *idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = rgb16[3 * *idx+RED];
       rgb[GREEN] = rgb16[3 * *idx+GREEN];
@@ -580,9 +580,9 @@ bool LookupTable::Decode8(char *output, size_t outlen, const char *input, size_t
       {
       if( IncompleteLUT )
         {
-        assert( *idx < Internal->Length[RED] );
-        assert( *idx < Internal->Length[GREEN] );
-        assert( *idx < Internal->Length[BLUE] );
+        gdcm_assert( *idx < Internal->Length[RED] );
+        gdcm_assert( *idx < Internal->Length[GREEN] );
+        gdcm_assert( *idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = Internal->RGB[3 * *idx+RED];
       rgb[GREEN] = Internal->RGB[3 * *idx+GREEN];
@@ -594,16 +594,16 @@ bool LookupTable::Decode8(char *output, size_t outlen, const char *input, size_t
   else if ( BitSample == 16 )
     {
     const uint16_t *rgb16 = (const uint16_t*)(void*)Internal->RGB.data();
-    assert( inlen % 2 == 0 );
+    gdcm_assert( inlen % 2 == 0 );
     const uint16_t * end = (const uint16_t*)(const void*)(input + inlen);
     uint8_t * rgb = (uint8_t*)output;
     for( const uint16_t * idx = (const uint16_t*)(const void*)input; idx != end; ++idx )
       {
       if( IncompleteLUT )
         {
-        assert( *idx < Internal->Length[RED] );
-        assert( *idx < Internal->Length[GREEN] );
-        assert( *idx < Internal->Length[BLUE] );
+        gdcm_assert( *idx < Internal->Length[RED] );
+        gdcm_assert( *idx < Internal->Length[GREEN] );
+        gdcm_assert( *idx < Internal->Length[BLUE] );
         }
       rgb[RED]   = rgb16[3 * *idx+RED] >> 8;
       rgb[GREEN] = rgb16[3 * *idx+GREEN] >> 8;
@@ -646,13 +646,13 @@ bool LookupTable::GetBufferAsRGBA(unsigned char *rgba) const
   else if ( BitSample == 16 )
     {
 /*
-    assert( Internal->Length[type]*(BitSample/8) == length );
+    gdcm_assert( Internal->Length[type]*(BitSample/8) == length );
     uint16_t *uchar16 = (uint16_t*)&Internal->RGB[0];
     const uint16_t *array16 = (uint16_t*)array;
     for( unsigned int i = 0; i < Internal->Length[type]; ++i)
       {
-      assert( 2*i < length );
-      assert( 2*(3*i+type) < Internal->RGB.size() );
+      gdcm_assert( 2*i < length );
+      gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
       uchar16[3*i+type] = array16[i];
       std::cout << i << " -> " << array16[i] << "\n";
       }
@@ -704,18 +704,18 @@ bool LookupTable::WriteBufferAsRGBA(const unsigned char *rgba)
     }
   else if ( BitSample == 16 )
     {
-    //assert( Internal->Length[type]*(BitSample/8) == length );
+    //gdcm_assert( Internal->Length[type]*(BitSample/8) == length );
     uint16_t *uchar16 = (uint16_t*)(void*)Internal->RGB.data();
     const uint16_t *rgba16 = (const uint16_t*)(const void*)rgba;
     size_t s = Internal->RGB.size();
     s /= 2;
     s /= 3;
-    assert( s == 65536 );
+    gdcm_assert( s == 65536 );
 
     for( unsigned int i = 0; i < s /*i < Internal->Length[type]*/; ++i)
       {
-      //assert( 2*i < length );
-      //assert( 2*(3*i+type) < Internal->RGB.size() );
+      //gdcm_assert( 2*i < length );
+      //gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
       //uchar16[3*i+type] = array16[i];
       //std::cout << i << " -> " << array16[i] << "\n";
       // RED
@@ -748,7 +748,7 @@ void LookupTable::Print(std::ostream &os) const
       os << std::dec <<std::setw( 5 ) << std::setfill( '0' ) << i << " : ";
       for(int type = RED; type <= BLUE; ++type )
         {
-        assert( 2*(3*i+type) < Internal->RGB.size() );
+        gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
         const uint16_t val = SwapperDoOp::Swap(uchar16[3*i+type]);
         minlut[type] = std::min( minlut[type], val );
         maxlut[type] = std::max( maxlut[type], val );
@@ -780,7 +780,7 @@ bool LookupTable::IsRGB8() const
       {
       for(int type = RED; type <= BLUE; ++type )
         {
-        assert( 2*(3*i+type) < Internal->RGB.size() );
+        gdcm_assert( 2*(3*i+type) < Internal->RGB.size() );
         const uint16_t val = SwapperDoOp::Swap(uchar16[3*i+type]);
         minlut[type] = std::min( minlut[type], val );
         maxlut[type] = std::max( maxlut[type], val );

--- a/Source/MediaStorageAndFileFormat/gdcmLookupTable.h
+++ b/Source/MediaStorageAndFileFormat/gdcmLookupTable.h
@@ -84,7 +84,7 @@ public:
 
   LookupTable(LookupTable const &lut):Object(lut), Internal(nullptr), BitSample(0), IncompleteLUT(false)
     {
-    assert(0);
+    gdcm_assert(0);
     }
 
   /// return the LUT as RGBA buffer

--- a/Source/MediaStorageAndFileFormat/gdcmMeshPrimitive.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmMeshPrimitive.cxx
@@ -33,7 +33,7 @@ static const char * MPStrings[] = {
 
 const char * MeshPrimitive::GetMPTypeString(const MPType type)
 {
-  assert( type <= MPType_END );
+  gdcm_assert( type <= MPType_END );
   return MPStrings[(int)type];
 }
 
@@ -86,7 +86,7 @@ MeshPrimitive::MPType MeshPrimitive::GetPrimitiveType() const
 
 void MeshPrimitive::SetPrimitiveType(const MPType type)
 {
-    assert( type <= MPType_END );
+    gdcm_assert( type <= MPType_END );
     PrimitiveType = type;
 }
 
@@ -132,12 +132,12 @@ void MeshPrimitive::AddPrimitiveData(DataElement const & de)
 
 const DataElement & MeshPrimitive::GetPrimitiveData(const unsigned int idx) const
 {
-    assert( idx < this->GetNumberOfPrimitivesData() );
+    gdcm_assert( idx < this->GetNumberOfPrimitivesData() );
     return PrimitiveData[idx];
 }
 DataElement & MeshPrimitive::GetPrimitiveData(const unsigned int idx)
 {
-    assert( idx < this->GetNumberOfPrimitivesData() );
+    gdcm_assert( idx < this->GetNumberOfPrimitivesData() );
     return PrimitiveData[idx];
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmOverlay.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmOverlay.cxx
@@ -94,7 +94,7 @@ Overlay::Overlay(Overlay const &ov):Object(ov)
 
 Overlay & Overlay::operator=(Overlay const &ov)
 {
-  assert( Internal );
+  gdcm_assert( Internal );
   *Internal = *ov.Internal;
   return *this;
 }
@@ -118,13 +118,13 @@ void Overlay::Update(const DataElement & de)
     Bit Position (60xx,0102) is always 0.
 */
 
-  assert( de.GetTag().IsPublic() );
+  gdcm_assert( de.GetTag().IsPublic() );
   const ByteValue* bv = de.GetByteValue();
   if( !bv ) return; // Discard any empty element (will default to another value)
-  assert( bv->GetPointer() && bv->GetLength() );
+  gdcm_assert( bv->GetPointer() && bv->GetLength() );
   std::string s( bv->GetPointer(), bv->GetLength() );
   // What if a \0 can be found before the end of string...
-  //assert( strlen( s.c_str() ) == s.size() );
+  //gdcm_assert( strlen( s.c_str() ) == s.size() );
 
   // First thing check consistency:
   if( !GetGroup() )
@@ -133,7 +133,7 @@ void Overlay::Update(const DataElement & de)
     }
   else // check consistency
     {
-    assert( GetGroup() == de.GetTag().GetGroup() ); // programmer error
+    gdcm_assert( GetGroup() == de.GetTag().GetGroup() ); // programmer error
     }
 
   //std::cerr << "Tag: " << de.GetTag() << std::endl;
@@ -185,7 +185,7 @@ void Overlay::Update(const DataElement & de)
     }
   else if( de.GetTag().GetElement() == 0x0060 ) // OverlayCompressionCode (RET)
     {
-    assert( s == "NONE" ); // FIXME ??
+    gdcm_assert( s == "NONE" ); // FIXME ??
     }
   else if( de.GetTag().GetElement() == 0x0100 ) // OverlayBitsAllocated
     {
@@ -211,7 +211,7 @@ void Overlay::Update(const DataElement & de)
     }
   else if( de.GetTag().GetElement() == 0x0110 ) // OverlayFormat (RET)
     {
-    assert( s == "RECT" );
+    gdcm_assert( s == "RECT" );
     }
   else if( de.GetTag().GetElement() == 0x0200 ) // OverlayLocation (RET)
     {
@@ -242,7 +242,7 @@ void Overlay::Update(const DataElement & de)
   else
     {
     gdcmErrorMacro( "Tag is not supported: " << de.GetTag() << std::endl );
-    assert(0);
+    gdcm_assert(0);
     }
 }
 
@@ -268,7 +268,7 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
     const unsigned int length = ovlength * 8 * 1; //bv->GetLength();
     const uint8_t *p = (const uint8_t*)(const void*)array;
     const uint8_t *end = (const uint8_t*)(const void*)(array + length);
-    assert( 8 * ovlength == (unsigned int)Internal->Rows * Internal->Columns );
+    gdcm_assert( 8 * ovlength == (unsigned int)Internal->Rows * Internal->Columns );
     if( Internal->Data.empty() )
       {
       gdcmWarningMacro("Internal Data is empty." );
@@ -277,11 +277,11 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
     unsigned char * overlay = (unsigned char*)Internal->Data.data();
     int c = 0;
     uint8_t pmask = (uint8_t)(1 << Internal->BitPosition);
-    assert( length / 1 == ovlength * 8 );
+    gdcm_assert( length / 1 == ovlength * 8 );
     while( p != end )
       {
       const uint8_t val = *p & pmask;
-      assert( val == 0x0 || val == pmask );
+      gdcm_assert( val == 0x0 || val == pmask );
       // 128 -> 0x80
       if( val )
         {
@@ -294,11 +294,11 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
       ++p;
       ++c;
       }
-    assert( (unsigned)c / 8 == ovlength );
+    gdcm_assert( (unsigned)c / 8 == ovlength );
     }
   else if( Internal->BitsAllocated == 16 )
     {
-    //assert( Internal->BitPosition >= 12 );
+    //gdcm_assert( Internal->BitPosition >= 12 );
     if( !ds.FindDataElement( Tag(0x7fe0,0x0010) ) )
       {
       gdcmWarningMacro("Could not find Pixel Data. Cannot extract Overlay." );
@@ -312,7 +312,7 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
       gdcmWarningMacro("Could not extract overlay from encapsulated stream." );
       return false;
       }
-    assert( bv );
+    gdcm_assert( bv );
     const char *array = bv->GetPointer();
     // SIEMENS_GBS_III-16-ACR_NEMA_1.acr is pain to support,
     // I cannot simply use the bv->GetLength I have to use the image dim:
@@ -320,7 +320,7 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
     const uint16_t *p = (const uint16_t*)(const void*)array;
     const uint16_t *end = (const uint16_t*)(const void*)(array + length);
     //const unsigned int ovlength = length / (8*2);
-    assert( 8 * ovlength == (unsigned int)Internal->Rows * Internal->Columns );
+    gdcm_assert( 8 * ovlength == (unsigned int)Internal->Rows * Internal->Columns );
     if( Internal->Data.empty() )
       {
       gdcmWarningMacro("Internal Data is empty." );
@@ -329,11 +329,11 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
     unsigned char * overlay = (unsigned char*)Internal->Data.data();
     int c = 0;
     uint16_t pmask = (uint16_t)(1 << Internal->BitPosition);
-    assert( length / 2 == ovlength * 8 );
+    gdcm_assert( length / 2 == ovlength * 8 );
     while( p != end )
       {
       const uint16_t val = *p & pmask;
-      assert( val == 0x0 || val == pmask );
+      gdcm_assert( val == 0x0 || val == pmask );
       // 128 -> 0x80
       if( val )
         {
@@ -346,7 +346,7 @@ bool Overlay::GrabOverlayFromPixelData(DataSet const &ds)
       ++p;
       ++c;
       }
-    assert( (unsigned)c / 8 == ovlength );
+    gdcm_assert( (unsigned)c / 8 == ovlength );
     }
   else
     {
@@ -473,8 +473,8 @@ void Overlay::SetOverlay(const char *array, size_t length)
     std::copy(array, array+computed_length, Internal->Data.begin());
     }
   /* warning need to take into account padding to the next word (8bits) */
-  //assert( length == compute_bit_and_dicom_padding(Internal->Rows, Internal->Columns) );
-  assert( Internal->Data.size() == computed_length );
+  //gdcm_assert( length == compute_bit_and_dicom_padding(Internal->Rows, Internal->Columns) );
+  gdcm_assert( Internal->Data.size() == computed_length );
 }
 
 const ByteValue &Overlay::GetOverlayData() const
@@ -498,7 +498,7 @@ bool Overlay::GetUnpackBuffer(char *buffer, size_t len) const
   const unsigned char *begin = unpackedbytes;
   for( std::vector<char>::const_iterator it = Internal->Data.begin(); it != Internal->Data.end(); ++it )
     {
-    assert( unpackedbytes <= begin + len ); // We never store more than actually required
+    gdcm_assert( unpackedbytes <= begin + len ); // We never store more than actually required
     // const unsigned char &packedbytes = *it;
     // weird bug with gcc 3.3 (prerelease on SuSE) apparently:
     unsigned char packedbytes = static_cast<unsigned char>(*it);
@@ -517,7 +517,7 @@ bool Overlay::GetUnpackBuffer(char *buffer, size_t len) const
       mask <<= 1;
       }
     }
-  assert(unpackedbytes <= begin + len);
+  gdcm_assert(unpackedbytes <= begin + len);
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmPNMCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPNMCodec.cxx
@@ -108,7 +108,7 @@ bool PNMCodec::Write(const char *filename, const DataElement &out) const
     gdcmErrorMacro( "PNM Codec does not handle compress syntax. You need to decompress first." );
     return false;
     }
-  assert(bv);
+  gdcm_assert(bv);
 
   if( pi == PhotometricInterpretation::PALETTE_COLOR )
     {
@@ -179,7 +179,7 @@ bool PNMCodec::Read(const char *filename, DataElement &out) const
     is.get();
     }
   std::streampos pos = is.tellg();
-  //assert(pos < INT_MAX);
+  //gdcm_assert(pos < INT_MAX);
   size_t m = (len - (size_t)pos ) / ( dims[0]*dims[1] );
   if( m * dims[0] * dims[1] != len - pos )
     {
@@ -218,7 +218,7 @@ bool PNMCodec::Read(const char *filename, DataElement &out) const
   //if ( maxval * 8 != bpp ) return 1;
 
   size_t pdlen = GetBufferLength();
-  assert( pdlen );
+  gdcm_assert( pdlen );
   char * buf = new char[pdlen];
   // is should be at right offset, just read!
   is.read(buf, len);
@@ -253,7 +253,7 @@ bool PNMCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
 {
   is.seekg( 0, std::ios::end );
   std::streampos len = is.tellg();
-  //assert(len < INT_MAX);
+  //gdcm_assert(len < INT_MAX);
   is.seekg( 0, std::ios::beg );
 
   std::string type, str;
@@ -291,8 +291,8 @@ bool PNMCodec::GetHeaderInfo(std::istream &is, TransferSyntax &ts)
     is.get();
     }
   std::streamoff pos = is.tellg();
-  //assert(len < INT_MAX);
-  //assert(pos < INT_MAX);
+  //gdcm_assert(len < INT_MAX);
+  //gdcm_assert(pos < INT_MAX);
   size_t m = ((size_t)len - (size_t)pos ) / ( dims[0]*dims[1] );
   bool cond;
   if( type == "P4" ) {

--- a/Source/MediaStorageAndFileFormat/gdcmPersonName.h
+++ b/Source/MediaStorageAndFileFormat/gdcmPersonName.h
@@ -45,7 +45,7 @@ public:
   unsigned int GetMaxLength() const { return MaxLength; }
   void SetBlob(const std::vector<char>& v) {
   (void)v;
-    //assert(0); //TODO
+    //gdcm_assert(0); //TODO
   }
   void SetComponents(const char *comp1 = "",
     const char *comp2 = "",
@@ -60,7 +60,7 @@ public:
       for(unsigned int i = 0; i < 5; ++i) {
         if( components[i] && strlen(components[i]) < GetMaxLength() )
           strcpy(Component[i], components[i]);
-        assert( strlen(Component[i]) < GetMaxLength() );
+        gdcm_assert( strlen(Component[i]) < GetMaxLength() );
       }
   }
   void Print(std::ostream &os) const

--- a/Source/MediaStorageAndFileFormat/gdcmPhotometricInterpretation.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPhotometricInterpretation.cxx
@@ -62,7 +62,7 @@ static const char *PIStrings[] = {
 
 const char *PhotometricInterpretation::GetPIString(PIType pi)
 {
-  //assert( pi < PhotometricInterpretation::PI_END );
+  //gdcm_assert( pi < PhotometricInterpretation::PI_END );
   return PIStrings[pi];
 }
 
@@ -100,7 +100,7 @@ PhotometricInterpretation::PIType PhotometricInterpretation::GetPIType(const cha
       return PIType(i);
       }
     }
-  //assert(0);
+  //gdcm_assert(0);
   return PI_END;
 }
 
@@ -124,8 +124,8 @@ unsigned short PhotometricInterpretation::GetSamplesPerPixel() const
     }
   else
     {
-    assert( PIField != PI_END );
-    assert( //PIField == PALETTE_COLOR
+    gdcm_assert( PIField != PI_END );
+    gdcm_assert( //PIField == PALETTE_COLOR
             PIField == RGB
          || PIField == HSV
          //|| PIField == ARGB
@@ -167,11 +167,11 @@ bool PhotometricInterpretation::IsLossless() const
   case YBR_ICT:
     return false;
   default:
-    assert(0);
+    gdcm_assert(0);
     return false;
     }
 
-  assert( 0 ); // technically one should not reach here, unless UNKNOWN ...
+  gdcm_assert( 0 ); // technically one should not reach here, unless UNKNOWN ...
   return false;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmPixelFormat.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPixelFormat.cxx
@@ -47,7 +47,7 @@ PixelFormat::PixelFormat(ScalarType st)
 unsigned short PixelFormat::GetSamplesPerPixel() const
 {
   // \postcondition
-  assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
+  gdcm_assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
   return SamplesPerPixel;
 }
 
@@ -120,7 +120,7 @@ void PixelFormat::SetScalarType(ScalarType st)
     PixelRepresentation = 0;
     break;
   default:
-    assert(0);
+    gdcm_assert(0);
     break;
     }
   BitsStored = BitsAllocated;
@@ -171,23 +171,23 @@ PixelFormat::ScalarType PixelFormat::GetScalarType() const
       }
     else if( PixelRepresentation == 1 )
       {
-      assert( type <= INT64 );
+      gdcm_assert( type <= INT64 );
       // That's why you need to order properly type in ScalarType
       type = ScalarType(int(type)+1);
       }
     else if( PixelRepresentation == 2 )
       {
-      assert( BitsAllocated == 16 );
+      gdcm_assert( BitsAllocated == 16 );
       return FLOAT16;
       }
     else if( PixelRepresentation == 3 )
       {
-      assert( BitsAllocated == 32 );
+      gdcm_assert( BitsAllocated == 32 );
       return FLOAT32;
       }
     else if( PixelRepresentation == 4 )
       {
-      assert( BitsAllocated == 64 );
+      gdcm_assert( BitsAllocated == 64 );
       return FLOAT64;
       }
     else
@@ -212,7 +212,7 @@ uint8_t PixelFormat::GetPixelSize() const
     }
   else
     {
-    assert( !(BitsAllocated % 8) );
+    gdcm_assert( !(BitsAllocated % 8) );
     }
   pixelsize *= SamplesPerPixel;
 
@@ -221,7 +221,7 @@ uint8_t PixelFormat::GetPixelSize() const
 
 int64_t PixelFormat::GetMin() const
 {
-  assert( BitsAllocated ); // cannot be unknown
+  gdcm_assert( BitsAllocated ); // cannot be unknown
   if( BitsStored <= 32 )
     {
     if( PixelRepresentation == 1 )
@@ -239,7 +239,7 @@ int64_t PixelFormat::GetMin() const
 
 int64_t PixelFormat::GetMax() const
 {
-  assert( BitsAllocated ); // cannot be unknown
+  gdcm_assert( BitsAllocated ); // cannot be unknown
   if( BitsStored <= 32 )
     {
     if( PixelRepresentation == 1 )
@@ -270,9 +270,9 @@ bool PixelFormat::IsValid() const
 bool PixelFormat::Validate()
 {
   if( !IsValid() ) return false;
-  //assert( BitsStored    >= HighBit ); // DigitexAlpha_no_7FE0.dcm
-  assert( PixelRepresentation == 0 || PixelRepresentation == 1 );
-  assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
+  //gdcm_assert( BitsStored    >= HighBit ); // DigitexAlpha_no_7FE0.dcm
+  gdcm_assert( PixelRepresentation == 0 || PixelRepresentation == 1 );
+  gdcm_assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
   if ( BitsStored == 0 )
     {
     gdcmDebugMacro( "Bits Stored is 0. Setting is to max value" );

--- a/Source/MediaStorageAndFileFormat/gdcmPixelFormat.h
+++ b/Source/MediaStorageAndFileFormat/gdcmPixelFormat.h
@@ -93,7 +93,7 @@ public:
     {
     gdcmAssertMacro( spp <= 4 );
     SamplesPerPixel = spp;
-    assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
+    gdcm_assert( SamplesPerPixel == 1 || SamplesPerPixel == 3 || SamplesPerPixel == 4 );
     }
 
   /// BitsAllocated see Tag (0028,0100) US Bits Allocated
@@ -128,7 +128,7 @@ public:
   /// BitsStored see Tag (0028,0101) US Bits Stored
   unsigned short GetBitsStored() const
     {
-    assert( BitsStored <= BitsAllocated );
+    gdcm_assert( BitsStored <= BitsAllocated );
     return BitsStored;
     }
   void SetBitsStored(unsigned short bs)
@@ -151,7 +151,7 @@ public:
   /// HighBit see Tag (0028,0102) US High Bit
   unsigned short GetHighBit() const
     {
-    assert( HighBit < BitsStored );
+    gdcm_assert( HighBit < BitsStored );
     return HighBit;
     }
   void SetHighBit(unsigned short hb)

--- a/Source/MediaStorageAndFileFormat/gdcmPixmap.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPixmap.cxx
@@ -45,7 +45,7 @@ bool Pixmap::AreOverlaysInPixelData() const
     {
     total += (int)it->IsInPixelData();
     }
-  assert( total == (int)GetNumberOfOverlays() || !total );
+  gdcm_assert( total == (int)GetNumberOfOverlays() || !total );
   return total != 0;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmPixmap.h
+++ b/Source/MediaStorageAndFileFormat/gdcmPixmap.h
@@ -43,11 +43,11 @@ public:
 
   /// Curve: group 50xx
   Curve& GetCurve(size_t i = 0) {
-    assert( i < Curves.size() );
+    gdcm_assert( i < Curves.size() );
     return Curves[i];
   }
   const Curve& GetCurve(size_t i = 0) const {
-    assert( i < Curves.size() );
+    gdcm_assert( i < Curves.size() );
     return Curves[i];
   }
   size_t GetNumberOfCurves() const { return Curves.size(); }
@@ -55,17 +55,17 @@ public:
 
   /// Overlay: group 60xx
   Overlay& GetOverlay(size_t i = 0) {
-    assert( i < Overlays.size() );
+    gdcm_assert( i < Overlays.size() );
     return Overlays[i];
   }
   const Overlay& GetOverlay(size_t i = 0) const {
-    assert( i < Overlays.size() );
+    gdcm_assert( i < Overlays.size() );
     return Overlays[i];
   }
   size_t GetNumberOfOverlays() const { return Overlays.size(); }
   void SetNumberOfOverlays(size_t n) { Overlays.resize(n); }
   void RemoveOverlay(size_t i) {
-    assert( i < Overlays.size() );
+    gdcm_assert( i < Overlays.size() );
     Overlays.erase( Overlays.begin() + i );
   }
 

--- a/Source/MediaStorageAndFileFormat/gdcmPixmapReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPixmapReader.cxx
@@ -81,8 +81,8 @@ bool PixmapReader::Read()
     {
     // I cannot leave this here, since ELSCINT1 / LOSSLESS RICE declares CT Image Storage,
     // when in fact this is a private Media Storage (no Pixel Data element)
-    //assert( ds.FindDataElement( Tag(0x7fe0,0x0010 ) ) );
-    assert( ts != TransferSyntax::TS_END && ms != MediaStorage::MS_END );
+    //gdcm_assert( ds.FindDataElement( Tag(0x7fe0,0x0010 ) ) );
+    gdcm_assert( ts != TransferSyntax::TS_END && ms != MediaStorage::MS_END );
     // Good it's the easy case. It's declared as an Image:
     //PixelData->SetCompressionFromTransferSyntax( ts );
     res = ReadImage(ms);
@@ -94,7 +94,7 @@ bool PixmapReader::Read()
   else
     {
     MediaStorage ms2 = ds.GetMediaStorage();
-    //assert( !ds.FindDataElement( Tag(0x7fe0,0x0010 ) ) );
+    //gdcm_assert( !ds.FindDataElement( Tag(0x7fe0,0x0010 ) ) );
     if( ms == MediaStorage::MediaStorageDirectoryStorage && ms2 == MediaStorage::MS_END )
       {
       gdcmDebugMacro( "DICOM file is not an Image file but a : " <<
@@ -146,7 +146,7 @@ bool PixmapReader::Read()
         }
       else // there is a Unknown Media Storage Syntax
         {
-        assert( ts != TransferSyntax::TS_END && ms == MediaStorage::MS_END );
+        gdcm_assert( ts != TransferSyntax::TS_END && ms == MediaStorage::MS_END );
         // god damit I don't know what to do...
         gdcmWarningMacro( "Attempting to read this file as a DICOM file"
           "\nDesperate attempt" );
@@ -253,7 +253,7 @@ static void DoIconImage(const DataSet& rootds, Pixmap& image)
       pi = PhotometricInterpretation::GetPIType(
         photometricinterpretation_str.c_str());
       }
-    assert( pi != PhotometricInterpretation::UNKNOWN);
+    gdcm_assert( pi != PhotometricInterpretation::UNKNOWN);
     pixeldata.SetPhotometricInterpretation( pi );
 
     //
@@ -263,7 +263,7 @@ static void DoIconImage(const DataSet& rootds, Pixmap& image)
       const Tag testseglut(0x0028, (0x1221 + 0));
       if( ds.FindDataElement( testseglut ) )
         {
-        assert(0 && "Please report this image");
+        gdcm_assert(0 && "Please report this image");
         lut = new SegmentedPaletteColorLookupTable;
         }
       //SmartPointer<SegmentedPaletteColorLookupTable> lut = new SegmentedPaletteColorLookupTable;
@@ -297,11 +297,11 @@ static void DoIconImage(const DataSet& rootds, Pixmap& image)
         if( ds.FindDataElement( tlut ) )
           {
           const ByteValue *lut_raw = ds.GetDataElement( tlut ).GetByteValue();
-          assert( lut_raw );
+          gdcm_assert( lut_raw );
           // LookupTableType::RED == 0
           lut->SetLUT( LookupTable::LookupTableType(i),
             (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-          //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+          //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
 
           unsigned long check =
             (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
@@ -316,15 +316,15 @@ static void DoIconImage(const DataSet& rootds, Pixmap& image)
         else if( ds.FindDataElement( seglut ) )
           {
           const ByteValue *lut_raw = ds.GetDataElement( seglut ).GetByteValue();
-          assert( lut_raw );
+          gdcm_assert( lut_raw );
           lut->SetLUT( LookupTable::LookupTableType(i),
             (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-          //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+          //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
 
           //unsigned long check =
           //  (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
           //  * el_us3.GetValue(2) / 8;
-          //assert( check == lut_raw->GetLength() ); (void)check;
+          //gdcm_assert( check == lut_raw->GetLength() ); (void)check;
           }
         else
           {
@@ -389,7 +389,7 @@ static void DoCurves(const DataSet& ds, Pixmap& pixeldata)
         ++idxcurves; // move on to the next one
         curve = de.GetTag();
         uint16_t currentcurve = curve.GetGroup();
-        assert( !(currentcurve % 2) ); // 0x6001 is not an curve...
+        gdcm_assert( !(currentcurve % 2) ); // 0x6001 is not an curve...
         // Now loop on all element from this current group:
         DataElement de2 = de;
         while( de2.GetTag().GetGroup() == currentcurve )
@@ -406,7 +406,7 @@ static void DoCurves(const DataSet& ds, Pixmap& pixeldata)
         }
       }
     //std::cout << "Num of curves: " << numcurves << std::endl;
-    assert( idxcurves == numcurves );
+    gdcm_assert( idxcurves == numcurves );
     }
 }
 
@@ -466,10 +466,10 @@ static unsigned int GetNumberOfOverlaysInternal(DataSet const & ds, std::vector<
         && ds.FindDataElement( toverlaybitpos ) )
         {
         // Overlay Pixel are in Unused Pixel
-        assert( !ds.FindDataElement( toverlaydata ) );
+        gdcm_assert( !ds.FindDataElement( toverlaydata ) );
         const DataElement& overlayrows = ds.GetDataElement( toverlayrows );
         const DataElement& overlaycols = ds.GetDataElement( toverlaycols );
-        assert( ds.FindDataElement( toverlaybitpos ) );
+        gdcm_assert( ds.FindDataElement( toverlaybitpos ) );
         const DataElement& overlaybitpos = ds.GetDataElement( toverlaybitpos );
         if( !overlayrows.IsEmpty() && !overlaycols.IsEmpty() && !overlaybitpos.IsEmpty() )
           {
@@ -485,13 +485,13 @@ static unsigned int GetNumberOfOverlaysInternal(DataSet const & ds, std::vector<
     }
 
   // at most one out of two :
-  assert( numoverlays < 0x00ff / 2 );
+  gdcm_assert( numoverlays < 0x00ff / 2 );
   // PS 3.3 - 2004:
   // C.9.2 Overlay plane module
   // Each Overlay Plane is one bit deep. Sixteen separate Overlay Planes may be associated with an
   // Image or exist as Standalone Overlays in a Series
-  assert( numoverlays <= 16 );
-  assert( numoverlays == overlaylist.size() );
+  gdcm_assert( numoverlays <= 16 );
+  gdcm_assert( numoverlays == overlaylist.size() );
   return numoverlays;
 }
 
@@ -512,7 +512,7 @@ static bool DoOverlays(const DataSet& ds, Pixmap& pixeldata)
       Tag overlay(0x6000,0x0000);
       overlay.SetGroup( currentoverlay );
       const DataElement &de = ds.FindNextDataElement( overlay );
-      assert( !(currentoverlay % 2) ); // 0x6001 is not an overlay...
+      gdcm_assert( !(currentoverlay % 2) ); // 0x6001 is not an overlay...
       // Now loop on all element from this current group:
       DataElement de2 = de;
       while( de2.GetTag().GetGroup() == currentoverlay )
@@ -531,12 +531,12 @@ static bool DoOverlays(const DataSet& ds, Pixmap& pixeldata)
       // since the overlays are stored in the unused bit of the PixelData
       if( !ov.IsEmpty() )
         {
-        //assert( unpack.str().size() / 8 == ((ov.GetRows() * ov.GetColumns()) + 7 ) / 8 );
-        assert( ov.IsInPixelData( ) == false );
+        //gdcm_assert( unpack.str().size() / 8 == ((ov.GetRows() * ov.GetColumns()) + 7 ) / 8 );
+        gdcm_assert( ov.IsInPixelData( ) == false );
         }
       else if( pixeldata.GetPixelFormat().GetSamplesPerPixel() == 1 )
         {
-        assert( ov.IsEmpty() );
+        gdcm_assert( ov.IsEmpty() );
         gdcmDebugMacro( "This image does not contains Overlay in the 0x60xx tags. "
           << "Instead the overlay is stored in the unused bit of the Pixel Data."
           << std::endl );
@@ -634,7 +634,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     gdcmDebugMacro( "Mixture of ACR NEMA and DICOM file" );
     isacrnema = true;
     const char *str = ds.GetDataElement( trecognitioncode ).GetByteValue()->GetPointer();
-    assert( strncmp( str, "ACR-NEMA", strlen( "ACR-NEMA" ) ) == 0 ||
+    gdcm_assert( strncmp( str, "ACR-NEMA", strlen( "ACR-NEMA" ) ) == 0 ||
       strncmp( str, "ACRNEMA", strlen( "ACRNEMA" ) ) == 0 ||
       strncmp( str, "MIPS 2.0", strlen( "MIPS 2.0" ) ) == 0 );
     (void)str;//warning removal
@@ -674,7 +674,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     }
   else
     {
-    assert( MediaStorage::IsImage( ms ) );
+    gdcm_assert( MediaStorage::IsImage( ms ) );
     // D 0028|0100 [US] [Bits Allocated] [16]
     //pf.SetBitsAllocated(
     //  ReadUSFromTag( Tag(0x0028, 0x0100), ss, conversion ) );
@@ -683,7 +683,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     Attribute<0x0028,0x0100> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetBitsAllocated( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0100), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0100), ss, conversion ) );
     }
 
     // D 0028|0101 [US] [Bits Stored] [12]
@@ -694,7 +694,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     Attribute<0x0028,0x0101> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetBitsStored( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0101), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0101), ss, conversion ) );
     }
 
     // D 0028|0102 [US] [High Bit] [11]
@@ -705,7 +705,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     Attribute<0x0028,0x0102> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetHighBit( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0102), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0102), ss, conversion ) );
     }
 
     // D 0028|0103 [US] [Pixel Representation] [0]
@@ -718,7 +718,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     Attribute<0x0028,0x0103> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetPixelRepresentation( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0103), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0103), ss, conversion ) );
 
       }
 //    else
@@ -772,7 +772,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
       return false;
       }
     }
-  assert( pi != PhotometricInterpretation::PI_END );
+  gdcm_assert( pi != PhotometricInterpretation::PI_END );
   if( !pf.GetSamplesPerPixel() || (pi.GetSamplesPerPixel() != pf.GetSamplesPerPixel()) )
     {
     if( pi != PhotometricInterpretation::UNKNOWN )
@@ -928,7 +928,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
           // LookupTableType::RED == 0
           lut->SetLUT( LookupTable::LookupTableType(i),
             (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-          //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+          //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
           }
         else
           {
@@ -938,7 +938,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
         unsigned long check =
           (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
           * el_us3.GetValue(2) / 8;
-        assert( !lut->Initialized() || check == lut_raw->GetLength() ); (void)check;
+        gdcm_assert( !lut->Initialized() || check == lut_raw->GetLength() ); (void)check;
         }
       else if( ds.FindDataElement( seglut ) )
         {
@@ -947,7 +947,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
           {
           lut->SetLUT( LookupTable::LookupTableType(i),
             (const unsigned char*)lut_raw->GetPointer(), lut_raw->GetLength() );
-          //assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
+          //gdcm_assert( pf.GetBitsAllocated() == el_us3.GetValue(2) );
           }
         else
           {
@@ -957,7 +957,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
         //unsigned long check =
         //  (el_us3.GetValue(0) ? el_us3.GetValue(0) : 65536)
          // * el_us3.GetValue(2) / 8;
-        //assert( check == lut_raw->GetLength() ); (void)check;
+        //gdcm_assert( check == lut_raw->GetLength() ); (void)check;
         }
       else
         {
@@ -968,10 +968,10 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
     PixelData->SetLUT(*lut);
     }
   // TODO
-  //assert( pi.GetSamplesPerPixel() == pf.GetSamplesPerPixel() );
+  //gdcm_assert( pi.GetSamplesPerPixel() == pf.GetSamplesPerPixel() );
 
   // 5.5 Do IconImage if any
-  assert( PixelData->GetIconImage().IsEmpty() );
+  gdcm_assert( PixelData->GetIconImage().IsEmpty() );
   DoIconImage(ds, *PixelData);
 
   // 6. Do the Curves if any
@@ -1059,8 +1059,8 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
           v[0] = PixelData->GetDimensions()[0];
           v[1] = PixelData->GetDimensions()[1];
           v[2] = PixelData->GetDimensions()[2];
-          assert( jpeg.GetDimensions()[0] );
-          assert( jpeg.GetDimensions()[1] );
+          gdcm_assert( jpeg.GetDimensions()[0] );
+          gdcm_assert( jpeg.GetDimensions()[1] );
           v[0] = jpeg.GetDimensions()[0];
           v[1] = jpeg.GetDimensions()[1];
           PixelData->SetDimensions( v.data() );
@@ -1076,7 +1076,7 @@ bool PixmapReader::ReadImageInternal(MediaStorage const &ms, bool handlepixeldat
           gdcmDebugMacro( "Fix photometric interpretation." );
           PixelData->SetPhotometricInterpretation( jpeg.GetPhotometricInterpretation() );
           }
-          assert( PixelData->IsTransferSyntaxCompatible( ts ) );
+          gdcm_assert( PixelData->IsTransferSyntaxCompatible( ts ) );
           }
         else
           {
@@ -1156,10 +1156,10 @@ bool PixmapReader::ReadACRNEMAImage()
     {
     Attribute<0x0028,0x0005> at0 = { 0 };
     at0.SetFromDataElement( de0 );
-    assert( at0.GetNumberOfValues() == 1 );
+    gdcm_assert( at0.GetNumberOfValues() == 1 );
     imagedimensions = at0.GetValue();
     }
-    //assert( imagedimensions == ReadSSFromTag( timagedimensions, ss, conversion ) );
+    //gdcm_assert( imagedimensions == ReadSSFromTag( timagedimensions, ss, conversion ) );
     if ( imagedimensions == 3 )
       {
       PixelData->SetNumberOfDimensions(3);
@@ -1167,9 +1167,9 @@ bool PixmapReader::ReadACRNEMAImage()
       const DataElement& de1 = ds.GetDataElement( Tag(0x0028, 0x0012) );
       Attribute<0x0028,0x0012> at1 = { 0 };
       at1.SetFromDataElement( de1 );
-      assert( at1.GetNumberOfValues() == 1 );
+      gdcm_assert( at1.GetNumberOfValues() == 1 );
       PixelData->SetDimension(2, at1.GetValue() );
-      //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0012), ss, conversion ) );
+      //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0012), ss, conversion ) );
       }
     else if ( imagedimensions == 2 )
       {
@@ -1194,7 +1194,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0011> at = { 0 };
     at.SetFromDataSet( ds );
     PixelData->SetDimension(0, at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0011), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0011), ss, conversion ) );
     }
 
   // D 0028|0010 [US] [Rows] [512]
@@ -1203,7 +1203,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0010> at = { 0 };
     at.SetFromDataSet( ds );
     PixelData->SetDimension(1, at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0010), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0010), ss, conversion ) );
     }
 
   // This is the definition of an ACR NEMA image:
@@ -1214,13 +1214,13 @@ bool PixmapReader::ReadACRNEMAImage()
   if( ds.FindDataElement( trecognitioncode ) && !ds.GetDataElement( trecognitioncode ).IsEmpty() )
     {
     const ByteValue *libido = ds.GetDataElement(trecognitioncode).GetByteValue();
-    assert( libido );
+    gdcm_assert( libido );
     std::string libido_str( libido->GetPointer(), libido->GetLength() );
-    assert( libido_str != "CANRME_AILIBOD1_1." );
+    gdcm_assert( libido_str != "CANRME_AILIBOD1_1." );
     if( strcmp(libido_str.c_str() , "ACRNEMA_LIBIDO_1.1") == 0 || strcmp(libido_str.c_str() , "ACRNEMA_LIBIDO_1.0") == 0 )
       {
       // Swap Columns & Rows
-      // assert( PixelData->GetNumberOfDimensions() == 2 );
+      // gdcm_assert( PixelData->GetNumberOfDimensions() == 2 );
       const unsigned int *dims = PixelData->GetDimensions();
       unsigned int tmp = dims[0];
       PixelData->SetDimension(0, dims[1] );
@@ -1228,7 +1228,7 @@ bool PixmapReader::ReadACRNEMAImage()
       }
     else
       {
-      assert( libido_str == "ACR-NEMA 2.0"
+      gdcm_assert( libido_str == "ACR-NEMA 2.0"
            || libido_str == "ACR-NEMA 1.0" );
       }
     }
@@ -1237,7 +1237,7 @@ bool PixmapReader::ReadACRNEMAImage()
     gdcmWarningMacro(
       "Reading as ACR NEMA an image which does not look likes ACR NEMA" );
     // File: acc-max.dcm is it ACR or DICOM ?
-    // assert(0);
+    // gdcm_assert(0);
     }
 
   // 3. Pixel Format ?
@@ -1248,7 +1248,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0100> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetBitsAllocated( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0100), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0100), ss, conversion ) );
     }
 
   // D 0028|0101 [US] [Bits Stored] [12]
@@ -1257,7 +1257,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0101> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetBitsStored( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0101), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0101), ss, conversion ) );
     }
 
   // D 0028|0102 [US] [High Bit] [11]
@@ -1266,7 +1266,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0102> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetHighBit( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0102), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0102), ss, conversion ) );
     }
 
   // D 0028|0103 [US] [Pixel Representation] [0]
@@ -1275,7 +1275,7 @@ bool PixmapReader::ReadACRNEMAImage()
     Attribute<0x0028,0x0103> at = { 0 };
     at.SetFromDataSet( ds );
     pf.SetPixelRepresentation( at.GetValue() );
-    //assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0103), ss, conversion ) );
+    //gdcm_assert( at.GetValue() == ReadUSFromTag( Tag(0x0028, 0x0103), ss, conversion ) );
     }
 
   PixelData->SetPixelFormat( pf );
@@ -1295,7 +1295,7 @@ bool PixmapReader::ReadACRNEMAImage()
   const DataElement& de = ds.GetDataElement( pixeldata );
   if ( de.GetVR() == VR::OW )
     {
-    //assert(0);
+    //gdcm_assert(0);
     //PixelData->SetNeedByteSwap(true);
     }
   PixelData->SetDataElement( de );
@@ -1328,7 +1328,7 @@ bool PixmapReader::ReadACRNEMAImage()
     {
     const ByteValue *photometricinterpretation
       = ds.GetDataElement( tphotometricinterpretation ).GetByteValue();
-    assert( photometricinterpretation );
+    gdcm_assert( photometricinterpretation );
     std::string photometricinterpretation_str(
       photometricinterpretation->GetPointer(),
       photometricinterpretation->GetLength() );
@@ -1342,7 +1342,7 @@ bool PixmapReader::ReadACRNEMAImage()
     // Wild guess:
     if( PixelData->GetPixelFormat().GetSamplesPerPixel() == 1 )
       {
-      assert( PixelData->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
+      gdcm_assert( PixelData->GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
       // No need...
       //PixelData->SetPhotometricInterpretation( PhotometricInterpretation::MONOCHROME2 );
       }

--- a/Source/MediaStorageAndFileFormat/gdcmPixmapWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPixmapWriter.cxx
@@ -110,7 +110,7 @@ Attribute<0x0028,0x0004> piat;
     if ( pi == PhotometricInterpretation::PALETTE_COLOR )
       {
       const LookupTable &lut = icon.GetLUT();
-      assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
+      gdcm_assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
            || (pf.GetBitsAllocated() == 16 && pf.GetPixelRepresentation() == 0) );
       // lut descriptor:
       // (0028,1101) US 256\0\16                                 #   6, 3 RedPaletteColorLookupTableDescriptor
@@ -182,7 +182,7 @@ Attribute<0x0028,0x0004> piat;
   de.SetValue( v );
   const ByteValue *bv = de.GetByteValue();
   const TransferSyntax &ts = icon.GetTransferSyntax();
-  assert( ts.IsExplicit() || ts.IsImplicit() );
+  gdcm_assert( ts.IsExplicit() || ts.IsImplicit() );
   VL vl;
   if( bv )
     {
@@ -207,7 +207,7 @@ Attribute<0x0028,0x0004> piat;
         de.SetVR( VR::OW );
         break;
       default:
-        assert( 0 && "should not happen" );
+        gdcm_assert( 0 && "should not happen" );
         break;
       }
     }
@@ -253,14 +253,14 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
   if( PixelData->GetNumberOfDimensions() == 3  )
     {
     Attribute<0x0028, 0x0008> numberofframes;
-    assert( PixelData->GetDimension(2) >= 1 );
+    gdcm_assert( PixelData->GetDimension(2) >= 1 );
     numberofframes.SetValue( PixelData->GetDimension(2) );
     ds.Replace( numberofframes.GetAsDataElement() );
     }
   else if( ds.FindDataElement(tnumberofframes) ) // Remove Number Of Frames
     {
-    assert( PixelData->GetNumberOfDimensions() == 2 );
-    assert( PixelData->GetDimension(2) == 1 );
+    gdcm_assert( PixelData->GetNumberOfDimensions() == 2 );
+    gdcm_assert( PixelData->GetDimension(2) == 1 );
     ds.Remove( tnumberofframes );
     }
 #endif
@@ -280,7 +280,7 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
     }
 
     {
-    assert( pi != PhotometricInterpretation::UNKNOWN );
+    gdcm_assert( pi != PhotometricInterpretation::UNKNOWN );
     const char *pistr = PhotometricInterpretation::GetPIString(pi);
     DataElement de( Tag(0x0028, 0x0004 ) );
     VL::Type strlenPistr = (VL::Type)strlen(pistr);
@@ -335,8 +335,8 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
     if ( pi == PhotometricInterpretation::PALETTE_COLOR )
       {
       const LookupTable &lut = PixelData->GetLUT();
-      assert( lut.Initialized() );
-//      assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
+      gdcm_assert( lut.Initialized() );
+//      gdcm_assert( (pf.GetBitsAllocated() == 8  && pf.GetPixelRepresentation() == 0)
 //           || (pf.GetBitsAllocated() == 16 && pf.GetPixelRepresentation() == 0) );
       // lut descriptor:
       // (0028,1101) US 256\0\16                                 #   6, 3 RedPaletteColorLookupTableDescriptor
@@ -503,7 +503,7 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
     bvpixdata = depixdata.GetByteValue();
     }
   const TransferSyntax &ts = PixelData->GetTransferSyntax();
-  assert( ts.IsExplicit() || ts.IsImplicit() );
+  gdcm_assert( ts.IsExplicit() || ts.IsImplicit() );
 
   // It is perfectly ok to store a lossy image using a J2K (this is odd, but valid).
   // as long as your mark LossyImageCompression with value 1
@@ -627,7 +627,7 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
           depixdata.SetVR( VR::OW );
         break;
       default:
-        assert( 0 && "should not happen" );
+        gdcm_assert( 0 && "should not happen" );
         break;
       }
     }
@@ -695,7 +695,7 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
       }
     else
       {
-      assert( bv->GetLength() == strlen( msstr ) || bv->GetLength() == strlen(msstr) + 1 );
+      gdcm_assert( bv->GetLength() == strlen( msstr ) || bv->GetLength() == strlen(msstr) + 1 );
       }
     }
   ImageHelper::SetDimensionsValue(file, *PixelData);
@@ -786,7 +786,7 @@ bool PixmapWriter::PrepareWrite( MediaStorage const & ref_ms )
   if( GetCheckFileMetaInformation() )
   {
     fmi.Clear();
-    //assert( ts == TransferSyntax::ImplicitVRLittleEndian );
+    //gdcm_assert( ts == TransferSyntax::ImplicitVRLittleEndian );
       {
       const char *tsuid = TransferSyntax::GetTSString( ts );
       DataElement de( Tag(0x0002,0x0010) );
@@ -829,7 +829,7 @@ bool PixmapWriter::Write()
   }
   if( !PrepareWrite( ms ) ) return false;
 
-  assert( Stream );
+  gdcm_assert( Stream );
   if( !Writer::Write() )
     {
     return false;

--- a/Source/MediaStorageAndFileFormat/gdcmPrinter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmPrinter.cxx
@@ -141,8 +141,8 @@ void PrintValue(VR::VRType const &vr, VM const &vm, const Value &v);
 template <typename T>
 inline char *bswap(char *out, const char *in, size_t length)
 {
-  assert( !(length % sizeof(T)) );
-  assert( out != in );
+  gdcm_assert( !(length % sizeof(T)) );
+  gdcm_assert( out != in );
   for(size_t i = 0; i < length; i+=2)
     {
     //const char copy = in[i];
@@ -193,15 +193,15 @@ void Printer::PrintElement(std::ostream& os, const ImplicitDataElement &ide, Dic
 #define PrinterTemplateSubCase1n(type,rep) \
   case VM::rep: \
     {Element<VR::type, VM::rep> e; \
-    /*assert( VM::rep == VM::VM1_n );*/ \
+    /*gdcm_assert( VM::rep == VM::VM1_n );*/ \
     e.SetArray( (const VRToType<VR::type>::Type *)array, length, true ); \
     e.Print( os ); }\
     break;
 #define PrinterTemplateSubCase(type,rep) \
   case VM::rep: \
     {Element<VR::type, VM::rep> e; \
-    /*assert( bv.GetLength() == VMToLength<VM::rep>::Length * sizeof( VRToType<VR::type>::Type) ); */ \
-    assert( bv.GetLength() == e.GetLength() * sizeof( VRToType<VR::type>::Type) ); \
+    /*gdcm_assert( bv.GetLength() == VMToLength<VM::rep>::Length * sizeof( VRToType<VR::type>::Type) ); */ \
+    gdcm_assert( bv.GetLength() == e.GetLength() * sizeof( VRToType<VR::type>::Type) ); \
     memcpy( (void*)(&e), array, e.GetLength() * sizeof( VRToType<VR::type>::Type) ); \
     e.Print( os ); }\
     break;
@@ -215,12 +215,12 @@ PrinterTemplateSubCase(type, VM5) \
 PrinterTemplateSubCase(type, VM6) \
 PrinterTemplateSubCase(type, VM24) \
 PrinterTemplateSubCase1n(type, VM1_n) \
-default: assert(0); }
+default: gdcm_assert(0); }
 
 #define PrinterTemplateSub2(type) \
 switch(vm) { \
   PrinterTemplateSubCase1n(type, VM1) \
-default: assert(0); }
+default: gdcm_assert(0); }
 
 #define PrinterTemplateCase(type) \
   case VR::type: \
@@ -259,7 +259,7 @@ PrinterTemplateCase(UL) \
 PrinterTemplateCase(UN) \
 PrinterTemplateCase(US) \
 PrinterTemplateCase(UT) \
-default: assert(0); }
+default: gdcm_assert(0); }
 
 void PrintValue(VR::VRType const &vr, VM const &vm, const Value &v)
 {
@@ -309,8 +309,8 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
       VM::VMType vm = entry.GetVM();
       if( /*de.GetTag().GetGroup()%2 &&*/ de.GetTag().GetElement() == 0 )
         {
-        assert( vr == VR::INVALID || vr == VR::UL );
-        assert( vm == VM::VM0 || vm == VM::VM1 );
+        gdcm_assert( vr == VR::INVALID || vr == VR::UL );
+        gdcm_assert( vm == VM::VM0 || vm == VM::VM1 );
         vr = VR::UL;
         vm = VM::VM1;
         }
@@ -334,7 +334,7 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
   //VM::VMType vm = VM::VM1;
   if( t == Tag(0x7fe0,0x0010) )
     {
-    assert( vr == VR::OB_OW );
+    gdcm_assert( vr == VR::OB_OW );
     vr = VR::OW;
     //vm = VM::VM1_n;
     }
@@ -346,7 +346,7 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
   // The component points shall be encoded in Little Endian.
   else if( t == Tag(0x5004,0x3000) ) // FIXME
     {
-    assert( vr == VR::OB_OW );
+    gdcm_assert( vr == VR::OB_OW );
     vr = VR::OB;
     }
   // Value of pixels not present in the native image added to an image
@@ -374,12 +374,12 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
       const ByteValue &bv = static_cast<const ByteValue&>(value);
       // FIXME:
       unsigned short pixel_rep_value = *(unsigned short*)(bv.GetPointer());
-      assert( pixel_rep_value == 0x0 || pixel_rep_value == 0x1 );
+      gdcm_assert( pixel_rep_value == 0x0 || pixel_rep_value == 0x1 );
       vr = pixel_rep_value ? VR::SS : VR::US;
       }
     else
     {
-      assert(0);
+      gdcm_assert(0);
     }
     }
 
@@ -387,7 +387,7 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
         }
       else
         {
-        assert(0);
+        gdcm_assert(0);
         const Value& val = de.GetValue();
         _os << de.GetTag();
         if ( printVR )
@@ -448,7 +448,7 @@ void Printer::PrintDataSet(std::ostream& os, const DataSet<ImplicitDataElement> 
       os << ""; } \
       else { if( de.IsEmpty() ) os << GDCM_TERMINAL_VT100_INVERSE << "(no value)" << GDCM_TERMINAL_VT100_NORMAL; \
                  else os << GDCM_TERMINAL_VT100_INVERSE << GDCM_TERMINAL_VT100_FOREGROUND_RED << "(VR=" << refvr << " is incompatible with length)" << GDCM_TERMINAL_VT100_NORMAL; } } \
-      else { assert( de.IsEmpty()); os << GDCM_TERMINAL_VT100_INVERSE << "(no value)" << GDCM_TERMINAL_VT100_NORMAL; } \
+      else { gdcm_assert( de.IsEmpty()); os << GDCM_TERMINAL_VT100_INVERSE << "(no value)" << GDCM_TERMINAL_VT100_NORMAL; } \
     } break
 
 VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const DataSet & ds,
@@ -472,7 +472,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
   const VM &vm = entry.GetVM();
   const char *name = entry.GetName();
   bool retired = entry.GetRetired();
-  //if( t.IsPrivate() ) assert( retired == false );
+  //if( t.IsPrivate() ) gdcm_assert( retired == false );
 
   const VR &vr_read = de.GetVR();
   const VL &vl_read = de.GetVL();
@@ -500,8 +500,8 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     refvr = DataSetHelper::ComputeVR(*F,ds, t);
     }
 
-  assert( refvr != VR::US_SS );
-  assert( refvr != VR::OB_OW );
+  gdcm_assert( refvr != VR::US_SS );
+  gdcm_assert( refvr != VR::OB_OW );
 
   if( !de.IsEmpty() )
   {
@@ -510,21 +510,21 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     {
     sqi = de.GetValueAsSQ();
     refvr = VR::SQ;
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 #if 0
   else if( vr == VR::SQ && vr_read != VR::SQ )
     {
     sqi = de.GetValueAsSQ();
     refvr = VR::SQ;
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 #endif
   }
 
   if( (vr_read == VR::INVALID || vr_read == VR::UN ) && vl_read.IsUndefined() )
     {
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 
 //  if( vr_read == VR::SQ || vr_read == VR::UN )
@@ -533,7 +533,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
 //    }
   if( vr != VR::INVALID && (!vr.Compatible( vr_read ) || vr_read == VR::INVALID || vr_read == VR::UN || vr_read != refvr ) )
     {
-    assert( vr != VR::INVALID );
+    gdcm_assert( vr != VR::INVALID );
     bool valid = true;
     if( vr_read == VR::SQ ) {
       if( !vr.Compatible( vr_read ) ) {
@@ -560,14 +560,14 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     os << GDCM_TERMINAL_VT100_FOREGROUND_GREEN;
     os << "(SQ) ";
     os << GDCM_TERMINAL_VT100_NORMAL;
-    assert( refvr == VR::INVALID );
+    gdcm_assert( refvr == VR::INVALID );
     refvr = VR::SQ;
     }
 
   // Print Value now:
   if( refvr & VR::VRASCII )
     {
-    assert( !sqi && !sqf );
+    gdcm_assert( !sqi && !sqf );
     if( bv )
       {
       VL l = std::min( bv->GetLength(), MaxPrintLength );
@@ -587,7 +587,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
       }
     else
       {
-      assert( de.IsEmpty() );
+      gdcm_assert( de.IsEmpty() );
       os << GDCM_TERMINAL_VT100_INVERSE;
       os << "(no value)";
       os << GDCM_TERMINAL_VT100_NORMAL;
@@ -595,7 +595,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     }
   else
     {
-    assert( refvr & VR::VRBINARY || (vr == VR::INVALID && refvr == VR::INVALID) );
+    gdcm_assert( refvr & VR::VRBINARY || (vr == VR::INVALID && refvr == VR::INVALID) );
     //std::ostringstream os;
     std::string s;
     switch(refvr)
@@ -642,7 +642,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
           }
         else if ( sqf )
           {
-          assert( t == Tag(0x7fe0,0x0010) );
+          gdcm_assert( t == Tag(0x7fe0,0x0010) );
           //os << *sqf;
           }
         else if ( sqi )
@@ -653,15 +653,15 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
           }
         else
           {
-          assert( !sqi && !sqf );
-          assert( de.IsEmpty() );
+          gdcm_assert( !sqi && !sqf );
+          gdcm_assert( de.IsEmpty() );
           os << GDCM_TERMINAL_VT100_INVERSE << "(no value)" << GDCM_TERMINAL_VT100_NORMAL;
           }
         }
       break;
     case VR::US_SS:
       // impossible...
-      assert( refvr != VR::US_SS );
+      gdcm_assert( refvr != VR::US_SS );
       break;
     case VR::SQ:
       if( !sqi /*!de.GetSequenceOfItems()*/ && !de.IsEmpty() && de.GetValue().GetLength() )
@@ -709,8 +709,8 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
           }
         else
           {
-          assert( !sqi && !sqf );
-          assert( de.IsEmpty() );
+          gdcm_assert( !sqi && !sqf );
+          gdcm_assert( de.IsEmpty() );
           os << GDCM_TERMINAL_VT100_INVERSE << "(no value)" << GDCM_TERMINAL_VT100_NORMAL;
           }
         }
@@ -742,7 +742,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     case VR::VR_VM1:
     case VR::VRALL:
     case VR::VR_END:
-      assert(0);
+      gdcm_assert(0);
       break;
       }
     os << s;
@@ -788,8 +788,8 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
   VM guessvm = VM::VM0;
   if( refvr & VR::VRASCII )
     {
-    assert( refvr != VR::INVALID );
-    assert( refvr & VR::VRASCII );
+    gdcm_assert( refvr != VR::INVALID );
+    gdcm_assert( refvr & VR::VRASCII );
     if( bv )
       {
       size_t count = VM::GetNumberOfElementsFromArray(bv->GetPointer(), bv->GetLength());
@@ -798,8 +798,8 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     }
   else if( refvr & VR::VRBINARY )
     {
-    assert( refvr != VR::INVALID );
-    assert( refvr & VR::VRBINARY );
+    gdcm_assert( refvr != VR::INVALID );
+    gdcm_assert( refvr & VR::VRBINARY );
     if( refvr & VR::OB_OW || refvr == VR::OD || refvr == VR::OF || refvr == VR::SQ )
       {
       guessvm = VM::VM1;
@@ -816,7 +816,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
     else
       {
       if( de.IsEmpty() ) guessvm = VM::VM0;
-      else assert( 0 && "Impossible" );
+      else gdcm_assert( 0 && "Impossible" );
       }
     }
   else if( refvr == VR::INVALID )
@@ -827,7 +827,7 @@ VR Printer::PrintDataElement(std::ostringstream &os, const Dicts &dicts, const D
   else
     {
     // Burst into flames !
-    assert( 0 && "Impossible happen" );
+    gdcm_assert( 0 && "Impossible happen" );
     }
   if( !vm.Compatible( guessvm ) )
     {
@@ -939,7 +939,7 @@ void Printer::PrintDataSet(const DataSet &ds, std::ostream &out, std::string con
       const SequenceOfItems *sqi = de.GetSequenceOfItems();
       if( sqi ) // empty SQ ?
       {
-      assert( sqi );
+      gdcm_assert( sqi );
       PrintSQ(sqi, os, indent);
       }
       else

--- a/Source/MediaStorageAndFileFormat/gdcmRAWCodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmRAWCodec.cxx
@@ -62,7 +62,7 @@ bool RAWCodec::CanDecode(TransferSyntax const &ts) const
 bool RAWCodec::Code(DataElement const &in, DataElement &out)
 {
   out = in;
-  //assert(0);
+  //gdcm_assert(0);
   return true;
 }
 
@@ -77,14 +77,14 @@ bool RAWCodec::DecodeBytes(const char* inBytes, size_t inBufferLength,
     GetPixelFormat().GetBitsAllocated() != 12 &&
     !NeedOverlayCleanup )
     {
-    assert( !NeedOverlayCleanup );
-    assert( PI != PhotometricInterpretation::YBR_PARTIAL_422 );
-    assert( PI != PhotometricInterpretation::YBR_PARTIAL_420 );
-    assert( PI != PhotometricInterpretation::YBR_ICT );
-    assert( this->GetPixelFormat() != PixelFormat::UINT12 );
-    assert( this->GetPixelFormat() != PixelFormat::INT12 );
+    gdcm_assert( !NeedOverlayCleanup );
+    gdcm_assert( PI != PhotometricInterpretation::YBR_PARTIAL_422 );
+    gdcm_assert( PI != PhotometricInterpretation::YBR_PARTIAL_420 );
+    gdcm_assert( PI != PhotometricInterpretation::YBR_ICT );
+    gdcm_assert( this->GetPixelFormat() != PixelFormat::UINT12 );
+    gdcm_assert( this->GetPixelFormat() != PixelFormat::INT12 );
     // DermaColorLossLess.dcm
-    //assert(inBufferLength == inOutBufferLength || inBufferLength == inOutBufferLength + 1);
+    //gdcm_assert(inBufferLength == inOutBufferLength || inBufferLength == inOutBufferLength + 1);
     // What if the user request a subportion of the image:
     // this happen in the case of MOSAIC image, where we are only interested in the non-zero
     // pixel of the tiled image.
@@ -102,13 +102,13 @@ bool RAWCodec::DecodeBytes(const char* inBytes, size_t inBufferLength,
     return true;
     }
   // else
-  assert( inBytes );
-  assert( outBytes );
+  gdcm_assert( inBytes );
+  gdcm_assert( outBytes );
   std::stringstream is;
   is.write(inBytes, inBufferLength);
   std::stringstream os;
   bool r = DecodeByStreams(is, os);
-  assert( r );
+  gdcm_assert( r );
   if(!r) return false;
 
   std::string str = os.str();
@@ -119,9 +119,9 @@ bool RAWCodec::DecodeBytes(const char* inBytes, size_t inBufferLength,
     size_t len = str.size() * 16 / 12;
     char * copy = new char[len];
     bool b = Unpacker12Bits::Unpack(copy, str.data(), str.size() ); (void)b;
-    assert( b );
+    gdcm_assert(b);
     assert (len == inOutBufferLength);
-    assert(inOutBufferLength == len);
+    gdcm_assert(inOutBufferLength == len);
     memcpy(outBytes, copy, len);
 
     delete[] copy;
@@ -156,20 +156,20 @@ bool RAWCodec::Decode(DataElement const &in, DataElement &out)
     GetPixelFormat().GetBitsAllocated() != 12 &&
     !NeedOverlayCleanup )
     {
-    assert( this->GetPixelFormat() != PixelFormat::UINT12 );
-    assert( this->GetPixelFormat() != PixelFormat::INT12 );
+    gdcm_assert( this->GetPixelFormat() != PixelFormat::UINT12 );
+    gdcm_assert( this->GetPixelFormat() != PixelFormat::INT12 );
     out = in;
     return true;
     }
   // else
   const ByteValue *bv = in.GetByteValue();
-  assert( bv );
+  gdcm_assert( bv );
   std::stringstream is;
   is.write(bv->GetPointer(), bv->GetLength());
   std::stringstream os;
   bool r = DecodeByStreams(is, os);
   if(!r) return false;
-  assert( r );
+  gdcm_assert( r );
 
   std::string str = os.str();
   //std::string::size_type check = str.size();
@@ -182,7 +182,7 @@ bool RAWCodec::Decode(DataElement const &in, DataElement &out)
     size_t len = str.size() * 16 / 12;
     char * copy = new char[len];//why use an array, and not a vector?
     bool b = Unpacker12Bits::Unpack(copy, str.data(), str.size() );
-    assert( b );
+    gdcm_assert(b);
     (void)b;
     VL::Type lenSize = (VL::Type)len;
     out.SetByteValue( copy, lenSize );

--- a/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
@@ -54,8 +54,8 @@ public:
     {
     // read Header (64 bytes)
     is.read((char*)(&Header), sizeof(uint32_t)*16);
-    assert( sizeof(uint32_t)*16 == 64 );
-    assert( sizeof(RLEHeader) == 64 );
+    gdcm_assert( sizeof(uint32_t)*16 == 64 );
+    gdcm_assert( sizeof(RLEHeader) == 64 );
     SwapperNoOp::SwapArray((uint32_t*)&Header,16);
     uint32_t numSegments = Header.NumSegments;
     if( numSegments >= 1 )
@@ -125,7 +125,7 @@ separately and not cross a row boundary.
 */
 inline int count_identical_bytes(const char *start, size_t len)
 {
-  assert( len );
+  gdcm_assert( len );
 #if 0
   const char *p = start + 1;
   const unsigned int cmin = std::min(128u,len);
@@ -144,8 +144,8 @@ inline int count_identical_bytes(const char *start, size_t len)
   //std::cerr << "count/len:" << count << "," << len << std::endl;
     ++count;
     }
-  assert( /*2 <= count && */ count <= 128 ); // remove post condition as it will be our return error code
-  assert( count >= 1 );
+  gdcm_assert( /*2 <= count && */ count <= 128 ); // remove post condition as it will be our return error code
+  gdcm_assert( count >= 1 );
   return count;
 #endif
 }
@@ -158,7 +158,7 @@ inline int count_nonrepetitive_bytes(const char *start, size_t len)
 Note: It is common to encode a 2-byte repeat run as a Replicate Run except when preceded and followed by
 a Literal Run, in which case it's best to merge the three runs into a Literal Run.
 */
-  assert( len );
+  gdcm_assert( len );
 #if 0
   const char *prev = start;
   const char *p = start + 1;
@@ -211,7 +211,7 @@ a Literal Run, in which case it's best to merge the three runs into a Literal Ru
     }
 #endif
 #endif
-  assert( 1 <= count && count <= 128 );
+  gdcm_assert( 1 <= count && count <= 128 );
   return count;
 #endif
 }
@@ -224,8 +224,8 @@ ptrdiff_t rle_encode(char *output, size_t outputlength, const char *input, size_
   size_t length = inputlength;
   while( pin != input + inputlength )
     {
-    assert( length <= inputlength );
-    assert( pin <= input + inputlength );
+    gdcm_assert( length <= inputlength );
+    gdcm_assert( pin <= input + inputlength );
     int count = count_identical_bytes(pin, length);
     if( count > 1 ) /* or 2 ? */
       {
@@ -234,8 +234,8 @@ ptrdiff_t rle_encode(char *output, size_t outputlength, const char *input, size_
       // Test first we are allowed to write two bytes:
       if( pout + 1 + 1 > output + outputlength ) return -1;
       *pout = (char)(-count + 1);
-      assert( /**pout != -128 &&*/ 1 - *pout == count );
-      assert( *pout <= -1 && *pout >= -127 );
+      gdcm_assert( /**pout != -128 &&*/ 1 - *pout == count );
+      gdcm_assert( *pout <= -1 && *pout >= -127 );
       ++pout;
       *pout = *pin;
       ++pout;
@@ -248,8 +248,8 @@ ptrdiff_t rle_encode(char *output, size_t outputlength, const char *input, size_
       // first test we are allowed to write 1 + count bytes in the output buffer:
       if( pout + count + 1 > output + outputlength ) return -1;
       *pout = (char)(count - 1);
-      assert( *pout != -128 && *pout+1 == count );
-      assert( *pout >= 0 );
+      gdcm_assert( *pout != -128 && *pout+1 == count );
+      gdcm_assert( *pout >= 0 );
       ++pout;
       memcpy(pout, pin, count);
       pout += count;
@@ -257,7 +257,7 @@ ptrdiff_t rle_encode(char *output, size_t outputlength, const char *input, size_
     // count byte where read, move pin to new position:
     pin += count;
     // compute remaining length:
-    assert( count <= (int)length );
+    gdcm_assert( count <= (int)length );
     length -= count;
     }
   return pout - output;
@@ -270,8 +270,8 @@ bool DoInvertPlanarConfiguration(T *output, const T *input, uint32_t inputlength
   const T *g = input+1;
   const T *b = input+2;
   uint32_t length = (inputlength / 3) * 3; // remove the 0 padding
-  assert( length == inputlength || length == inputlength - 1 );
-  assert( length % 3 == 0 );
+  gdcm_assert( length == inputlength || length == inputlength - 1 );
+  gdcm_assert( length % 3 == 0 );
   uint32_t plane_length = length / 3;
   T *pout = output;
   // copy red plane:
@@ -280,23 +280,23 @@ bool DoInvertPlanarConfiguration(T *output, const T *input, uint32_t inputlength
     *pout++ = *r;
     r += 3;
     }
-  assert( r == input + length );
+  gdcm_assert( r == input + length );
   // copy green plane:
-  assert( pout == output + plane_length );
+  gdcm_assert( pout == output + plane_length );
   while( pout != output + plane_length * 2 )
     {
     *pout++ = *g;
     g += 3;
     }
-  assert( g == input + length + 1);
+  gdcm_assert( g == input + length + 1);
   // copy blue plane:
-  assert( pout == output + 2*plane_length );
+  gdcm_assert( pout == output + 2*plane_length );
   while( pout != output + plane_length * 3 )
     {
     *pout++ = *b;
     b += 3;
     }
-  assert( b == input + length + 2);
+  gdcm_assert( b == input + length + 2);
   assert ( pout == output + length );
   return true;
 }
@@ -321,7 +321,7 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
   //sq->GetTable().SetByteValue( dummy, sizeof(dummy) );
 
   const ByteValue *bv = in.GetByteValue();
-  assert( bv );
+  gdcm_assert( bv );
   const char *input = bv->GetPointer();
   unsigned long bvl = bv->GetLength();
   unsigned long image_len = bvl / dims[2];
@@ -372,11 +372,11 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
     MaxNumSegments *= 3;
     }
 
-  assert( GetPixelFormat().GetBitsAllocated() == 8 || GetPixelFormat().GetBitsAllocated() == 16
+  gdcm_assert( GetPixelFormat().GetBitsAllocated() == 8 || GetPixelFormat().GetBitsAllocated() == 16
     || GetPixelFormat().GetBitsAllocated() == 32 );
   if( GetPixelFormat().GetSamplesPerPixel() == 3 )
     {
-    assert( MaxNumSegments % 3 == 0 );
+    gdcm_assert( MaxNumSegments % 3 == 0 );
     }
 
   RLEHeader header = { static_cast<uint32_t> ( MaxNumSegments ), { 64 } };
@@ -402,7 +402,7 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
         }
       else /* ( GetPixelFormat().GetBitsAllocated() == 32 ) */
         {
-        assert( GetPixelFormat().GetBitsAllocated() == 32 );
+        gdcm_assert( GetPixelFormat().GetBitsAllocated() == 32 );
         DoInvertPlanarConfiguration<int32_t>(
           (int32_t*)(void*)bufferrgb,
           (const int32_t*)(const void*)ptr_img,
@@ -413,15 +413,15 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
       }
     if( GetPixelFormat().GetBitsAllocated() == 32 )
       {
-      assert( !(image_len % 4) );
-      //assert( image_len % 3 == 0 );
+      gdcm_assert( !(image_len % 4) );
+      //gdcm_assert( image_len % 3 == 0 );
       unsigned int div = GetPixelFormat().GetSamplesPerPixel();
       for(unsigned int j = 0; j < div; ++j)
         {
         unsigned long iimage_len = image_len / div;
         char *ibuffer = buffer + j * iimage_len;
         const char *iptr_img = ptr_img + j * iimage_len;
-        assert( iimage_len % 4 == 0 );
+        gdcm_assert( iimage_len % 4 == 0 );
         for(unsigned long i = 0; i < iimage_len/4; ++i)
           {
 #ifdef GDCM_WORDS_BIGENDIAN
@@ -459,15 +459,15 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
       }
     else if( GetPixelFormat().GetBitsAllocated() == 16 )
       {
-      assert( !(image_len % 2) );
-      //assert( image_len % 3 == 0 );
+      gdcm_assert( !(image_len % 2) );
+      //gdcm_assert( image_len % 3 == 0 );
       unsigned int div = GetPixelFormat().GetSamplesPerPixel();
       for(unsigned int j = 0; j < div; ++j)
         {
         unsigned long iimage_len = image_len / div;
         char *ibuffer = buffer + j * iimage_len;
         const char *iptr_img = ptr_img + j * iimage_len;
-        assert( iimage_len % 2 == 0 );
+        gdcm_assert( iimage_len % 2 == 0 );
         for(unsigned long i = 0; i < iimage_len/2; ++i)
           {
 #ifdef GDCM_WORDS_BIGENDIAN
@@ -487,23 +487,23 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
         }
       ptr_img = buffer;
       }
-    assert( image_len % MaxNumSegments == 0 );
+    gdcm_assert( image_len % MaxNumSegments == 0 );
     const size_t input_seg_length = image_len / MaxNumSegments;
     std::string datastr;
     for(unsigned int seg = 0; seg < MaxNumSegments; ++seg )
       {
       size_t partition = input_seg_length;
       const char *ptr = ptr_img + seg * input_seg_length;
-      assert( ptr < ptr_img + image_len );
+      gdcm_assert( ptr < ptr_img + image_len );
       if( seg == MaxNumSegments - 1 )
         {
         partition += image_len % MaxNumSegments;
-        assert( (MaxNumSegments-1) * input_seg_length + partition == (size_t)image_len );
+        gdcm_assert( (MaxNumSegments-1) * input_seg_length + partition == (size_t)image_len );
         }
-      assert( partition == input_seg_length );
+      gdcm_assert( partition == input_seg_length );
 
       std::stringstream data;
-      assert( partition % dims[1] == 0 );
+      gdcm_assert( partition % dims[1] == 0 );
       size_t length = 0;
       // Do not cross row boundary:
       for(unsigned int y = 0; y < dims[1]; ++y)
@@ -516,14 +516,14 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
           delete[] bufferrgb;
           return false;
           }
-        assert( llength );
+        gdcm_assert( llength );
         data.write((char*)outbuf, llength);
         length += llength;
         }
       // update header
       header.Offset[1+seg] = (uint32_t)(header.Offset[seg] + length);
 
-      assert( data.str().size() == length );
+      gdcm_assert( data.str().size() == length );
       datastr += data.str();
       }
     header.Offset[MaxNumSegments] = 0;
@@ -531,7 +531,7 @@ bool RLECodec::Code(DataElement const &in, DataElement &out)
     //header.Print( std::cout );
     os.write((char*)&header,sizeof(header));
     std::string str = os.str() + datastr;
-    assert( !str.empty() );
+    gdcm_assert( !str.empty() );
     Fragment frag;
     //frag.SetTag( itemStart );
     VL::Type strSize = (VL::Type)str.size();
@@ -574,7 +574,7 @@ size_t RLECodec::DecodeFragment(Fragment const & frag, char *buffer, size_t llen
 #if !defined(NDEBUG)
   const unsigned int * const dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat();
-  assert( llen == dimensions[0] * dimensions[1] * pf.GetPixelSize() );
+  gdcm_assert( llen == dimensions[0] * dimensions[1] * pf.GetPixelSize() );
 #endif
   bool r = DecodeByStreams(is, os);
   if( !r ) return 0;
@@ -587,7 +587,7 @@ size_t RLECodec::DecodeFragment(Fragment const & frag, char *buffer, size_t llen
     // which is discarded
     std::streamoff check = bv.GetLength() - p;
     // check == 2 for gdcmDataExtra/gdcmSampleData/US_DataSet/GE_US/2929J686-breaker
-    //assert( check == 0 || check == 1 || check == 2 );
+    //gdcm_assert( check == 0 || check == 1 || check == 2 );
     if( check ) { gdcmDebugMacro( "tiny offset detected in between RLE segments: " << check ); }
     }
   else
@@ -622,7 +622,7 @@ bool RLECodec::Decode(DataElement const &in, DataElement &out)
     }
     std::string str = os.str();
     std::string::size_type check = str.size();
-    assert( check == len );
+    gdcm_assert( check == len );
     VL::Type checkCast = (VL::Type)check;
     out.SetByteValue( str.data(), checkCast );
     return true;
@@ -644,7 +644,7 @@ bool RLECodec::Decode(DataElement const &in, DataElement &out)
     }
     char *buffer = new char[len];
     const std::size_t llen = len / nframes;
-    // assert( GetNumberOfDimensions() == 2
+    // gdcm_assert( GetNumberOfDimensions() == 2
     //      || GetDimension(2) == sf->GetNumberOfFragments() );
     bool corruption = false;
     for(unsigned int i = 0; i < nframes; ++i)
@@ -659,7 +659,7 @@ bool RLECodec::Decode(DataElement const &in, DataElement &out)
       pos += (unsigned long)llen;
       }
     if( !corruption )
-      assert( pos == len );
+      gdcm_assert( pos == len );
     out.SetByteValue( buffer, (uint32_t)len );
     delete[] buffer;
     return !corruption;
@@ -682,9 +682,9 @@ bool RLECodec::DecodeExtent(
 
   const unsigned int * dimensions = this->GetDimensions();
   const PixelFormat & pf = this->GetPixelFormat();
-  assert( pf.GetBitsAllocated() % 8 == 0 );
-  assert( pf != PixelFormat::SINGLEBIT );
-  assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
+  gdcm_assert( pf.GetBitsAllocated() % 8 == 0 );
+  gdcm_assert( pf != PixelFormat::SINGLEBIT );
+  gdcm_assert( pf != PixelFormat::UINT12 && pf != PixelFormat::INT12 );
 
   // skip
   std::stringstream os;
@@ -703,7 +703,7 @@ bool RLECodec::DecodeExtent(
     SetLength( dimensions[0] * dimensions[1] * pf.GetPixelSize() );
     const bool r = DecodeByStreams(is, os); (void)r;
     if( !r ) return false;
-    assert( r );
+    gdcm_assert( r );
 
     // handle DICOM padding
     std::streampos end = is.tellg();
@@ -712,12 +712,12 @@ bool RLECodec::DecodeExtent(
       {
       // Special handling for ALOKA_SSD-8-MONO2-RLE-SQ.dcm
       size_t diff = numberOfReadBytes - frag.GetVL();
-      assert( diff == 1 );
+      gdcm_assert( diff == 1 );
       os.seekp( 0 - (int)diff, std::ios::cur );
       os.put( 0 );
       end = (size_t)end - 1;
       }
-    assert( end - start == frag.GetVL() || (size_t)(end - start) + 1 == frag.GetVL() );
+    gdcm_assert( end - start == frag.GetVL() || (size_t)(end - start) + 1 == frag.GetVL() );
     // sync is (rle16loo.dcm)
     if( (end - start) % 2 == 1 )
       {
@@ -726,7 +726,7 @@ bool RLECodec::DecodeExtent(
     } // for each z
 
   os.seekg(0, std::ios::beg );
-  assert( os.good() );
+  gdcm_assert( os.good() );
   std::istream *theStream = &os;
 
   unsigned int rowsize = xmax - xmin + 1;
@@ -772,9 +772,9 @@ bool RLECodec::DecodeByStreams(std::istream &is, std::ostream &os)
   unsigned long numSegments = frame.Header.NumSegments;
 
   unsigned long length = Length;
-  assert( length );
+  gdcm_assert( length );
   // Special case:
-  assert( GetPixelFormat().GetBitsAllocated() == 32 ||
+  gdcm_assert( GetPixelFormat().GetBitsAllocated() == 32 ||
           GetPixelFormat().GetBitsAllocated() == 16 ||
           GetPixelFormat().GetBitsAllocated() == 8 );
   if( GetPixelFormat().GetBitsAllocated() > 8 )
@@ -782,7 +782,7 @@ bool RLECodec::DecodeByStreams(std::istream &is, std::ostream &os)
     RequestPaddedCompositePixelCode = true;
     }
 
-  assert( GetPixelFormat().GetSamplesPerPixel() == 3 || GetPixelFormat().GetSamplesPerPixel() == 1 );
+  gdcm_assert( GetPixelFormat().GetSamplesPerPixel() == 3 || GetPixelFormat().GetSamplesPerPixel() == 1 );
   // A footnote:
   // RLE *by definition* with more than one component will have applied the
   // Planar Configuration because it simply does not make sense to do it
@@ -810,7 +810,7 @@ bool RLECodec::DecodeByStreams(std::istream &is, std::ostream &os)
       //   " when it should says: " << pos << std::endl );
       std::streamoff check = frame.Header.Offset[i] - pos;//should it be a streampos or a uint32? mmr
       // check == 2 for gdcmDataExtra/gdcmSampleData/US_DataSet/GE_US/2929J686-breaker
-      //assert( check == 1 || check == 2);
+      //gdcm_assert( check == 1 || check == 2);
       (void)check; //warning removal
       is.seekg( frame.Header.Offset[i] + start, std::ios::beg );
       }
@@ -832,7 +832,7 @@ bool RLECodec::DecodeByStreams(std::istream &is, std::ostream &os)
       if( byte >= 0 /*&& byte <= 127*/ ) /* 2nd is always true */
         {
         is.read( dummy_buffer, byte+1 );
-        //assert( is.good() ); // impossible because ALOKA_SSD-8-MONO2-RLE-SQ.dc
+        //gdcm_assert( is.good() ); // impossible because ALOKA_SSD-8-MONO2-RLE-SQ.dc
         numberOfReadBytes += byte+1;
         numOutBytes += byte+ 1;
         tmpos.write( dummy_buffer, byte+1 );
@@ -848,9 +848,9 @@ bool RLECodec::DecodeByStreams(std::istream &is, std::ostream &os)
         }
       else /* byte == -128 */
         {
-        assert( byte == -128 );
+        gdcm_assert( byte == -128 );
         }
-      //assert( numberOfReadBytes + frame.Header.Offset[i] - is.tellg() + start == 0);
+      //gdcm_assert( numberOfReadBytes + frame.Header.Offset[i] - is.tellg() + start == 0);
       }
     if( numOutBytes != length ) return false;
     }
@@ -912,23 +912,23 @@ public:
     {
     memcpy( out, cur, l );
     cur += l;
-    assert( cur <= ptr + len );
+    gdcm_assert( cur <= ptr + len );
     return l;
     }
   streampos_t tell() override
     {
-    assert( cur <= ptr + len );
+    gdcm_assert( cur <= ptr + len );
     return (streampos_t)(cur - ptr);
     }
   bool seek(streampos_t pos) override
     {
     cur = ptr + pos;
-    assert( cur <= ptr + len && cur >= ptr );
+    gdcm_assert( cur <= ptr + len && cur >= ptr );
     return true;
     }
   bool eof() override
     {
-    assert( cur <= ptr + len );
+    gdcm_assert( cur <= ptr + len );
     return cur == ptr + len;
     }
   memsrc * clone() override
@@ -945,7 +945,7 @@ private:
 bool RLECodec::AppendRowEncode( std::ostream & os, const char * data, size_t datalen)
 {
   (void)os; (void)data; (void)datalen;
-  assert(0);
+  gdcm_assert(0);
   return false;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmScanner.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmScanner.cxx
@@ -43,7 +43,7 @@ void Scanner::ClearSkipTags()
 void Scanner::AddSkipTag( Tag const & t )
 {
   SkipTags.insert( t );
-  assert(0); // This is NOT implemented for now
+  gdcm_assert(0); // This is NOT implemented for now
 }
 
 // Warning: API is passing a public tag (no way to specify private tag)
@@ -64,7 +64,7 @@ void Scanner::AddPrivateTag( PrivateTag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PrivateTags.insert( t );
     }
@@ -86,7 +86,7 @@ void Scanner::AddTag( Tag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     Tags.insert( t );
     }
@@ -131,7 +131,7 @@ bool Scanner::Scan( Directory::FilenamesType const & filenames )
       {
       Reader reader;
       const char *filename = it->c_str();
-      assert( filename );
+      gdcm_assert( filename );
       reader.SetFileName( filename );
       bool read = false;
       try
@@ -183,7 +183,7 @@ void Scanner::Print( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     bool b = IsKey(filename);
     const char *comment = !b ? "could not be read" : "could be read";
     os << "Filename: " << filename << " (" << comment << ")\n";
@@ -223,7 +223,7 @@ void Scanner::PrintTable( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     os << '"' << filename << '"' << "\t";
     TagsType::const_iterator tag = Tags.begin();
     const TagToValue &mapping = GetMapping(filename);
@@ -245,8 +245,8 @@ void Scanner::PrintTable( std::ostream & os ) const
 
 Scanner::TagToValue const & Scanner::GetMapping(const char *filename) const
 {
-//  assert( Mappings.find(filename) != Mappings.end() );
-  assert( filename && *filename );
+//  gdcm_assert( Mappings.find(filename) != Mappings.end() );
+  gdcm_assert( filename && *filename );
   if( Mappings.find(filename) != Mappings.end() )
     return Mappings.find(filename)->second;
   return Mappings.find("")->second; // dummy file could not be found
@@ -264,7 +264,7 @@ bool Scanner::IsKey( const char * filename ) const
     }
 */
   // Look for the file in Mappings table:
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   MappingType::const_iterator it2 = Mappings.find(filename);
   return it2 != Mappings.end();
 }
@@ -283,7 +283,7 @@ Directory::FilenamesType Scanner::GetKeys() const
       keys.push_back( filename );
       }
     }
-  assert( keys.size() <= Filenames.size() );
+  gdcm_assert( keys.size() <= Filenames.size() );
   return keys;
 }
 
@@ -291,7 +291,7 @@ Directory::FilenamesType Scanner::GetKeys() const
 const char* Scanner::GetValue(const char *filename, Tag const &t) const
 {
   // \precondition
-  assert( Tags.find( t ) != Tags.end() );
+  gdcm_assert( Tags.find( t ) != Tags.end() );
   TagToValue const &ftv = GetMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -393,7 +393,7 @@ Directory::FilenamesType Scanner::GetOrderedValues(Tag const &t) const
 
 void Scanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   TagToValue &mapping = Mappings[filename];
   const File& file = sf.GetFile();
 
@@ -409,7 +409,7 @@ void Scanner::ProcessPublicTag(StringFilter &sf, const char *filename)
         //std::string s;
         DataElement const & de = header.GetDataElement( *tag );
         //const ByteValue *bv = de.GetByteValue();
-        ////assert( VR::IsASCII( vr ) );
+        ////gdcm_assert( VR::IsASCII( vr ) );
         //if( bv ) // Hum, should I store an empty string or what ?
         //  {
         //  s = std::string( bv->GetPointer(), bv->GetLength() );
@@ -419,9 +419,9 @@ void Scanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           TagToValue::value_type(*tag, value));
         }
@@ -433,7 +433,7 @@ void Scanner::ProcessPublicTag(StringFilter &sf, const char *filename)
         //std::string s;
         DataElement const & de = ds.GetDataElement( *tag );
         //const ByteValue *bv = de.GetByteValue();
-        ////assert( VR::IsASCII( vr ) );
+        ////gdcm_assert( VR::IsASCII( vr ) );
         //if( bv ) // Hum, should I store an empty string or what ?
         //  {
         //  s = std::string( bv->GetPointer(), bv->GetLength() );
@@ -443,9 +443,9 @@ void Scanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           TagToValue::value_type(*tag, value));
         }

--- a/Source/MediaStorageAndFileFormat/gdcmScanner.h
+++ b/Source/MediaStorageAndFileFormat/gdcmScanner.h
@@ -119,7 +119,7 @@ public:
     {
     bool operator()(const char* s1, const char* s2) const
       {
-      assert( s1 && s2 );
+      gdcm_assert( s1 && s2 );
       return strcmp(s1, s2) < 0;
       }
     };

--- a/Source/MediaStorageAndFileFormat/gdcmScanner2.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmScanner2.cxx
@@ -67,7 +67,7 @@ bool Scanner2::AddPrivateTag( PrivateTag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PrivateTags.insert( t );
     }
@@ -92,7 +92,7 @@ bool Scanner2::AddPublicTag( Tag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PublicTags.insert( t );
     }
@@ -142,7 +142,7 @@ bool Scanner2::Scan( Directory::FilenamesType const & filenames )
       {
       Reader reader;
       const char *filename = it->c_str();
-      assert( filename );
+      gdcm_assert( filename );
       reader.SetFileName( filename );
       bool read = false;
       try
@@ -194,7 +194,7 @@ void Scanner2::Print( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     bool b = IsKey(filename);
     const char *comment = !b ? "could not be read" : "could be read";
     os << "Filename: " << filename << " (" << comment << ")\n";
@@ -270,7 +270,7 @@ void Scanner2::PrintTable( std::ostream & os, bool header ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     os << '"' << filename << '"' << "\t";
     {
     PublicTagsType::const_iterator tag = PublicTags.begin();
@@ -310,7 +310,7 @@ void Scanner2::PrintTable( std::ostream & os, bool header ) const
 
 Scanner2::PublicTagToValue const & Scanner2::GetPublicMapping(const char *filename) const
 {
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   if( PublicMappings.find(filename) != PublicMappings.end() )
     return PublicMappings.find(filename)->second;
   return PublicMappings.find("")->second; // dummy file could not be found
@@ -318,7 +318,7 @@ Scanner2::PublicTagToValue const & Scanner2::GetPublicMapping(const char *filena
 
 Scanner2::PrivateTagToValue const & Scanner2::GetPrivateMapping(const char *filename) const
 {
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   if( PrivateMappings.find(filename) != PrivateMappings.end() )
     return PrivateMappings.find(filename)->second;
   return PrivateMappings.find("")->second; // dummy file could not be found
@@ -327,7 +327,7 @@ Scanner2::PrivateTagToValue const & Scanner2::GetPrivateMapping(const char *file
 bool Scanner2::IsKey( const char * filename ) const
 {
   // Look for the file in Mappings tables:
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   PublicMappingType::const_iterator it2 = PublicMappings.find(filename);
   PrivateMappingType::const_iterator it3 = PrivateMappings.find(filename);
   return it2 != PublicMappings.end() || it3 != PrivateMappings.end();
@@ -346,14 +346,14 @@ Directory::FilenamesType Scanner2::GetKeys() const
       keys.push_back( filename );
       }
     }
-  assert( keys.size() <= Filenames.size() );
+  gdcm_assert( keys.size() <= Filenames.size() );
   return keys;
 }
 
 const char* Scanner2::GetPublicValue(const char *filename, Tag const &t) const
 {
   // \precondition
-  assert( PublicTags.find( t ) != PublicTags.end() );
+  gdcm_assert( PublicTags.find( t ) != PublicTags.end() );
   PublicTagToValue const &ftv = GetPublicMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -365,7 +365,7 @@ const char* Scanner2::GetPublicValue(const char *filename, Tag const &t) const
 const char* Scanner2::GetPrivateValue(const char *filename, PrivateTag const &t) const
 {
   // \precondition
-  assert( PrivateTags.find( t ) != PrivateTags.end() );
+  gdcm_assert( PrivateTags.find( t ) != PrivateTags.end() );
   PrivateTagToValue const &ftv = GetPrivateMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -540,7 +540,7 @@ Directory::FilenamesType Scanner2::GetPrivateOrderedValues(PrivateTag const &pt)
 
 void Scanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   PublicTagToValue &mapping = PublicMappings[filename];
   const File& file = sf.GetFile();
 
@@ -558,9 +558,9 @@ void Scanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           PublicTagToValue::value_type(*tag, value));
         }
@@ -574,9 +574,9 @@ void Scanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           PublicTagToValue::value_type(*tag, value));
         }
@@ -586,7 +586,7 @@ void Scanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
 void Scanner2::ProcessPrivateTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   PrivateTagToValue &mapping = PrivateMappings[filename];
   const File& file = sf.GetFile();
   const DataSet & ds = file.GetDataSet();
@@ -600,9 +600,9 @@ void Scanner2::ProcessPrivateTag(StringFilter &sf, const char *filename)
 
       // Store the potentially new value:
       Values.insert( s );
-      assert( Values.find( s ) != Values.end() );
+      gdcm_assert( Values.find( s ) != Values.end() );
       const char *value = Values.find( s )->c_str();
-      assert( value );
+      gdcm_assert( value );
       mapping.insert(
         PrivateTagToValue::value_type(*ptag, value));
       }

--- a/Source/MediaStorageAndFileFormat/gdcmScanner2.h
+++ b/Source/MediaStorageAndFileFormat/gdcmScanner2.h
@@ -128,7 +128,7 @@ public:
     {
     bool operator()(const char* s1, const char* s2) const
       {
-      assert( s1 && s2 );
+      gdcm_assert( s1 && s2 );
       return strcmp(s1, s2) < 0;
       }
     };

--- a/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegment.cxx
@@ -29,7 +29,7 @@ static const char * ALGOTypeStrings[] = {
 
 const char * Segment::GetALGOTypeString(ALGOType type)
 {
-  assert( type <= ALGOType_END );
+  gdcm_assert( type <= ALGOType_END );
   return ALGOTypeStrings[(int)type];
 }
 
@@ -201,7 +201,7 @@ Segment::ALGOType Segment::GetSegmentAlgorithmType() const
 
 void Segment::SetSegmentAlgorithmType(Segment::ALGOType type)
 {
-  assert(type <= ALGOType_END);
+  gdcm_assert(type <= ALGOType_END);
   SegmentAlgorithmType = type;
 }
 
@@ -252,7 +252,7 @@ Segment::SurfaceVector & Segment::GetSurfaces()
 
 SmartPointer< Surface > Segment::GetSurface(const unsigned int idx /*= 0*/) const
 {
-  assert( idx < SurfaceCount );
+  gdcm_assert( idx < SurfaceCount );
   return Surfaces[idx];
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmSegmentWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegmentWriter.cxx
@@ -45,7 +45,7 @@ SegmentWriter::SegmentVector & SegmentWriter::GetSegments()
 
 SmartPointer< Segment > SegmentWriter::GetSegment(const unsigned int idx /*= 0*/) const
 {
-  assert( idx < Segments.size() );
+  gdcm_assert( idx < Segments.size() );
   return Segments[idx];
 }
 
@@ -159,7 +159,7 @@ bool SegmentWriter::PrepareWrite()
   {
     // Fill the Segment Sequence
     const unsigned int              numberOfSegments  = this->GetNumberOfSegments();
-    assert( numberOfSegments );
+    gdcm_assert( numberOfSegments );
     const size_t nbItems           = segmentsSQ->GetNumberOfItems();
     if (nbItems < numberOfSegments)
     {
@@ -182,7 +182,7 @@ bool SegmentWriter::PrepareWrite()
   for (; it0 != it0End; it0++)
   {
     SmartPointer< Segment > segment = *it0;
-    assert( segment );
+    gdcm_assert( segment );
 
     Item &    segmentItem = segmentsSQ->GetItem(itemNumber);
     DataSet & segmentDS   = segmentItem.GetNestedDataSet();
@@ -389,7 +389,7 @@ bool SegmentWriter::Write()
     return false;
   }
 
-  assert( Stream );
+  gdcm_assert( Stream );
   if( !Writer::Write() )
   {
     return false;

--- a/Source/MediaStorageAndFileFormat/gdcmSegmentedPaletteColorLookupTable.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSegmentedPaletteColorLookupTable.cxx
@@ -124,7 +124,7 @@ namespace gdcm
             EntryType nNumCopies = *(this->_first + 1);
             typename SegmentMap::const_iterator ppSeg = ppHeadSeg;
             while ( std::distance(ppHeadSeg, ppSeg) <nNumCopies ) {
-                assert( ppSeg != instances.end() );
+                gdcm_assert( ppSeg != instances.end() );
                 ppSeg->second->Expand(instances, expanded);
                 ++ppSeg;
             }
@@ -181,7 +181,7 @@ void SegmentedPaletteColorLookupTable::SetLUT(LookupTableType type, const unsign
 {
   if( BitSample == 8 )
     {
-    assert(0); // TODO
+    gdcm_assert(0); // TODO
     }
   else if( BitSample == 16 )
     {
@@ -190,7 +190,7 @@ void SegmentedPaletteColorLookupTable::SetLUT(LookupTableType type, const unsign
     std::vector<uint16_t> palette;
     unsigned int num_entries = GetLUTLength(type);
     palette.reserve(num_entries);
-    assert( length % 2 == 0 );
+    gdcm_assert( length % 2 == 0 );
     // FIXME: inplace byteswapping (BAD!)
     SwapperNoOp::SwapArray(const_cast<uint16_t*>(segment_values),length/2);
     ExpandPalette(segment_values, length, palette);

--- a/Source/MediaStorageAndFileFormat/gdcmSerieHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSerieHelper.cxx
@@ -154,7 +154,7 @@ static bool CompareDicomString(const std::string &s1, const char *s2, int op)
   // s2 is the string from the DICOM reference e.g. : 'MONOCHROME1'
   std::string s1_even = s1; //Never change input parameter
   std::string s2_even = /*DicomString(*/ s2 ;
-  assert( s2_even.size() % 2 == 0 );
+  gdcm_assert( s2_even.size() % 2 == 0 );
   if ( s1_even[s1_even.size()-1] == ' ' )
     {
     s1_even[s1_even.size()-1] = '\0'; //replace space character by null

--- a/Source/MediaStorageAndFileFormat/gdcmSpacing.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSpacing.cxx
@@ -90,7 +90,7 @@ double frap(double frac[2], double startx, double maxden = 10 )
   //printf("%ld/%ld, error = %e\n", m[0][0], m[1][0],
   //  startx - ((double) m[0][0] / (double) m[1][0]));
   const double error2 = startx - ((double) m[0][0] / (double) m[1][0]);
-  assert( fabs(error) < fabs(error2) ); (void)error2;
+  gdcm_assert( fabs(error) < fabs(error2) ); (void)error2;
 
   return error;
 }

--- a/Source/MediaStorageAndFileFormat/gdcmStreamImageReader.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStreamImageReader.cxx
@@ -139,7 +139,7 @@ bool StreamImageReader::Read(char* inReadBuffer, const std::size_t& inBufferLeng
 bool StreamImageReader::ReadImageSubregionRAW(char* inReadBuffer, const std::size_t& inBufferLength)
 {
   //assumes that the file is organized in row-major format, with each row rastering across
-  assert( mFileOffset != -1 );
+  gdcm_assert( mFileOffset != -1 );
   (void)inBufferLength;
   int y, z;
   std::streamoff theOffset;
@@ -377,7 +377,7 @@ bool StreamImageReader::ReadImageInformation()
   if( mFileOffset == -1 ) return false;
 
   // postcondition
-  assert( mFileOffset != -1 );
+  gdcm_assert( mFileOffset != -1 );
 
   const File &file_t = mReader.GetFile();
   const DataSet &ds_t = file_t.GetDataSet();
@@ -485,7 +485,7 @@ File const &StreamImageReader::GetFile() const
     }
   else
     {
-    assert(0);
+    gdcm_assert(0);
     return mReader.GetFile();
     }
 }

--- a/Source/MediaStorageAndFileFormat/gdcmStreamImageWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStreamImageWriter.cxx
@@ -155,10 +155,10 @@ int StreamImageWriter::WriteRawHeader(RAWCodec* inCodec, std::ostream* inStream)
     memcpy(&(tmpBuffer1[5*sizeof(uint16_t)+sizeof(uint32_t)]), &seventhTag, sizeof(uint16_t));//e000
     memcpy(&(tmpBuffer1[6*sizeof(uint16_t)+sizeof(uint32_t)]), &eightthTag, sizeof(uint32_t));//00000000H
 
-    assert( inStream && *inStream && !inStream->eof() && inStream->good() );
+    gdcm_assert( inStream && *inStream && !inStream->eof() && inStream->good() );
     inStream->write(tmpBuffer1, theBufferSize);
     inStream->flush();
-    assert( inStream && *inStream );
+    gdcm_assert( inStream && *inStream );
     }
 
   uint16_t NinthTag = 0xfffe;
@@ -197,10 +197,10 @@ int StreamImageWriter::WriteRawHeader(RAWCodec* inCodec, std::ostream* inStream)
     //    inStream->seekp(std::ios::beg);
     //    theOffset = mFileOffset;
     //    inStream->seekp(theOffset);
-    assert( inStream && *inStream && !inStream->eof() && inStream->good() );
+    gdcm_assert( inStream && *inStream && !inStream->eof() && inStream->good() );
     inStream->write(tmpBuffer4, theBufferSize1);
     inStream->flush();
-    assert( inStream && *inStream );
+    gdcm_assert( inStream && *inStream );
 
   } catch(...){
     delete [] tmpBuffer3;
@@ -220,7 +220,7 @@ bool StreamImageWriter::WriteImageSubregionRAW(char* inWriteBuffer, const std::s
 {
   (void)inBufferLength;
   //assumes that the file is organized in row-major format, with each row rastering across
-//  assert( mFileOffset != -1 );
+//  gdcm_assert( mFileOffset != -1 );
   int y, z;
 //  std::streamoff theOffset;
 
@@ -264,7 +264,7 @@ bool StreamImageWriter::WriteImageSubregionRAW(char* inWriteBuffer, const std::s
   //to ensure thread safety; if the stream ptr handler gets used simultaneously by different threads,
   //that would be BAD
   //tmpBuffer is for a single raster
-  assert( theStream && *theStream );
+  gdcm_assert( theStream && *theStream );
   char* tmpBuffer = new char[SubRowSize*bytesPerPixel];
   char* tmpBuffer2 = new char[SubRowSize*bytesPerPixel];
   try {
@@ -301,10 +301,10 @@ bool StreamImageWriter::WriteImageSubregionRAW(char* inWriteBuffer, const std::s
           return false;
         }
         //should be appending
-           //assert( theStream && *theStream && !theStream->eof() && theStream->good() );
+           //gdcm_assert( theStream && *theStream && !theStream->eof() && theStream->good() );
           theStream->write(tmpBuffer2, SubRowSize*bytesPerPixel);
           theStream->flush();
-          //assert( theStream && *theStream );
+          //gdcm_assert( theStream && *theStream );
       }
     }
   }
@@ -341,10 +341,10 @@ bool StreamImageWriter::WriteImageInformation(){
   {
     //question! is this file a copy of the file that was given in, or a reference?
      mFile.GetDataSet().Remove( Tag(0x7fe0,0x0010) ); // FIXME
-     assert( !mFile.GetDataSet().FindDataElement( Tag(0x7fe0,0x0010) ) );
+     gdcm_assert( !mFile.GetDataSet().FindDataElement( Tag(0x7fe0,0x0010) ) );
     if( !mWriter.Write() )//should write everything BUT the image tag.  right?
       {
-      //assert( 0 );//this assert fires when the image is not writeable, ie, doesn't have
+      //gdcm_assert( 0 );//this assert fires when the image is not writeable, ie, doesn't have
         //tags 2,3 and 8,18
         //if the writer can't write, then this should return false.
         return false;
@@ -381,7 +381,7 @@ bool StreamImageWriter::WriteImageInformation(){
 //  if( mFileOffset == -1 ) return false;
 
   // postcondition
-//  assert( mFileOffset != -1 );
+//  gdcm_assert( mFileOffset != -1 );
   return true;
 }
 

--- a/Source/MediaStorageAndFileFormat/gdcmStrictScanner.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStrictScanner.cxx
@@ -43,7 +43,7 @@ void StrictScanner::ClearSkipTags()
 void StrictScanner::AddSkipTag( Tag const & t )
 {
   SkipTags.insert( t );
-  assert(0); // This is NOT implemented for now
+  gdcm_assert(0); // This is NOT implemented for now
 }
 
 // Warning: API is passing a public tag (no way to specify private tag)
@@ -64,7 +64,7 @@ void StrictScanner::AddPrivateTag( PrivateTag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PrivateTags.insert( t );
     }
@@ -86,7 +86,7 @@ void StrictScanner::AddTag( Tag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     Tags.insert( t );
     }
@@ -134,7 +134,7 @@ bool StrictScanner::Scan( Directory::FilenamesType const & filenames )
       {
       Reader reader;
       const char *filename = it->c_str();
-      assert( filename );
+      gdcm_assert( filename );
       reader.SetFileName( filename );
       // Pass #1, just check if the file is valid (up to the tag)
       const bool strict = StrictReadUpToTag( filename, last, SkipTags );
@@ -192,7 +192,7 @@ void StrictScanner::Print( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     bool b = IsKey(filename);
     const char *comment = !b ? "could not be read" : "could be read";
     os << "Filename: " << filename << " (" << comment << ")\n";
@@ -232,7 +232,7 @@ void StrictScanner::PrintTable( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     os << '"' << filename << '"' << "\t";
     TagsType::const_iterator tag = Tags.begin();
     const TagToValue &mapping = GetMapping(filename);
@@ -254,8 +254,8 @@ void StrictScanner::PrintTable( std::ostream & os ) const
 
 StrictScanner::TagToValue const & StrictScanner::GetMapping(const char *filename) const
 {
-//  assert( Mappings.find(filename) != Mappings.end() );
-  assert( filename && *filename );
+//  gdcm_assert( Mappings.find(filename) != Mappings.end() );
+  gdcm_assert( filename && *filename );
   if( Mappings.find(filename) != Mappings.end() )
     return Mappings.find(filename)->second;
   return Mappings.find("")->second; // dummy file could not be found
@@ -273,7 +273,7 @@ bool StrictScanner::IsKey( const char * filename ) const
     }
 */
   // Look for the file in Mappings table:
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   MappingType::const_iterator it2 = Mappings.find(filename);
   return it2 != Mappings.end();
 }
@@ -292,7 +292,7 @@ Directory::FilenamesType StrictScanner::GetKeys() const
       keys.push_back( filename );
       }
     }
-  assert( keys.size() <= Filenames.size() );
+  gdcm_assert( keys.size() <= Filenames.size() );
   return keys;
 }
 
@@ -300,7 +300,7 @@ Directory::FilenamesType StrictScanner::GetKeys() const
 const char* StrictScanner::GetValue(const char *filename, Tag const &t) const
 {
   // \precondition
-  assert( Tags.find( t ) != Tags.end() );
+  gdcm_assert( Tags.find( t ) != Tags.end() );
   TagToValue const &ftv = GetMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -402,7 +402,7 @@ Directory::FilenamesType StrictScanner::GetOrderedValues(Tag const &t) const
 
 void StrictScanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   TagToValue &mapping = Mappings[filename];
   const File& file = sf.GetFile();
 
@@ -418,7 +418,7 @@ void StrictScanner::ProcessPublicTag(StringFilter &sf, const char *filename)
         //std::string s;
         DataElement const & de = header.GetDataElement( *tag );
         //const ByteValue *bv = de.GetByteValue();
-        ////assert( VR::IsASCII( vr ) );
+        ////gdcm_assert( VR::IsASCII( vr ) );
         //if( bv ) // Hum, should I store an empty string or what ?
         //  {
         //  s = std::string( bv->GetPointer(), bv->GetLength() );
@@ -428,9 +428,9 @@ void StrictScanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           TagToValue::value_type(*tag, value));
         }
@@ -442,7 +442,7 @@ void StrictScanner::ProcessPublicTag(StringFilter &sf, const char *filename)
         //std::string s;
         DataElement const & de = ds.GetDataElement( *tag );
         //const ByteValue *bv = de.GetByteValue();
-        ////assert( VR::IsASCII( vr ) );
+        ////gdcm_assert( VR::IsASCII( vr ) );
         //if( bv ) // Hum, should I store an empty string or what ?
         //  {
         //  s = std::string( bv->GetPointer(), bv->GetLength() );
@@ -452,9 +452,9 @@ void StrictScanner::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           TagToValue::value_type(*tag, value));
         }

--- a/Source/MediaStorageAndFileFormat/gdcmStrictScanner.h
+++ b/Source/MediaStorageAndFileFormat/gdcmStrictScanner.h
@@ -119,7 +119,7 @@ public:
     {
     bool operator()(const char* s1, const char* s2) const
       {
-      assert( s1 && s2 );
+      gdcm_assert( s1 && s2 );
       return strcmp(s1, s2) < 0;
       }
     };

--- a/Source/MediaStorageAndFileFormat/gdcmStrictScanner2.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStrictScanner2.cxx
@@ -67,7 +67,7 @@ bool StrictScanner2::AddPrivateTag( PrivateTag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PrivateTags.insert( t );
     }
@@ -92,7 +92,7 @@ bool StrictScanner2::AddPublicTag( Tag const & t )
     }
   else
     {
-    assert( entry.GetVR() & VR::VRBINARY );
+    gdcm_assert( entry.GetVR() & VR::VRBINARY );
     //gdcmWarningMacro( "Only ASCII VR are supported for now. Tag " << t << " will be discarded" );
     PublicTags.insert( t );
     }
@@ -145,7 +145,7 @@ bool StrictScanner2::Scan( Directory::FilenamesType const & filenames )
       {
       Reader reader;
       const char *filename = it->c_str();
-      assert( filename );
+      gdcm_assert( filename );
       reader.SetFileName( filename );
       // Pass #1, just check if the file is valid (up to the tag)
       const bool strict = StrictReadUpToTag( filename, last, SkipTags );
@@ -203,7 +203,7 @@ void StrictScanner2::Print( std::ostream & os ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     bool b = IsKey(filename);
     const char *comment = !b ? "could not be read" : "could be read";
     os << "Filename: " << filename << " (" << comment << ")\n";
@@ -279,7 +279,7 @@ void StrictScanner2::PrintTable( std::ostream & os, bool header ) const
   for(; file != Filenames.end(); ++file)
     {
     const char *filename = file->c_str();
-    assert( filename && *filename );
+    gdcm_assert( filename && *filename );
     os << '"' << filename << '"' << "\t";
     {
     PublicTagsType::const_iterator tag = PublicTags.begin();
@@ -319,7 +319,7 @@ void StrictScanner2::PrintTable( std::ostream & os, bool header ) const
 
 StrictScanner2::PublicTagToValue const & StrictScanner2::GetPublicMapping(const char *filename) const
 {
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   if( PublicMappings.find(filename) != PublicMappings.end() )
     return PublicMappings.find(filename)->second;
   return PublicMappings.find("")->second; // dummy file could not be found
@@ -327,7 +327,7 @@ StrictScanner2::PublicTagToValue const & StrictScanner2::GetPublicMapping(const 
 
 StrictScanner2::PrivateTagToValue const & StrictScanner2::GetPrivateMapping(const char *filename) const
 {
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   if( PrivateMappings.find(filename) != PrivateMappings.end() )
     return PrivateMappings.find(filename)->second;
   return PrivateMappings.find("")->second; // dummy file could not be found
@@ -336,7 +336,7 @@ StrictScanner2::PrivateTagToValue const & StrictScanner2::GetPrivateMapping(cons
 bool StrictScanner2::IsKey( const char * filename ) const
 {
   // Look for the file in Mappings tables:
-  assert( filename && *filename );
+  gdcm_assert( filename && *filename );
   PublicMappingType::const_iterator it2 = PublicMappings.find(filename);
   PrivateMappingType::const_iterator it3 = PrivateMappings.find(filename);
   return it2 != PublicMappings.end() || it3 != PrivateMappings.end();
@@ -355,14 +355,14 @@ Directory::FilenamesType StrictScanner2::GetKeys() const
       keys.push_back( filename );
       }
     }
-  assert( keys.size() <= Filenames.size() );
+  gdcm_assert( keys.size() <= Filenames.size() );
   return keys;
 }
 
 const char* StrictScanner2::GetPublicValue(const char *filename, Tag const &t) const
 {
   // \precondition
-  assert( PublicTags.find( t ) != PublicTags.end() );
+  gdcm_assert( PublicTags.find( t ) != PublicTags.end() );
   PublicTagToValue const &ftv = GetPublicMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -374,7 +374,7 @@ const char* StrictScanner2::GetPublicValue(const char *filename, Tag const &t) c
 const char* StrictScanner2::GetPrivateValue(const char *filename, PrivateTag const &t) const
 {
   // \precondition
-  assert( PrivateTags.find( t ) != PrivateTags.end() );
+  gdcm_assert( PrivateTags.find( t ) != PrivateTags.end() );
   PrivateTagToValue const &ftv = GetPrivateMapping(filename);
   if( ftv.find(t) != ftv.end() )
     {
@@ -549,7 +549,7 @@ Directory::FilenamesType StrictScanner2::GetPrivateOrderedValues(PrivateTag cons
 
 void StrictScanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   PublicTagToValue &mapping = PublicMappings[filename];
   const File& file = sf.GetFile();
 
@@ -567,9 +567,9 @@ void StrictScanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           PublicTagToValue::value_type(*tag, value));
         }
@@ -583,9 +583,9 @@ void StrictScanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
         // Store the potentially new value:
         Values.insert( s );
-        assert( Values.find( s ) != Values.end() );
+        gdcm_assert( Values.find( s ) != Values.end() );
         const char *value = Values.find( s )->c_str();
-        assert( value );
+        gdcm_assert( value );
         mapping.insert(
           PublicTagToValue::value_type(*tag, value));
         }
@@ -595,7 +595,7 @@ void StrictScanner2::ProcessPublicTag(StringFilter &sf, const char *filename)
 
 void StrictScanner2::ProcessPrivateTag(StringFilter &sf, const char *filename)
 {
-  assert( filename );
+  gdcm_assert( filename );
   PrivateTagToValue &mapping = PrivateMappings[filename];
   const File& file = sf.GetFile();
   const DataSet & ds = file.GetDataSet();
@@ -609,9 +609,9 @@ void StrictScanner2::ProcessPrivateTag(StringFilter &sf, const char *filename)
 
       // Store the potentially new value:
       Values.insert( s );
-      assert( Values.find( s ) != Values.end() );
+      gdcm_assert( Values.find( s ) != Values.end() );
       const char *value = Values.find( s )->c_str();
-      assert( value );
+      gdcm_assert( value );
       mapping.insert(
         PrivateTagToValue::value_type(*ptag, value));
       }

--- a/Source/MediaStorageAndFileFormat/gdcmStrictScanner2.h
+++ b/Source/MediaStorageAndFileFormat/gdcmStrictScanner2.h
@@ -125,7 +125,7 @@ class GDCM_EXPORT StrictScanner2 : public Subject {
    * comparison */
   struct ltstr {
     bool operator()(const char *s1, const char *s2) const {
-      assert(s1 && s2);
+      gdcm_assert(s1 && s2);
       return strcmp(s1, s2) < 0;
     }
   };

--- a/Source/MediaStorageAndFileFormat/gdcmStringFilter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmStringFilter.cxx
@@ -34,7 +34,7 @@ StringFilter::~StringFilter()
 void StringFilter::SetDicts(const Dicts &dicts)
 {
   (void)dicts;
-  assert(0); // FIXME
+  gdcm_assert(0); // FIXME
 }
 
 std::string StringFilter::ToString(const Tag& t) const
@@ -169,7 +169,7 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
     if( subtokens[0] == "DicomNativeModel" )
       {
       // move to next state
-      assert( state == 0 );
+      gdcm_assert( state == 0 );
       state = 1;
       curds = &ds;
       }
@@ -180,7 +180,7 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
         state = -1;
         break;
         }
-      assert( subtokens[1] == "keyword" );
+      gdcm_assert( subtokens[1] == "keyword" );
       const char *k = subtokens[2].c_str();
       /*const DictEntry &dictentry = */pubdict.GetDictEntryByKeyword(k, t);
       if( !curds->FindDataElement( t ) )
@@ -192,9 +192,9 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
       }
     else if( subtokens[0] == "Item" )
       {
-      assert( state == 1 );
-      assert( curde );
-      assert( subtokens[1] == "number" );
+      gdcm_assert( state == 1 );
+      gdcm_assert( curde );
+      gdcm_assert( subtokens[1] == "number" );
       sqi = curde->GetValueAsSQ();
       if( !sqi )
         {
@@ -206,19 +206,19 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
       }
     else if( subtokens[0] == "Value" )
       {
-      assert( state == 1 );
+      gdcm_assert( state == 1 );
       // move to next state
       state = 2;
-      assert( subtokens[1] == "number" );
+      gdcm_assert( subtokens[1] == "number" );
 #if !defined(NDEBUG)
       const ByteValue * const bv = curde->GetByteValue(); (void)bv;
-      assert( bv );
+      gdcm_assert( bv );
       //bv->Print( std::cout << std::endl );
 #endif
       }
     else
       {
-      assert( !subtokens.empty() );
+      gdcm_assert( !subtokens.empty() );
       gdcmDebugMacro( "Unhandled token: " << subtokens[0] );
       state = -1;
       }
@@ -268,33 +268,33 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
     return false;
     }
 
-  assert( vr != VR::UN && vr != VR::INVALID );
+  gdcm_assert( vr != VR::UN && vr != VR::INVALID );
   //ret.first = entry.GetName();
   if( VR::IsASCII( vr ) )
     {
-    assert( vr & VR::VRASCII );
+    gdcm_assert( vr & VR::VRASCII );
     const ByteValue *bv = de.GetByteValue();
     if( de.GetVL() )
       {
-      assert( bv /*|| bv->IsEmpty()*/ );
+      gdcm_assert( bv /*|| bv->IsEmpty()*/ );
       retvalue = std::string( bv->GetPointer(), bv->GetLength() );
       // Let's remove any trailing \0 :
       retvalue.resize( std::min( retvalue.size(), strlen( retvalue.c_str() ) ) ); // strlen is guarantee to be lower or equal to ::size()
       }
     else
       {
-      //assert( bv == NULL );
+      //gdcm_assert( bv == NULL );
       retvalue = ""; // ??
       }
     }
   else
     {
-    assert( vr & VR::VRBINARY );
+    gdcm_assert( vr & VR::VRBINARY );
     const ByteValue *bv = de.GetByteValue();
     if( bv )
       {
       //VM::VMType vm = entry.GetVM();//!!mmr-- can I remove this, or will it mess with the stream?
-      //assert( vm == VM::VM1 );
+      //gdcm_assert( vm == VM::VM1 );
       if( vr.IsDual() ) // This mean vr was read from a dict entry:
         {
         vr = DataSetHelper::ComputeVR(GetFile(),ds, t);
@@ -317,7 +317,7 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
         StringFilterCase(UT);
       case VR::UN:
       case VR::US_SS:
-        assert(0);
+        gdcm_assert(0);
         break;
       case VR::OB:
       case VR::OW:
@@ -327,7 +327,7 @@ bool StringFilter::ExecuteQuery(std::string const & query_const,
         retvalue = "";
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
         break;
         }
       }
@@ -358,7 +358,7 @@ std::pair<std::string, std::string> StringFilter::ToStringPairInternal(const Dat
     gdcmDebugMacro( "DataSet is empty or does not contains tag:" );
     return ret;
     }
-  //assert( de.GetTag().IsPublic() );
+  //gdcm_assert( de.GetTag().IsPublic() );
   std::string strowner;
   const char *owner = nullptr;
   const Tag &t = de.GetTag();
@@ -405,34 +405,34 @@ std::pair<std::string, std::string> StringFilter::ToStringPairInternal(const Dat
     return ret;
     }
 
-  assert( vr != VR::UN && vr != VR::INVALID );
+  gdcm_assert( vr != VR::UN && vr != VR::INVALID );
   //std::cerr << "Found " << vr << " for " << de.GetTag() << std::endl;
   ret.first = entry.GetName();
   if( VR::IsASCII( vr ) )
     {
-    assert( vr & VR::VRASCII );
+    gdcm_assert( vr & VR::VRASCII );
     const ByteValue *bv = de.GetByteValue();
     if( de.GetVL() )
       {
-      assert( bv /*|| bv->IsEmpty()*/ );
+      gdcm_assert( bv /*|| bv->IsEmpty()*/ );
       ret.second = std::string( bv->GetPointer(), bv->GetLength() );
       // Let's remove any trailing \0 :
       ret.second.resize( std::min( ret.second.size(), strlen( ret.second.c_str() ) ) ); // strlen is guarantee to be lower or equal to ::size()
       }
     else
       {
-      //assert( bv == NULL );
+      //gdcm_assert( bv == NULL );
       ret.second = ""; // ??
       }
     }
   else
     {
-    assert( vr & VR::VRBINARY );
+    gdcm_assert( vr & VR::VRBINARY );
     const ByteValue *bv = de.GetByteValue();
     if( bv )
       {
       //VM::VMType vm = entry.GetVM();//!!mmr-- can I remove this, or will it mess with the stream?
-      //assert( vm == VM::VM1 );
+      //gdcm_assert( vm == VM::VM1 );
       if( vr.IsDual() ) // This mean vr was read from a dict entry:
         {
         vr = DataSetHelper::ComputeVR(GetFile(),ds, t);
@@ -456,7 +456,7 @@ std::pair<std::string, std::string> StringFilter::ToStringPairInternal(const Dat
         StringFilterCase(UT);
       case VR::UN:
       case VR::US_SS:
-        assert(0);
+        gdcm_assert(0);
         break;
       case VR::OB:
       case VR::OW:
@@ -466,7 +466,7 @@ std::pair<std::string, std::string> StringFilter::ToStringPairInternal(const Dat
         ret.second = "";
         break;
       default:
-        assert(0);
+        gdcm_assert(0);
         break;
         }
         ret.second = retvalue;
@@ -493,7 +493,7 @@ std::pair<std::string, std::string> StringFilter::ToStringPairInternal(const Dat
 #if 0
 static inline size_t count_backslash(const char *s, size_t len)
 {
-  assert( s );
+  gdcm_assert( s );
   size_t c = 0;
   for(size_t i = 0; i < len; ++i, ++s)
     {
@@ -567,7 +567,7 @@ std::string StringFilter::FromString(const Tag&t, const char * value, size_t len
 #if !defined(NDEBUG)
     VM check = VM::GetVMTypeFromLength(count, 1);
     if( vm != VM::VM0 )
-    assert( vm.Compatible( check ) );
+    gdcm_assert( vm.Compatible( check ) );
 #endif
     }
 
@@ -590,7 +590,7 @@ std::string StringFilter::FromString(const Tag&t, const char * value, size_t len
     FromStringFilterCase(US);
   default:
     gdcmErrorMacro( "Not implemented" );
-    assert(0);
+    gdcm_assert(0);
     }
   return os.str();
 }

--- a/Source/MediaStorageAndFileFormat/gdcmSurface.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSurface.cxx
@@ -30,7 +30,7 @@ static const char * STATESStrings[] = {
 
 const char * Surface::GetSTATESString(STATES state)
 {
-  assert( state <= STATES_END );
+  gdcm_assert( state <= STATES_END );
   return STATESStrings[(int)state];
 }
 
@@ -77,7 +77,7 @@ static const char * VIEWStrings[] = {
 
 const char * Surface::GetVIEWTypeString(VIEWType type)
 {
-  assert( type <= VIEWType_END );
+  gdcm_assert( type <= VIEWType_END );
   return VIEWStrings[(int)type];
 }
 
@@ -171,7 +171,7 @@ const unsigned short * Surface::GetRecommendedDisplayCIELabValue() const
 
 unsigned short Surface::GetRecommendedDisplayCIELabValue(const unsigned int idx) const
 {
-  assert( idx < 3 );
+  gdcm_assert( idx < 3 );
   return RecommendedDisplayCIELabValue[idx];
 }
 
@@ -184,13 +184,13 @@ void Surface::SetRecommendedDisplayCIELabValue(const unsigned short vl[3])
 
 void Surface::SetRecommendedDisplayCIELabValue(const unsigned short vl, const unsigned int idx/* = 0*/)
 {
-  assert( idx < 3 );
+  gdcm_assert( idx < 3 );
   RecommendedDisplayCIELabValue[idx] = vl;
 }
 
 void Surface::SetRecommendedDisplayCIELabValue(const std::vector< unsigned short > & vl)
 {
-  assert( vl.size() > 2 );
+  gdcm_assert( vl.size() > 2 );
 
   RecommendedDisplayCIELabValue[0] = vl[0];
   RecommendedDisplayCIELabValue[1] = vl[1];
@@ -298,7 +298,7 @@ Surface::STATES Surface::GetFiniteVolume() const
 
 void Surface::SetFiniteVolume(STATES state)
 {
-  assert( state < STATES_END );
+  gdcm_assert( state < STATES_END );
   FiniteVolume = state;
 }
 
@@ -309,7 +309,7 @@ Surface::STATES Surface::GetManifold() const
 
 void Surface::SetManifold(STATES state)
 {
-  assert( state < STATES_END );
+  gdcm_assert( state < STATES_END );
   Manifold = state;
 }
 
@@ -383,7 +383,7 @@ const float * Surface::GetPointPositionAccuracy() const
 
 void Surface::SetPointPositionAccuracy(const float * accuracies)
 {
-  assert(accuracies);
+  gdcm_assert(accuracies);
 
   if (PointPositionAccuracy == nullptr) PointPositionAccuracy = new float[3];
 
@@ -419,7 +419,7 @@ const float * Surface::GetPointsBoundingBoxCoordinates() const
 
 void Surface::SetPointsBoundingBoxCoordinates(const float * coordinates)
 {
-  assert(coordinates);
+  gdcm_assert(coordinates);
 
   if (PointsBoundingBoxCoordinates == nullptr) PointsBoundingBoxCoordinates = new float[6];
 
@@ -438,7 +438,7 @@ const float * Surface::GetAxisOfRotation() const
 
 void Surface::SetAxisOfRotation(const float * axis)
 {
-  assert(axis);
+  gdcm_assert(axis);
 
   if (AxisOfRotation == nullptr) AxisOfRotation = new float[3];
 
@@ -454,7 +454,7 @@ const float * Surface::GetCenterOfRotation() const
 
 void Surface::SetCenterOfRotation(const float * center)
 {
-  assert(center);
+  gdcm_assert(center);
 
   if (CenterOfRotation == nullptr) CenterOfRotation = new float[3];
 
@@ -490,7 +490,7 @@ const float * Surface::GetVectorAccuracy() const
 
 void Surface::SetVectorAccuracy(const float * accuracy)
 {
-  assert(accuracy);
+  gdcm_assert(accuracy);
 
   if (VectorAccuracy == nullptr) VectorAccuracy = new float[ VectorDimensionality ];
 

--- a/Source/MediaStorageAndFileFormat/gdcmSurfaceHelper.h
+++ b/Source/MediaStorageAndFileFormat/gdcmSurfaceHelper.h
@@ -103,7 +103,7 @@ template <typename T, typename U>
 unsigned short SurfaceHelper::RGBToRecommendedDisplayGrayscale(const std::vector<T> & RGB,
                                                                const U rangeMax/* = 255*/)
 {
-  assert(RGB.size() > 2);
+  gdcm_assert(RGB.size() > 2);
 
   unsigned short Grayscale = 0;
 
@@ -121,7 +121,7 @@ template <typename T, typename U>
 SurfaceHelper::ColorArray SurfaceHelper::RGBToRecommendedDisplayCIELab(const std::vector<T> & RGB,
                                                                        const U rangeMax/* = 255*/)
 {
-  assert(RGB.size() > 2);
+  gdcm_assert(RGB.size() > 2);
 
   ColorArray CIELab(3);
   std::vector<float> tmp(3);
@@ -161,7 +161,7 @@ template <typename T, typename U>
 std::vector<T> SurfaceHelper::RecommendedDisplayCIELabToRGB(const ColorArray & CIELab,
                                                             const U rangeMax/* = 255*/)
 {
-  assert(CIELab.size() > 2);
+  gdcm_assert(CIELab.size() > 2);
 
   std::vector<T> RGB(3);
   std::vector<float> tmp(3);

--- a/Source/MediaStorageAndFileFormat/gdcmSurfaceWriter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmSurfaceWriter.cxx
@@ -63,7 +63,7 @@ bool SurfaceWriter::PrepareWrite()
 
   FileMetaInformation &  fmi  = file.GetHeader();
   const TransferSyntax & ts   = fmi.GetDataSetTransferSyntax();
-  assert( ts.IsExplicit() || ts.IsImplicit() );
+  gdcm_assert( ts.IsExplicit() || ts.IsImplicit() );
 
   // Number Of Surface
   const unsigned long     nbSurfaces = this->GetNumberOfSurfaces();
@@ -115,7 +115,7 @@ bool SurfaceWriter::PrepareWrite()
   for (; it0 != it0End; it0++)
   {
     SmartPointer< Segment > segment = *it0;
-    assert( segment );
+    gdcm_assert( segment );
 
     std::vector< SmartPointer< Surface > >                  surfaces  = segment->GetSurfaces();
     std::vector< SmartPointer< Surface > >::const_iterator  it1        = surfaces.begin();
@@ -123,7 +123,7 @@ bool SurfaceWriter::PrepareWrite()
     for (; it1 != it1End; it1++)
     {
       SmartPointer< Surface > surface = *it1;
-      assert( surface );
+      gdcm_assert( surface );
 
       Item &    surfaceItem = surfacesSQ->GetItem( numSurface );
       DataSet & surfaceDS   = surfaceItem.GetNestedDataSet();
@@ -342,7 +342,7 @@ bool SurfaceWriter::PrepareWrite()
         // Vector Dimensionality
         Attribute<0x0066, 0x001F> vectorDimensionalityAt;
         unsigned short vectorDimensionality = surface->GetVectorDimensionality();
-        assert( vectorDimensionality );
+        gdcm_assert( vectorDimensionality );
         vectorDimensionalityAt.SetValue( vectorDimensionality );
         surfacePointsNormalsDS.Replace( vectorDimensionalityAt.GetAsDataElement() );
 
@@ -508,7 +508,7 @@ bool SurfaceWriter::PrepareWrite()
 
           // Fill the Segment Sequence
           const unsigned int              numberOfPrimitives  = meshPrimitive->GetNumberOfPrimitivesData();
-          assert( numberOfPrimitives );
+          gdcm_assert( numberOfPrimitives );
           const size_t nbItems             = typedSequenceSQ->GetNumberOfItems();
           if (nbItems < numberOfPrimitives)
           {
@@ -822,7 +822,7 @@ bool SurfaceWriter::Write()
     return false;
   }
 
-  assert( Stream );
+  gdcm_assert( Stream );
   if( !Writer::Write() )
   {
     return false;

--- a/Source/MediaStorageAndFileFormat/gdcmTagPath.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmTagPath.cxx
@@ -51,7 +51,7 @@ void TagPath::Print(std::ostream &os) const
       }
     else // item number
       {
-      // assert( it->GetElementTag() < 255 ); // how many item max can we have ?
+      // gdcm_assert( it->GetElementTag() < 255 ); // how many item max can we have ?
       os << it->GetElementTag() << "/";
       }
     ++flip;
@@ -126,7 +126,7 @@ bool TagPath::ConstructFromString(const char *path)
       }
     ++flip;
     if( pos != len && path[pos] == '/' ) ++pos;
-    //else assert(0);
+    //else gdcm_assert(0);
     }
   return true;
 }

--- a/Source/MediaStorageAndFileFormat/gdcmUIDGenerator.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmUIDGenerator.cxx
@@ -57,7 +57,7 @@ std::string UIDGenerator::EncodedHardwareAddress; // = System::GetHardwareAddres
 
 const char *UIDGenerator::GetRoot() { return Root.c_str(); }
 void UIDGenerator::SetRoot(const char * root) {
-  assert( IsValid( root ) );
+  gdcm_assert( IsValid( root ) );
   Root = root;
 }
 
@@ -114,7 +114,7 @@ const char* UIDGenerator::Generate()
   if( !r ) return nullptr;
   char randbytesbuf[64];
   size_t len = System::EncodeBytes(randbytesbuf, uuid, sizeof(uuid));
-  assert( len < 64 ); // programmer error
+  gdcm_assert( len < 64 ); // programmer error
   Unique += "."; // This dot is compulsory to separate root from suffix
   if( Unique.size() + len > 64 )
     {
@@ -155,7 +155,7 @@ const char* UIDGenerator::Generate()
   // can now safely use randbytesbuf as is, no need to truncate any more:
   Unique += randbytesbuf;
 
-  assert( IsValid( Unique.c_str() ) );
+  gdcm_assert( IsValid( Unique.c_str() ) );
 
   return Unique.c_str();
 }

--- a/Source/MediaStorageAndFileFormat/gdcmUUIDGenerator.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmUUIDGenerator.cxx
@@ -40,7 +40,7 @@ const char* UUIDGenerator::Generate()
   Unique.resize( 36 );
   char *uuid_data = &Unique[0];
 #if defined(HAVE_UUID_GENERATE)
-  assert( sizeof(uuid_t) == 16 );
+  gdcm_assert( sizeof(uuid_t) == 16 );
   uuid_t g;
   uuid_generate(g);
   uuid_unparse(g, uuid_data);
@@ -61,7 +61,7 @@ const char* UUIDGenerator::Generate()
 #else
 #error should not happen
 #endif
-  assert( IsValid( Unique.c_str() ) );
+  gdcm_assert( IsValid( Unique.c_str() ) );
 
   return Unique.c_str();
 }

--- a/Source/MediaStorageAndFileFormat/gdcmXMLPrinter.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmXMLPrinter.cxx
@@ -109,8 +109,8 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
     }
 
   //as DataSetHelper would have been called
-  assert( refvr != VR::US_SS );
-  assert( refvr != VR::OB_OW );
+  gdcm_assert( refvr != VR::US_SS );
+  gdcm_assert( refvr != VR::OB_OW );
 
   if( !de.IsEmpty() )
   {
@@ -119,21 +119,21 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
     {
     sqi = de.GetValueAsSQ();
     refvr = VR::SQ;
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 #if 0
   else if( vr == VR::SQ && vr_read != VR::SQ )
     {
     sqi = de.GetValueAsSQ();
     refvr = VR::SQ;
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 #endif
   }
 
   if( (vr_read == VR::INVALID || vr_read == VR::UN ) && vl_read.IsUndefined() )
     {
-    assert( refvr == VR::SQ );
+    gdcm_assert( refvr == VR::SQ );
     }
 
 //  if( vr_read == VR::SQ || vr_read == VR::UN )
@@ -142,7 +142,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
 //    }
   if( vr != VR::INVALID && (!vr.Compatible( vr_read ) || vr_read == VR::INVALID || vr_read == VR::UN ) )
     {
-    assert( vr != VR::INVALID );
+    gdcm_assert( vr != VR::INVALID );
 
     /*
     No need as we will save only the VR to which it is stored by GDCM in the XML file
@@ -164,7 +164,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
     // the vr
     // eg. CD1/647662/647663/6471066 has a SQ at (2001,9000)
 
-    assert( refvr == VR::INVALID );
+    gdcm_assert( refvr == VR::INVALID );
     refvr = VR::SQ;
     }
 
@@ -191,7 +191,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
       /* retired element */
       else if( retired )
         {
-        assert( t.IsPublic() || t.GetElement() == 0x0 ); // Is there such thing as private and retired element ?
+        gdcm_assert( t.IsPublic() || t.GetElement() == 0x0 ); // Is there such thing as private and retired element ?
         //os << name;
         //os = PrintXML_char(os,name);
         }
@@ -248,7 +248,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
       } \
       else { if( de.IsEmpty() ) \
                  {} } } \
-      else { assert( de.IsEmpty()); } \
+      else { gdcm_assert( de.IsEmpty()); } \
     } break
 
 
@@ -263,25 +263,25 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
       }
     else
       {
-      assert( de.IsEmpty() );
+      gdcm_assert( de.IsEmpty() );
       }
     }
   else if( refvr & VR::VRASCII )
     {
-    //assert( !sqi && !sqf);
-    assert(!sqi);
+    //gdcm_assert( !sqi && !sqf);
+    gdcm_assert(!sqi);
     if( bv )
       {
       bv->PrintASCIIXML(os);    //new function to print each value in new child tag
       }
     else
       {
-      assert( de.IsEmpty() );
+      gdcm_assert( de.IsEmpty() );
       }
     }
   else
     {
-    assert( refvr & VR::VRBINARY || (vr == VR::INVALID && refvr == VR::INVALID) );
+    gdcm_assert( refvr & VR::VRBINARY || (vr == VR::INVALID && refvr == VR::INVALID) );
     std::string s;
     switch(refvr)
       {
@@ -324,7 +324,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
           }
         else if ( sqf )
           {
-          assert( t == Tag(0x7fe0,0x0010) );
+          gdcm_assert( t == Tag(0x7fe0,0x0010) );
           }
         else if ( sqi )
           {
@@ -332,13 +332,13 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
           }
         else
           {
-          assert( !sqi && !sqf );
-          assert( de.IsEmpty() );
+          gdcm_assert( !sqi && !sqf );
+          gdcm_assert( de.IsEmpty() );
           }
         }
       break;
     case VR::US_SS:
-      assert( refvr != VR::US_SS );
+      gdcm_assert( refvr != VR::US_SS );
       break;
     case VR::SQ://The below info need not be printed into the XML infoset acc. to the standard
       if( !sqi && !de.IsEmpty() && de.GetValue().GetLength() )
@@ -374,8 +374,8 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
         }
       else
         {
-        assert( !sqi && !sqf );
-        assert( de.IsEmpty() );
+        gdcm_assert( !sqi && !sqf );
+        gdcm_assert( de.IsEmpty() );
         }
       break;
     /* ASCII are treated elsewhere but we do not want to use default: here to get warnings */
@@ -405,7 +405,7 @@ VR XMLPrinter::PrintDataElement(std::ostream &os, const Dicts &dicts, const Data
     case VR::VR_VM1:
     case VR::VRALL:
     case VR::VR_END:
-      assert(0 && "No Match! Impossible!!");
+      gdcm_assert(0 && "No Match! Impossible!!");
       break;
       }
     }

--- a/Source/MessageExchangeDefinition/gdcmAAbortPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAAbortPDU.cxx
@@ -54,14 +54,14 @@ AAbortPDU::AAbortPDU()
   Reason = 0;
 
   ItemLength = (uint32_t)Size() - 6;
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 }
 
 std::istream &AAbortPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t itemlength = ItemLength;
@@ -79,7 +79,7 @@ std::istream &AAbortPDU::Read(std::istream &is)
   is.read( (char*)&reason, sizeof(Reason) );
   Reason = reason;
 
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
   return is;
 }
 
@@ -138,7 +138,7 @@ static const char *PrintReasonAsString( uint8_t reason )
   case 0x6:
     return "invalid-PDU-parameter value";
     }
-  assert( 0 );
+  gdcm_assert( 0 );
   return nullptr;
 }
 }

--- a/Source/MessageExchangeDefinition/gdcmAAssociateACPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAAssociateACPDU.cxx
@@ -40,14 +40,14 @@ AAssociateACPDU::AAssociateACPDU()
 void AAssociateACPDU::SetCalledAETitle(const char calledaetitle[16])
 {
   //size_t len = strlen( calledaetitle );
-  //assert( len <= 16 ); // since forwarded from AA-RQ no reason to be invalid
+  //gdcm_assert( len <= 16 ); // since forwarded from AA-RQ no reason to be invalid
   memcpy(Reserved11_26, calledaetitle, 16 );
 }
 
 void AAssociateACPDU::SetCallingAETitle(const char callingaetitle[16])
 {
   //size_t len = strlen( callingaetitle );
-  //assert( len <= 16 ); // since forwarded from AA-RQ no reason to be invalid
+  //gdcm_assert( len <= 16 ); // since forwarded from AA-RQ no reason to be invalid
   memcpy(Reserved27_42, callingaetitle, 16 );
 }
 
@@ -55,8 +55,8 @@ std::istream &AAssociateACPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
-  assert( is.good() );
+  //gdcm_assert( itemtype == ItemType );
+  gdcm_assert( is.good() );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t pdulength = 0;
@@ -119,8 +119,8 @@ std::istream &AAssociateACPDU::Read(std::istream &is)
     // length of remaining bytes to read.
     //curlen = Size();
     }
-  assert( curlen + 68 == PDULength );
-  assert( PDULength + 4 + 1 + 1 == Size() );
+  gdcm_assert( curlen + 68 == PDULength );
+  gdcm_assert( PDULength + 4 + 1 + 1 == Size() );
 
   return is;
 }
@@ -155,7 +155,7 @@ const std::ostream &AAssociateACPDU::Write(std::ostream &os) const
     }
   UserInfo.Write( os );
 
-  assert( PDULength + 4 + 1 + 1 == Size() );
+  gdcm_assert( PDULength + 4 + 1 + 1 == Size() );
 
   return os;
 }
@@ -185,7 +185,7 @@ void AAssociateACPDU::AddPresentationContextAC( PresentationContextAC const &pca
 {
   PresContextAC.push_back( pcac );
   PDULength = (uint32_t)(Size() - 6);
-  assert( PDULength + 4 + 1 + 1 == Size() );
+  gdcm_assert( PDULength + 4 + 1 + 1 == Size() );
 }
 
 void AAssociateACPDU::Print(std::ostream &os) const
@@ -219,11 +219,11 @@ void AAssociateACPDU::InitFromRQ( AAssociateRQPDU const & rqpdu )
   const std::string reserved = rqpdu.GetReserved43_74();
   memcpy( Reserved43_74, reserved.c_str(), sizeof(Reserved43_74) );
 
-  assert( ProtocolVersion == 0x01 );
-  assert( Reserved9_10 == 0x0 );
-  assert( memcmp( Reserved11_26, called.c_str(), sizeof( Reserved11_26) ) == 0 );
-  assert( memcmp( Reserved27_42, calling.c_str(), sizeof(Reserved27_42) ) == 0 );
-  assert( memcmp( Reserved43_74, reserved.c_str(), sizeof(Reserved43_74) ) == 0 );
+  gdcm_assert( ProtocolVersion == 0x01 );
+  gdcm_assert( Reserved9_10 == 0x0 );
+  gdcm_assert( memcmp( Reserved11_26, called.c_str(), sizeof( Reserved11_26) ) == 0 );
+  gdcm_assert( memcmp( Reserved27_42, calling.c_str(), sizeof(Reserved27_42) ) == 0 );
+  gdcm_assert( memcmp( Reserved43_74, reserved.c_str(), sizeof(Reserved43_74) ) == 0 );
 }
 
 
@@ -232,7 +232,7 @@ void AAssociateACPDU::InitSimple( AAssociateRQPDU const & rqpdu )
   TransferSyntaxSub ts1;
   ts1.SetNameFromUID( UIDs::ImplicitVRLittleEndianDefaultTransferSyntaxforDICOM );
 
-  assert( rqpdu.GetNumberOfPresentationContext() );
+  gdcm_assert( rqpdu.GetNumberOfPresentationContext() );
   for( unsigned int index = 0; index < rqpdu.GetNumberOfPresentationContext(); index++ )
     {
     // FIXME / HARDCODED We only ever accept Little Endian

--- a/Source/MessageExchangeDefinition/gdcmAAssociateACPDU.h
+++ b/Source/MessageExchangeDefinition/gdcmAAssociateACPDU.h
@@ -45,7 +45,7 @@ public:
 
   typedef std::vector<PresentationContextAC>::size_type SizeType;
   const PresentationContextAC &GetPresentationContextAC( SizeType i ) {
-    assert( !PresContextAC.empty() && i < PresContextAC.size() );
+    gdcm_assert( !PresContextAC.empty() && i < PresContextAC.size() );
     return PresContextAC[i];
   }
   SizeType GetNumberOfPresentationContextAC() const {

--- a/Source/MessageExchangeDefinition/gdcmAAssociateRJPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAAssociateRJPDU.cxx
@@ -34,7 +34,7 @@ std::istream &AAssociateRJPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is >> reserved2;
   uint32_t itemlength;
@@ -53,7 +53,7 @@ std::istream &AAssociateRJPDU::Read(std::istream &is)
   is >> reason;
   Reason = reason;
 
-  //assert( ItemLength + 4 + 1 + 1 == Size() );
+  //gdcm_assert( ItemLength + 4 + 1 + 1 == Size() );
 
   return is;
 }
@@ -73,7 +73,7 @@ static const char *PrintResultAsString( uint8_t result )
   case 0x2:
     return "rejected-transient";
     }
-  assert( 0 );
+  gdcm_assert( 0 );
   return nullptr;
 }
 
@@ -88,7 +88,7 @@ static const char *PrintSourceAsString( uint8_t source )
   case 0x2:
     return "DICOM UL service-provider (Presentation related function)";
     }
-  assert( 0 );
+  gdcm_assert( 0 );
   return nullptr;
 }
 
@@ -143,7 +143,7 @@ static const char *PrintReasonAsString( uint8_t source, uint8_t reason )
       return "3-7 - reserved";
       }
     }
-  assert( 0 );
+  gdcm_assert( 0 );
   return nullptr;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmAAssociateRQPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAAssociateRQPDU.cxx
@@ -49,14 +49,14 @@ AAssociateRQPDU::AAssociateRQPDU()
   //SetCallingAETitle( "MOVESCU" );
 
   ItemLength = (uint32_t)Size() - 6;
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 }
 
 std::istream &AAssociateRQPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is >> reserved2;
   uint32_t itemlength;
@@ -114,16 +114,16 @@ std::istream &AAssociateRQPDU::Read(std::istream &is)
     // length of remaining bytes to read.
     //curlen = Size();
     }
-  assert( curlen + 68 == ItemLength );
+  gdcm_assert( curlen + 68 == ItemLength );
 
-  assert( ItemLength + 4 + 1 + 1 == Size() );
+  gdcm_assert( ItemLength + 4 + 1 + 1 == Size() );
 
   return is;
 }
 
 const std::ostream &AAssociateRQPDU::Write(std::ostream &os) const
 {
-  assert( ItemLength + 4 + 1 + 1 == Size() );
+  gdcm_assert( ItemLength + 4 + 1 + 1 == Size() );
 #if 0
   // Need to check all context Id are ordered ? and odd number ?
   std::vector<PresentationContextRQ>::const_iterator it = PresContext.begin();
@@ -141,9 +141,9 @@ const std::ostream &AAssociateRQPDU::Write(std::ostream &os) const
   SwapperDoOp::SwapArray(&protocolversion,1);
   os.write( (const char*)&protocolversion, sizeof(ProtocolVersion) );
   os.write( (const char*)&Reserved9_10, sizeof(Reserved9_10) );
-  assert( AAssociateRQPDU::IsAETitleValid(CalledAETitle) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid(CalledAETitle) );
   os.write( CalledAETitle, 16 );
-  assert( AAssociateRQPDU::IsAETitleValid(CallingAETitle) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid(CallingAETitle) );
   os.write( CallingAETitle, 16 );
   os.write( (const char*)&Reserved43_74, sizeof(Reserved43_74) );
   AppContext.Write(os);
@@ -216,12 +216,12 @@ void AAssociateRQPDU::AddPresentationContext( PresentationContextRQ const &pc )
 {
   PresContext.push_back( pc );
   ItemLength = (uint32_t)Size() - 6;
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 }
 
 void AAssociateRQPDU::SetCalledAETitle(const char calledaetitle[16])
 {
-  assert( AAssociateRQPDU::IsAETitleValid(calledaetitle) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid(calledaetitle) );
   size_t len = strlen( calledaetitle );
   if( len <= 16 )
     {
@@ -234,7 +234,7 @@ void AAssociateRQPDU::SetCalledAETitle(const char calledaetitle[16])
 
 void AAssociateRQPDU::SetCallingAETitle(const char callingaetitle[16])
 {
-  assert( AAssociateRQPDU::IsAETitleValid(callingaetitle) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid(callingaetitle) );
   size_t len = strlen( callingaetitle );
   if( len <= 16 )
     {
@@ -307,7 +307,7 @@ void AAssociateRQPDU::SetUserInformation( UserInformation const & ui )
 {
   UserInfo = ui;
   ItemLength = (uint32_t)Size() - 6;
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 }
 
 } // end namespace network

--- a/Source/MessageExchangeDefinition/gdcmAAssociateRQPDU.h
+++ b/Source/MessageExchangeDefinition/gdcmAAssociateRQPDU.h
@@ -60,12 +60,12 @@ public:
 
   AAssociateRQPDU(const AAssociateRQPDU &pdu):BasePDU(pdu)
     {
-    assert( 0 );
+    gdcm_assert( 0 );
     }
   //this function fails to compile on windows.
 //  AAssociateRQPDU &operator=(const AAssociateRQPDU &_val)
 //    {
-//    assert( 0 );
+//    gdcm_assert( 0 );
 //    }
 
   typedef std::vector<PresentationContextRQ>::size_type SizeType;
@@ -73,7 +73,7 @@ public:
     return PresContext.size();
   }
   PresentationContextRQ const &GetPresentationContext(SizeType i) const {
-    assert( !PresContext.empty() && i < PresContext.size() );
+    gdcm_assert( !PresContext.empty() && i < PresContext.size() );
     return PresContext[i];
   }
   typedef std::vector<PresentationContextRQ> PresentationContextArrayType;

--- a/Source/MessageExchangeDefinition/gdcmAReleaseRPPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAReleaseRPPDU.cxx
@@ -25,14 +25,14 @@ const uint32_t AReleaseRPPDU::Reserved7_10 = 0x0;
 AReleaseRPPDU::AReleaseRPPDU()
 {
   ItemLength = (uint32_t)(Size() - 6); // PDU Length
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
 }
 
 std::istream &AReleaseRPPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t itemlength = ItemLength;
@@ -42,7 +42,7 @@ std::istream &AReleaseRPPDU::Read(std::istream &is)
   uint32_t reserved7_10;
   is.read( (char*)&reserved7_10, sizeof(Reserved7_10) );
 
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
   return is;
 }
 
@@ -55,7 +55,7 @@ const std::ostream &AReleaseRPPDU::Write(std::ostream &os) const
   os.write( (const char*)&copy, sizeof(ItemLength) );
   os.write( (const char*)&Reserved7_10, sizeof(Reserved7_10) );
 
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
 
   return os;
 }

--- a/Source/MessageExchangeDefinition/gdcmAReleaseRQPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAReleaseRQPDU.cxx
@@ -25,14 +25,14 @@ const uint32_t AReleaseRQPDU::Reserved7_10 = 0x0;
 AReleaseRQPDU::AReleaseRQPDU()
 {
   ItemLength = (uint32_t)(Size() - 6); // PDU Length
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
 }
 
 std::istream &AReleaseRQPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t itemlength = ItemLength;
@@ -42,7 +42,7 @@ std::istream &AReleaseRQPDU::Read(std::istream &is)
   uint32_t reserved7_10;
   is.read( (char*)&reserved7_10, sizeof(Reserved7_10) );
 
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
   return is;
 }
 
@@ -55,7 +55,7 @@ const std::ostream &AReleaseRQPDU::Write(std::ostream &os) const
   os.write( (const char*)&copy, sizeof(ItemLength) );
   os.write( (const char*)&Reserved7_10, sizeof(Reserved7_10) );
 
-  assert( ItemLength + 6 == Size() );
+  gdcm_assert( ItemLength + 6 == Size() );
 
   return os;
 }

--- a/Source/MessageExchangeDefinition/gdcmAbstractSyntax.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAbstractSyntax.cxx
@@ -32,7 +32,7 @@ std::istream &AbstractSyntax::Read(std::istream &is)
 {
   uint8_t itemtype = 0x0;
   is.read( (char*)&itemtype, sizeof(ItemType) );
-  assert( itemtype == ItemType );
+  gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -41,7 +41,7 @@ std::istream &AbstractSyntax::Read(std::istream &is)
   ItemLength = itemlength;
 
   char name[256];
-  assert( itemlength < 256 );
+  gdcm_assert( itemlength < 256 );
   is.read( name, itemlength );
   Name = std::string(name,itemlength);
 
@@ -64,13 +64,13 @@ const std::ostream &AbstractSyntax::Write(std::ostream &os) const
 size_t AbstractSyntax::Size() const
 {
   size_t ret = 0;
-  assert( Name.size() == ItemLength );
+  gdcm_assert( Name.size() == ItemLength );
   ret += sizeof(ItemType);
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);
   ret += ItemLength;
-  assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
-  assert(ret >= 4);
+  gdcm_assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
+  gdcm_assert(ret >= 4);
   return ret;
 }
 
@@ -84,9 +84,9 @@ void AbstractSyntax::UpdateName( const char *name )
       {
       Name = name;
       size_t lenTemp = Name.size();
-      assert(lenTemp < (size_t)std::numeric_limits<uint16_t>::max);
+      gdcm_assert(lenTemp < (size_t)std::numeric_limits<uint16_t>::max);
       ItemLength = (uint16_t)lenTemp;
-      assert( (size_t)ItemLength + 4 == Size() );
+      gdcm_assert( (size_t)ItemLength + 4 == Size() );
       return;
       }
     }

--- a/Source/MessageExchangeDefinition/gdcmApplicationContext.cxx
+++ b/Source/MessageExchangeDefinition/gdcmApplicationContext.cxx
@@ -36,7 +36,7 @@ std::istream &ApplicationContext::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0x0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -45,10 +45,10 @@ std::istream &ApplicationContext::Read(std::istream &is)
   ItemLength = itemlength;
 
   char name[256];
-  assert( itemlength < 256 );
+  gdcm_assert( itemlength < 256 );
   is.read( name, ItemLength );
   Name = std::string(name,itemlength);
-  assert( Name == DICOMApplicationContextName );
+  gdcm_assert( Name == DICOMApplicationContextName );
 
   return is;
 }
@@ -61,7 +61,7 @@ const std::ostream &ApplicationContext::Write(std::ostream &os) const
   SwapperDoOp::SwapArray(&copy,1);
   os.write( (const char*)&copy, sizeof(ItemLength) );
 
-  assert( Name == DICOMApplicationContextName );
+  gdcm_assert( Name == DICOMApplicationContextName );
   os.write( Name.c_str(), Name.size() );
   return os;
 }
@@ -69,7 +69,7 @@ const std::ostream &ApplicationContext::Write(std::ostream &os) const
 size_t ApplicationContext::Size() const
 {
   size_t ret = 0;
-  assert( Name.size() == ItemLength );
+  gdcm_assert( Name.size() == ItemLength );
   ret += sizeof(ItemType);
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);
@@ -82,9 +82,9 @@ void ApplicationContext::UpdateName( const char *name )
   if( name )
     {
     Name = name;
-    assert( Name.size() < std::numeric_limits<uint16_t>::max() );
+    gdcm_assert( Name.size() < std::numeric_limits<uint16_t>::max() );
     ItemLength = (uint16_t)Name.size();
-    assert( (size_t)ItemLength + 4 == Size() );
+    gdcm_assert( (size_t)ItemLength + 4 == Size() );
     }
 }
 

--- a/Source/MessageExchangeDefinition/gdcmAsynchronousOperationsWindowSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmAsynchronousOperationsWindowSub.cxx
@@ -29,14 +29,14 @@ AsynchronousOperationsWindowSub::AsynchronousOperationsWindowSub()
   MaximumNumberOperationsPerformed = 0;
 
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &AsynchronousOperationsWindowSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;

--- a/Source/MessageExchangeDefinition/gdcmBaseQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmBaseQuery.cxx
@@ -87,7 +87,7 @@ namespace gdcm
       thePaddedValue.push_back(' ');
     }
 
-    assert(thePaddedValue.length() < std::numeric_limits<uint32_t>::max());
+    gdcm_assert(thePaddedValue.length() < std::numeric_limits<uint32_t>::max());
     de.SetByteValue(thePaddedValue.c_str(), (uint32_t)thePaddedValue.length());
 
     //Replace any existing values

--- a/Source/MessageExchangeDefinition/gdcmBaseRootQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmBaseRootQuery.cxx
@@ -88,7 +88,7 @@ namespace gdcm
   {
     QueryBase* qb = nullptr;
     // Check no new extension:
-    assert( inRootType == ePatientRootType || inRootType == eStudyRootType );
+    gdcm_assert( inRootType == ePatientRootType || inRootType == eStudyRootType );
 
     if( qlevel == ePatient )
     {
@@ -124,7 +124,7 @@ namespace gdcm
       level = eStudy;
       break;
     }
-    assert( level == eStudy || level == ePatient );
+    gdcm_assert( level == eStudy || level == ePatient );
     return level;
   }
 

--- a/Source/MessageExchangeDefinition/gdcmCEchoMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmCEchoMessages.cxx
@@ -61,7 +61,7 @@ std::vector<PresentationDataValue> CEchoRQ::ConstructPDV(
   {
   Attribute<0x0,0x0> at = { 0 };
   unsigned int glen = ds.GetLength<ImplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   at.SetValue( glen );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -77,7 +77,7 @@ std::vector<PresentationDataValue> CEchoRQ::ConstructPDV(
 std::vector<PresentationDataValue>  CEchoRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDV;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDV;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmCFindMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmCFindMessages.cxx
@@ -91,7 +91,7 @@ std::vector<PresentationDataValue> CFindRQ::ConstructPDV(
   {
   Attribute<0x0,0x0> at = { 0 };
   unsigned int glen = ds.GetLength<ImplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   at.SetValue( glen );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -107,13 +107,13 @@ std::vector<PresentationDataValue> CFindRQ::ConstructPDV(
 std::vector<PresentationDataValue>  CFindRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDV;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDV;
 }
 std::vector<PresentationDataValue>  CFindCancelRQ::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDV;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDV;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmCMoveMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmCMoveMessages.cxx
@@ -69,7 +69,7 @@ std::vector<PresentationDataValue> CMoveRQ::ConstructPDV(
   {
   Attribute<0x0,0x600> at = { "" };
   const char *calling = inConnection.GetConnectionInfo().GetCallingAETitle();
-  assert( AAssociateRQPDU::IsAETitleValid( calling ) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid( calling ) );
   at.SetValue( calling );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -84,7 +84,7 @@ std::vector<PresentationDataValue> CMoveRQ::ConstructPDV(
   {
   Attribute<0x0,0x0> at = { 0 };
   unsigned int glen = ds.GetLength<ImplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   at.SetValue( glen );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -110,7 +110,7 @@ std::vector<PresentationDataValue> CMoveRQ::ConstructPDV(
 std::vector<PresentationDataValue> CMoveRQ::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDVs;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDVs;
 
 }
@@ -118,13 +118,13 @@ std::vector<PresentationDataValue> CMoveRQ::ConstructPDVByDataSet(const DataSet*
 std::vector<PresentationDataValue>  CMoveRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDV;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDV;
 }
 std::vector<PresentationDataValue>  CMoveCancelRq::ConstructPDVByDataSet(const DataSet* inDataSet){
   std::vector<PresentationDataValue> thePDV;
   (void)inDataSet;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDV;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmCStoreMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmCStoreMessages.cxx
@@ -53,7 +53,7 @@ const DataSet* inDataSet = &file.GetDataSet();
   PresentationContextRQ pc( UIDs::VerificationSOPClass );
   uint8_t prescontid;
 {
-  assert( inDataSet );
+  gdcm_assert( inDataSet );
   PresentationDataValue thePDV;
 #if 0
   std::string UIDString;
@@ -91,12 +91,12 @@ const DataSet* inDataSet = &file.GetDataSet();
     }
   const DataElement& msclass = inDataSet->GetDataElement( Tag(0x0008, 0x0016) );
   const char *uid = msclass.GetByteValue()->GetPointer();
-  assert( uid );
+  gdcm_assert( uid );
   std::string suid = std::string(uid, msclass.GetByteValue()->GetLength());
 
   // self check
 //  const PresentationContextAC * pc = inConnection.GetPresentationContextACByID(prescontid);
-//  assert( pc );
+//  gdcm_assert( pc );
 //  TransferSyntaxSub const &tssub = pc->GetTransferSyntax();
   const TransferSyntax & fmits = file.GetHeader().GetDataSetTransferSyntax();
   const char *tsuidvalue = fmits.GetString();
@@ -109,9 +109,9 @@ const DataSet* inDataSet = &file.GetDataSet();
   prescontid = inConnection.GetPresentationContextIDFromPresentationContext(pc);
   // prescontid cannot possibly be unknown since we are only looking in our own
   // AAssociateRQPDU
-  assert( prescontid != 0 );
+  gdcm_assert( prescontid != 0 );
   const PresentationContextRQ * rqpc = inConnection.GetPresentationContextRQByID(prescontid);
-  assert( rqpc );
+  gdcm_assert( rqpc );
 
   // Now let's see if this best matching PresentationContextRQ can be found in the AC
   // section of the AAssociateACPDU
@@ -130,7 +130,7 @@ const DataSet* inDataSet = &file.GetDataSet();
     }
 
   TransferSyntaxSub const & actssub = acpc->GetTransferSyntax();
-  assert( rqpc->GetNumberOfTransferSyntaxes() == 1 ); // TODO FIXME
+  gdcm_assert( rqpc->GetNumberOfTransferSyntaxes() == 1 ); // TODO FIXME
   TransferSyntaxSub const & rqtssub = rqpc->GetTransferSyntax(0);
   if( !(actssub == rqtssub) )
     {
@@ -154,13 +154,13 @@ const DataSet* inDataSet = &file.GetDataSet();
 
   thePDV.SetPresentationContextID( prescontid );
 
-  assert(suid.size() < std::numeric_limits<uint32_t>::max());
+  gdcm_assert(suid.size() < std::numeric_limits<uint32_t>::max());
   de.SetByteValue( suid.c_str(), (uint32_t)suid.size()  );
   ds.Insert( de );
   }
 
   {
-  assert( inDataSet->FindDataElement( Tag(0x0008, 0x0018) ) );
+  gdcm_assert( inDataSet->FindDataElement( Tag(0x0008, 0x0018) ) );
   const DataElement& msinst = inDataSet->GetDataElement( Tag(0x0008, 0x0018) );
   std::string suid;
   DataElement de( Tag(0x0,0x1000) );
@@ -171,9 +171,9 @@ const DataSet* inDataSet = &file.GetDataSet();
     if( bv )
       {
       const char *uid = bv->GetPointer();
-      assert( uid );
+      gdcm_assert( uid );
       suid = std::string(uid, bv->GetLength() );
-      assert(suid.size() < std::numeric_limits<uint32_t>::max());
+      gdcm_assert(suid.size() < std::numeric_limits<uint32_t>::max());
       }
     }
   de.SetByteValue( suid.c_str(), (uint32_t)suid.size()  );
@@ -188,7 +188,7 @@ static uint32_t messageid = 1;
   {
   Attribute<0x0,0x110> at = { 0 };
   at.SetValue( (unsigned short)messageid++ );
-  assert( messageid < std::numeric_limits<uint32_t>::max());
+  gdcm_assert( messageid < std::numeric_limits<uint32_t>::max());
   ds.Insert( at.GetAsDataElement() );
   }
   {
@@ -202,7 +202,7 @@ static uint32_t messageid = 1;
   {
   Attribute<0x0,0x0> at = { 0 };
   unsigned int glen = ds.GetLength<ImplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   at.SetValue( glen );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -252,7 +252,7 @@ if( !writeDataSet )
       thePDV.SetMessageHeader( 0 );
     else
       {
-      assert( cur == end );
+      gdcm_assert( cur == end );
       thePDV.SetMessageHeader( 2 );
       }
     thePDVs.push_back(thePDV);
@@ -270,7 +270,7 @@ const ULConnection &inConnection, const BaseRootQuery* inRootQuery)
   std::vector<PresentationDataValue> thePDVs;
   (void)inRootQuery;
   (void)inConnection;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDVs;
 }
 
@@ -279,7 +279,7 @@ std::vector<PresentationDataValue>  CStoreRSP::ConstructPDV(const ULConnection &
 {
   std::vector<PresentationDataValue> thePDVs;
   (void)inRootQuery;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return thePDVs;
 }
 
@@ -324,7 +324,7 @@ std::vector<PresentationDataValue> CStoreRSP::ConstructPDV(const DataSet* inData
     {
     Attribute<0x0,0x0> at = { 0 };
     unsigned int glen = ds.GetLength<ImplicitDataElement>();
-    assert( (glen % 2) == 0 );
+    gdcm_assert( (glen % 2) == 0 );
     at.SetValue( glen );
     ds.Insert( at.GetAsDataElement() );
     }

--- a/Source/MessageExchangeDefinition/gdcmCompositeNetworkFunctions.cxx
+++ b/Source/MessageExchangeDefinition/gdcmCompositeNetworkFunctions.cxx
@@ -257,7 +257,7 @@ bool CompositeNetworkFunctions::CFind( const char *remote, uint16_t portno,
     gdcmErrorMacro( "Failed to GetResponses." );
     return false;
     }
-  assert( !theResponses.empty() );
+  gdcm_assert( !theResponses.empty() );
   // take the last one:
   const DataSet &ds = theResponses[ theResponses.size() - 1 ]; // FIXME
   assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );
@@ -288,7 +288,7 @@ bool CompositeNetworkFunctions::CFind( const char *remote, uint16_t portno,
       Attribute<0x0,0x0902> errormsg;
       errormsg.SetFromDataSet( ds );
       const char *themsg = errormsg.GetValue();
-      assert( themsg ); (void)themsg;
+      gdcm_assert( themsg ); (void)themsg;
       gdcmErrorMacro( "Response Status: [" << themsg << "]" );
       }
     break;
@@ -305,7 +305,7 @@ bool CompositeNetworkFunctions::CFind( const char *remote, uint16_t portno,
         Attribute<0x0,0x0902> errormsg;
         errormsg.SetFromDataSet( ds );
         const char *themsg = errormsg.GetValue();
-        assert( themsg ); (void)themsg;
+        gdcm_assert( themsg ); (void)themsg;
         gdcmErrorMacro( "Response Status: " << themsg );
         }
       }
@@ -326,7 +326,7 @@ public:
   void ShowIteration() override
     {
     index++;
-    assert( index <= nfiles );
+    gdcm_assert( index <= nfiles );
     refprogress = progress;
     }
   void ShowProgress(Subject *caller, const Event &evt) override
@@ -384,7 +384,7 @@ bool CompositeNetworkFunctions::CStore( const char *remote, uint16_t portno,
       {
       const std::string & filename = files[i];
       fn = filename.c_str();
-      assert( fn && *fn ); (void)fn;
+      gdcm_assert( fn && *fn ); (void)fn;
       Reader reader;
       reader.SetFileName( filename.c_str() );
       gdcmDebugMacro( "Processing: " << filename );
@@ -401,7 +401,7 @@ bool CompositeNetworkFunctions::CStore( const char *remote, uint16_t portno,
         gdcmErrorMacro( "Could not C-STORE: " << filename );
         return false;
         }
-      assert( theDataSets.size() == 1 );
+      gdcm_assert( theDataSets.size() == 1 );
       const DataSet &ds = theDataSets[0];
       assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );
       DataElement const & de = ds.GetDataElement(Tag(0x0,0x0900));
@@ -429,7 +429,7 @@ bool CompositeNetworkFunctions::CStore( const char *remote, uint16_t portno,
           Attribute<0x0,0x0902> errormsg;
           errormsg.SetFromDataSet( ds );
           const char *themsg = errormsg.GetValue();
-          assert( themsg ); (void)themsg;
+          gdcm_assert( themsg ); (void)themsg;
           gdcmErrorMacro( "Response Status: " << themsg );
           ret = false; // at least one file was not sent correctly
         }

--- a/Source/MessageExchangeDefinition/gdcmFindPatientRootQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmFindPatientRootQuery.cxx
@@ -84,7 +84,7 @@ std::vector<Tag> FindPatientRootQuery::GetTagListByLevel(const EQueryLevel& inQu
   case eImage:
     return mImage.GetAllTags(ePatientRootType);
   default: //have to return _something_ if a query level isn't given
-	  assert(0);
+	  gdcm_assert(0);
 	  {
 		  std::vector<Tag> empty;
 		  return empty;
@@ -225,7 +225,7 @@ bool FindPatientRootQuery::ValidateQuery(bool inStrict) const
       Tag t = itor->GetTag();
       if (t == level.GetTag()) continue;
       if (t == language.GetTag()) continue;
-      assert( !tags.empty() );
+      gdcm_assert( !tags.empty() );
       if (std::find(tags.begin(), tags.end(), t) == tags.end())
         {
         //check to see if it's a language tag, 8,5, and if it is, ignore if it's one

--- a/Source/MessageExchangeDefinition/gdcmFindStudyRootQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmFindStudyRootQuery.cxx
@@ -76,7 +76,7 @@ std::vector<Tag> FindStudyRootQuery::GetTagListByLevel(const EQueryLevel& inQuer
   case eImage:
     return mImage.GetAllTags(eStudyRootType); 
   default: //have to return _something_ if a query level isn't given
-    assert(0);
+    gdcm_assert(0);
       {
       std::vector<Tag> empty;
       return empty;
@@ -232,7 +232,7 @@ bool FindStudyRootQuery::ValidateQuery(bool inStrict) const
       }
     if( thePresentTagCount != hiertags.size() )
       {
-      assert( !hiertags.empty() );
+      gdcm_assert( !hiertags.empty() );
       gdcmWarningMacro( "Missing Key found (within the hierarchical search ones): " << hiertags[0] );
       gdcmDebugMacro( "Current DataSet is: " << ds );
       theReturn = false;

--- a/Source/MessageExchangeDefinition/gdcmImplementationClassUIDSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmImplementationClassUIDSub.cxx
@@ -27,14 +27,14 @@ ImplementationClassUIDSub::ImplementationClassUIDSub()
   ImplementationClassUID = FileMetaInformation::GetImplementationClassUID();
 
   ItemLength = (uint16_t)ImplementationClassUID.size();
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &ImplementationClassUIDSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -43,11 +43,11 @@ std::istream &ImplementationClassUIDSub::Read(std::istream &is)
   ItemLength = itemlength;
 
   char name[256];
-  assert( itemlength < 256 );
+  gdcm_assert( itemlength < 256 );
   is.read( name, itemlength );
   ImplementationClassUID = std::string(name, itemlength);
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   return is;
 }
 
@@ -68,7 +68,7 @@ const std::ostream &ImplementationClassUIDSub::Write(std::ostream &os) const
 size_t ImplementationClassUIDSub::Size() const
 {
   size_t ret = 0;
-  assert( ImplementationClassUID.size() == ItemLength );
+  gdcm_assert( ImplementationClassUID.size() == ItemLength );
   ret += sizeof(ItemType);
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);

--- a/Source/MessageExchangeDefinition/gdcmImplementationVersionNameSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmImplementationVersionNameSub.cxx
@@ -26,14 +26,14 @@ ImplementationVersionNameSub::ImplementationVersionNameSub()
 {
   ImplementationVersionName = FileMetaInformation::GetImplementationVersionName();
   ItemLength = (uint16_t)ImplementationVersionName.size();
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &ImplementationVersionNameSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -42,7 +42,7 @@ std::istream &ImplementationVersionNameSub::Read(std::istream &is)
   ItemLength = itemlength;
 
   char name[256];
-  assert( itemlength < 256 );
+  gdcm_assert( itemlength < 256 );
   is.read( name, itemlength );
   ImplementationVersionName = std::string(name,itemlength);
 
@@ -66,7 +66,7 @@ const std::ostream &ImplementationVersionNameSub::Write(std::ostream &os) const
 size_t ImplementationVersionNameSub::Size() const
 {
   size_t ret = 0;
-  assert( ImplementationVersionName.size() == ItemLength );
+  gdcm_assert( ImplementationVersionName.size() == ItemLength );
   ret += sizeof(ItemType);
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);

--- a/Source/MessageExchangeDefinition/gdcmMaximumLengthSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmMaximumLengthSub.cxx
@@ -25,14 +25,14 @@ MaximumLengthSub::MaximumLengthSub()
 {
   ItemLength = 0x4;
   MaximumLength = 0x4000;
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &MaximumLengthSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;

--- a/Source/MessageExchangeDefinition/gdcmMovePatientRootQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmMovePatientRootQuery.cxx
@@ -84,7 +84,7 @@ std::vector<Tag> MovePatientRootQuery::GetTagListByLevel(const EQueryLevel& inQu
   case eImage:
     return mImage.GetUniqueTags(ePatientRootType);
   default: //have to return _something_ if a query level isn't given
-    assert(0);
+    gdcm_assert(0);
       {
       std::vector<Tag> empty;
       return empty;
@@ -225,7 +225,7 @@ bool MovePatientRootQuery::ValidateQuery(bool inStrict) const
       const Tag &t = itor->GetTag();
       if (t == level.GetTag()) continue;
       if (t == language.GetTag()) continue;
-      assert( !tags.empty() );
+      gdcm_assert( !tags.empty() );
       if (std::find(tags.begin(), tags.end(), t) == tags.end())
         {
         //check to see if it's a language tag, 8,5, and if it is, ignore if it's one

--- a/Source/MessageExchangeDefinition/gdcmMoveStudyRootQuery.cxx
+++ b/Source/MessageExchangeDefinition/gdcmMoveStudyRootQuery.cxx
@@ -74,7 +74,7 @@ std::vector<Tag> MoveStudyRootQuery::GetTagListByLevel(const EQueryLevel& inQuer
   case eImage:
     return mImage.GetUniqueTags(eStudyRootType);
   default: //have to return _something_ if a query level isn't given
-	  assert(0);
+	  gdcm_assert(0);
 	  {
 		  std::vector<Tag> empty;
 		  return empty;

--- a/Source/MessageExchangeDefinition/gdcmNActionMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNActionMessages.cxx
@@ -28,7 +28,7 @@ namespace gdcm{
     {
       std::vector<PresentationDataValue> thePDV;
       (void)inConnection; (void)inQuery;
-      assert( 0 && "TODO" );
+      gdcm_assert( 0 && "TODO" );
       return thePDV;
     }
 
@@ -36,7 +36,7 @@ namespace gdcm{
       NActionRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
         std::vector<PresentationDataValue> thePDV;
         (void)inDataSet;
-        assert( 0 && "TODO" );
+        gdcm_assert( 0 && "TODO" );
         return thePDV;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmNCreateMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNCreateMessages.cxx
@@ -73,7 +73,7 @@ namespace gdcm{
       {
         Attribute<0x0,0x0> at = { 0 };
         unsigned int glen = ds.GetLength<ImplicitDataElement>();
-        assert( (glen % 2) == 0 );
+        gdcm_assert( (glen % 2) == 0 );
         at.SetValue( glen );
         ds.Insert( at.GetAsDataElement() );
       }
@@ -91,7 +91,7 @@ namespace gdcm{
       NCreateRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
         std::vector<PresentationDataValue> thePDV;
         (void)inDataSet;
-        assert( 0 && "TODO" );
+        gdcm_assert( 0 && "TODO" );
         return thePDV;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmNDeleteMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNDeleteMessages.cxx
@@ -28,7 +28,7 @@ namespace gdcm{
     {
       std::vector<PresentationDataValue> thePDV;
       (void)inConnection; (void)inQuery;
-      assert( 0 && "TODO" );
+      gdcm_assert( 0 && "TODO" );
       return thePDV;
     }
 
@@ -36,7 +36,7 @@ namespace gdcm{
       NDeleteRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
         std::vector<PresentationDataValue> thePDV;
         (void)inDataSet;
-        assert( 0 && "TODO" );
+        gdcm_assert( 0 && "TODO" );
         return thePDV;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmNEventReportMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNEventReportMessages.cxx
@@ -32,7 +32,7 @@ namespace gdcm{
     {
       std::vector<PresentationDataValue> thePDV;
       (void)inConnection; (void)inQuery;
-      assert( 0 && "TODO" );
+      gdcm_assert( 0 && "TODO" );
       return thePDV;
     }
 
@@ -40,7 +40,7 @@ namespace gdcm{
       NEventReportRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
         std::vector<PresentationDataValue> thePDV;
         (void)inDataSet;
-        assert( 0 && "TODO" );
+        gdcm_assert( 0 && "TODO" );
         return thePDV;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmNGetMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNGetMessages.cxx
@@ -28,7 +28,7 @@ namespace gdcm{
     {
       std::vector<PresentationDataValue> thePDV;
       (void)inConnection; (void)inQuery;
-      assert( 0 && "TODO" );
+      gdcm_assert( 0 && "TODO" );
       return thePDV;
     }
 
@@ -36,7 +36,7 @@ namespace gdcm{
       NGetRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
         std::vector<PresentationDataValue> thePDV;
         (void)inDataSet;
-        assert( 0 && "TODO" );
+        gdcm_assert( 0 && "TODO" );
         return thePDV;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmNSetMessages.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNSetMessages.cxx
@@ -73,7 +73,7 @@ namespace gdcm{
   {
   Attribute<0x0,0x0> at = { 0 };
   unsigned int glen = ds.GetLength<ImplicitDataElement>();
-  assert( (glen % 2) == 0 );
+  gdcm_assert( (glen % 2) == 0 );
   at.SetValue( glen );
   ds.Insert( at.GetAsDataElement() );
   }
@@ -90,7 +90,7 @@ namespace gdcm{
       NSetRSP::ConstructPDVByDataSet(const DataSet* inDataSet){
     std::vector<PresentationDataValue> thePDV;
     (void)inDataSet;
-    assert( 0 && "TODO" );
+    gdcm_assert( 0 && "TODO" );
     return thePDV;
   }
 

--- a/Source/MessageExchangeDefinition/gdcmNormalizedNetworkFunctions.cxx
+++ b/Source/MessageExchangeDefinition/gdcmNormalizedNetworkFunctions.cxx
@@ -132,7 +132,7 @@ namespace gdcm
 			gdcmErrorMacro( "Failed to GetResponses." );
 			return false;
 		}
-		assert( !theResponses.empty() );
+		gdcm_assert( !theResponses.empty() );
 		// take the last one:
 		const DataSet &ds = theResponses[ theResponses.size() - 1 ]; // FIXME
 		assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );
@@ -243,7 +243,7 @@ namespace gdcm
 			gdcmErrorMacro( "Failed to GetResponses." );
 			return false;
 		}
-		assert( !theResponses.empty() );
+		gdcm_assert( !theResponses.empty() );
 		// take the last one:
 		const DataSet &ds = theResponses[ theResponses.size() - 1 ]; // FIXME
 		assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );

--- a/Source/MessageExchangeDefinition/gdcmPDUFactory.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPDUFactory.cxx
@@ -345,7 +345,7 @@ std::vector<PresentationDataValue> PDUFactory::GetPDVs(const std::vector<BasePDU
     PDataTFPDU* thePDataTFPDU = dynamic_cast<PDataTFPDU*>(*itor);
     if (thePDataTFPDU == nullptr)
       {
-      assert(0); //shouldn't really get here.
+      gdcm_assert(0); //shouldn't really get here.
       return outPDVs; //just stop now, no longer with data pdus.
       }
     size_t theNumPDVsinPDU = thePDataTFPDU->GetNumberOfPresentationDataValues();

--- a/Source/MessageExchangeDefinition/gdcmPDataTFPDU.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPDataTFPDU.cxx
@@ -23,16 +23,16 @@ const uint8_t PDataTFPDU::Reserved2 = 0x00;
 
 PDataTFPDU::PDataTFPDU()
 {
-  assert(Size() < std::numeric_limits<uint32_t>::max());
+  gdcm_assert(Size() < std::numeric_limits<uint32_t>::max());
   ItemLength = (uint32_t)Size() - 6;
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 }
 
 std::istream &PDataTFPDU::Read(std::istream &is)
 {
   //uint8_t itemtype = 0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t itemlength = ItemLength;
@@ -48,8 +48,8 @@ std::istream &PDataTFPDU::Read(std::istream &is)
     V.push_back( pdv );
     curlen += pdv.Size();
     }
-  assert( curlen == ItemLength );
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( curlen == ItemLength );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 
   return is;
 }
@@ -58,7 +58,7 @@ std::istream &PDataTFPDU::ReadInto(std::istream &is, std::ostream &os)
 {
   uint8_t itemtype = 0;
   is.read( (char*)&itemtype, sizeof(ItemType) );
-  assert( itemtype == ItemType );
+  gdcm_assert( itemtype == ItemType );
   uint8_t reserved2 = 0;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint32_t itemlength = ItemLength;
@@ -74,15 +74,15 @@ std::istream &PDataTFPDU::ReadInto(std::istream &is, std::ostream &os)
     V.push_back( pdv );
     curlen += pdv.Size();
     }
-  assert( curlen == ItemLength );
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( curlen == ItemLength );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
 
   return is;
 }
 
 const std::ostream &PDataTFPDU::Write(std::ostream &os) const
 {
-  assert( (ItemLength + 4 + 1 + 1) == Size() );
+  gdcm_assert( (ItemLength + 4 + 1 + 1) == Size() );
   os.write( (const char*)&ItemType, sizeof(ItemType) );
   os.write( (const char*)&Reserved2, sizeof(Reserved2) );
   //os.write( (const char*)&ItemLength, sizeof(ItemLength) );

--- a/Source/MessageExchangeDefinition/gdcmPDataTFPDU.h
+++ b/Source/MessageExchangeDefinition/gdcmPDataTFPDU.h
@@ -42,13 +42,13 @@ public:
 
   void AddPresentationDataValue( PresentationDataValue const &pdv ) {
     V.push_back( pdv );
-    assert(Size() < std::numeric_limits<uint32_t>::max());
+    gdcm_assert(Size() < std::numeric_limits<uint32_t>::max());
     ItemLength = (uint32_t)Size() - 6;
     }
 
   typedef std::vector<PresentationDataValue>::size_type SizeType;
   PresentationDataValue const &GetPresentationDataValue(SizeType i) const {
-    assert( !V.empty() && i < V.size() );
+    gdcm_assert( !V.empty() && i < V.size() );
     return V[i];
   }
   SizeType GetNumberOfPresentationDataValues() const {

--- a/Source/MessageExchangeDefinition/gdcmPresentationContext.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContext.cxx
@@ -45,7 +45,7 @@ void PresentationContext::AddTransferSyntax( const char *tsstr )
 
 void PresentationContext::SetPresentationContextID( uint8_t id )
 {
-  assert( id );
+  gdcm_assert( id );
   ID = id;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmPresentationContext.h
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContext.h
@@ -53,8 +53,8 @@ public:
 
   bool operator==(const PresentationContext & pc) const
     {
-    assert( TransferSyntaxes.size() == 1 ); // TODO
-    assert( pc.TransferSyntaxes.size() == 1 );
+    gdcm_assert( TransferSyntaxes.size() == 1 ); // TODO
+    gdcm_assert( pc.TransferSyntaxes.size() == 1 );
     return AbstractSyntax == pc.AbstractSyntax && TransferSyntaxes == pc.TransferSyntaxes;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmPresentationContextAC.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContextAC.cxx
@@ -30,14 +30,14 @@ PresentationContextAC::PresentationContextAC()
   ID = 1; // odd [1-255]
   Result = 0;
   ItemLength = 8;
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &PresentationContextAC::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -56,7 +56,7 @@ std::istream &PresentationContextAC::Read(std::istream &is)
   is.read( (char*)&reserved8, sizeof(Reserved6) );
   SubItems.Read( is );
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   return is;
 }
 
@@ -74,7 +74,7 @@ const std::ostream &PresentationContextAC::Write(std::ostream &os) const
   os.write( (const char*)&Reserved8, sizeof(Reserved8) );
   SubItems.Write(os);
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   return os;
 }
 
@@ -90,8 +90,8 @@ size_t PresentationContextAC::Size() const
   ret += sizeof(Reserved8);
   ret += SubItems.Size();
 
-  assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
-  assert(ret >= 4);
+  gdcm_assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
+  gdcm_assert(ret >= 4);
   return ret;
 }
 
@@ -99,7 +99,7 @@ void PresentationContextAC::SetTransferSyntax( TransferSyntaxSub const &ts )
 {
   SubItems = ts;
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 void PresentationContextAC::Print(std::ostream &os) const

--- a/Source/MessageExchangeDefinition/gdcmPresentationContextGenerator.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContextGenerator.cxx
@@ -128,14 +128,14 @@ bool PresentationContextGenerator::GenerateFromFilenames(const Directory::Filena
 bool PresentationContextGenerator::AddPresentationContext( const char *as, const char * ts )
 {
   // \precondition
-  assert( as );
-  assert( ts );
+  gdcm_assert( as );
+  gdcm_assert( ts );
 
   SizeType n = PresContext.size();
   PresentationContext pc;
   pc.SetAbstractSyntax( as );
   SizeType idn = 2*n + 1;
-  assert( idn <= std::numeric_limits<uint8_t>::max() );
+  gdcm_assert( idn <= std::numeric_limits<uint8_t>::max() );
   pc.SetPresentationContextID( (uint8_t)idn );
   pc.AddTransferSyntax( ts );
 
@@ -159,7 +159,7 @@ void PresentationContextGenerator::SetMergeModeToAbstractSyntax()
 
 void PresentationContextGenerator::SetMergeModeToTransferSyntax()
 {
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
 }
 
 } // end namespace gdcm

--- a/Source/MessageExchangeDefinition/gdcmPresentationContextRQ.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContextRQ.cxx
@@ -36,7 +36,7 @@ PresentationContextRQ::PresentationContextRQ()
 {
   ID = 0x01;
   ItemLength = 8;
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 PresentationContextRQ::PresentationContextRQ( UIDs::TSName asname, UIDs::TSName tsname )
@@ -48,7 +48,7 @@ PresentationContextRQ::PresentationContextRQ( UIDs::TSName asname, UIDs::TSName 
 
   TransferSyntaxSub ts;
   ts.SetNameFromUID( tsname );
-  assert( TransferSyntaxes.empty() );
+  gdcm_assert( TransferSyntaxes.empty() );
   AddTransferSyntax( ts );
 }
 
@@ -56,7 +56,7 @@ std::istream &PresentationContextRQ::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -70,7 +70,7 @@ std::istream &PresentationContextRQ::Read(std::istream &is)
   is.read( (char*)&reserved6, sizeof(Reserved6) );
   uint8_t reserved7;
   is.read( (char*)&reserved7, sizeof(Reserved7) );
-//  assert( reserved7 == 0 );
+//  gdcm_assert( reserved7 == 0 );
   //no need for this assert--'This reserved field shall be sent with a value 00H but not tested to this value when received.'
   uint8_t reserved8;
   is.read( (char*)&reserved8, sizeof(Reserved6) );
@@ -85,15 +85,15 @@ std::istream &PresentationContextRQ::Read(std::istream &is)
     TransferSyntaxes.push_back( ts );
     curlen += ts.Size();
     }
-  assert( curlen + offset == ItemLength );
+  gdcm_assert( curlen + offset == ItemLength );
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   return is;
 }
 
 const std::ostream &PresentationContextRQ::Write(std::ostream &os) const
 {
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   os.write( (const char*)&ItemType, sizeof(ItemType) );
   os.write( (const char*)&Reserved2, sizeof(Reserved2) );
   uint16_t copy = ItemLength;
@@ -131,8 +131,8 @@ size_t PresentationContextRQ::Size() const
     ret += it->Size();
     }
 
-  assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
-  assert(ret >= 4);
+  gdcm_assert(ret <= (size_t)std::numeric_limits<uint16_t>::max);
+  gdcm_assert(ret >= 4);
   return ret;
 }
 
@@ -140,19 +140,19 @@ void PresentationContextRQ::SetAbstractSyntax( AbstractSyntax const & as )
 {
   SubItems = as;
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 void PresentationContextRQ::AddTransferSyntax( TransferSyntaxSub const &ts )
 {
   TransferSyntaxes.push_back( ts );
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 void PresentationContextRQ::SetPresentationContextID( uint8_t id )
 {
-  assert( id );
+  gdcm_assert( id );
   ID = id;
 }
 
@@ -192,7 +192,7 @@ PresentationContextRQ::PresentationContextRQ(const PresentationContext & in)
     AddTransferSyntax( ts );
     }
   SetPresentationContextID( in.GetPresentationContextID() );
-  assert( GetNumberOfTransferSyntaxes() == in.GetNumberOfTransferSyntaxes() );
+  gdcm_assert( GetNumberOfTransferSyntaxes() == in.GetNumberOfTransferSyntaxes() );
 }
 
 } // end namespace network

--- a/Source/MessageExchangeDefinition/gdcmPresentationContextRQ.h
+++ b/Source/MessageExchangeDefinition/gdcmPresentationContextRQ.h
@@ -64,8 +64,8 @@ public:
 
   bool operator==(const PresentationContextRQ & pc) const
     {
-    assert( TransferSyntaxes.size() == 1 ); // TODO
-    assert( pc.TransferSyntaxes.size() == 1 );
+    gdcm_assert( TransferSyntaxes.size() == 1 ); // TODO
+    gdcm_assert( pc.TransferSyntaxes.size() == 1 );
     return SubItems == pc.SubItems && TransferSyntaxes == pc.TransferSyntaxes;
     }
 

--- a/Source/MessageExchangeDefinition/gdcmPresentationDataValue.cxx
+++ b/Source/MessageExchangeDefinition/gdcmPresentationDataValue.cxx
@@ -31,7 +31,7 @@ PresentationDataValue::PresentationDataValue()
   PresentationContextID = 0; //MUST BE SET BY THE CALLER!
 
   // postcondition
-  assert(Size() < std::numeric_limits<uint32_t>::max());
+  gdcm_assert(Size() < std::numeric_limits<uint32_t>::max());
   ItemLength = (uint32_t)Size() - 4;
   assert (ItemLength + 4 == Size() );
 }
@@ -52,7 +52,7 @@ std::istream &PresentationDataValue::Read(std::istream &is)
     gdcmDebugMacro( "Bizarre MessageHeader: " << MessageHeader );
     }
 
-  assert( ItemLength > 2 );
+  gdcm_assert( ItemLength > 2 );
   uint32_t vl = ItemLength - 2;
   Blob.resize( vl );
   is.read( &Blob[0], vl );
@@ -77,7 +77,7 @@ std::istream &PresentationDataValue::ReadInto(std::istream &is, std::ostream &os
     gdcmDebugMacro( "Bizarre MessageHeader: " << MessageHeader );
     }
 
-  assert( ItemLength > 2 );
+  gdcm_assert( ItemLength > 2 );
   uint32_t vl = ItemLength - 2;
   Blob.resize( vl );
   is.read( &Blob[0], vl );
@@ -92,18 +92,18 @@ const std::ostream &PresentationDataValue::Write(std::ostream &os) const
   uint32_t copy = ItemLength;
   SwapperDoOp::SwapArray(&copy,1);
   os.write( (const char*)&copy, sizeof(ItemLength) );
-  assert( os.good() );
+  gdcm_assert( os.good() );
   os.write( (const char*)&PresentationContextID, sizeof(PresentationContextID) );
-  assert( os.good() );
+  gdcm_assert( os.good() );
 
-  assert( MessageHeader <= 3 );
+  gdcm_assert( MessageHeader <= 3 );
   uint8_t t = MessageHeader;
   os.write( (const char*)&t, 1 );
-  assert( os.good() );
+  gdcm_assert( os.good() );
 
   os.write( Blob.c_str(), Blob.size() );
 
-  assert( Blob.size() == ItemLength - 2 );
+  gdcm_assert( Blob.size() == ItemLength - 2 );
   assert (ItemLength + 4 == Size() );
 
   return os;
@@ -122,9 +122,9 @@ size_t PresentationDataValue::Size() const
 
 void PresentationDataValue::SetBlob(const std::string & partialblob)
 {
-  assert( !partialblob.empty() );
+  gdcm_assert( !partialblob.empty() );
   Blob = partialblob;
-  assert(Size() < std::numeric_limits<uint32_t>::max());
+  gdcm_assert(Size() < std::numeric_limits<uint32_t>::max());
   ItemLength = (uint32_t)Size() - 4;
   assert (ItemLength + 4 == Size() );
 }

--- a/Source/MessageExchangeDefinition/gdcmPresentationDataValue.h
+++ b/Source/MessageExchangeDefinition/gdcmPresentationDataValue.h
@@ -49,18 +49,18 @@ public:
 
   uint8_t GetPresentationContextID() const { return PresentationContextID; }
   void SetPresentationContextID(uint8_t id) {
-    assert( id );
+    gdcm_assert( id );
     PresentationContextID = id;
   }
   uint8_t GetMessageHeader() const {
-    assert( MessageHeader <= 0x3 );
+    gdcm_assert( MessageHeader <= 0x3 );
     return MessageHeader;
   }
   // E.2 MESSAGE CONTROL HEADER ENCODING
   // Only the first two bits are considered
   void SetMessageHeader(uint8_t messageheader) {
     MessageHeader = messageheader;
-    assert( MessageHeader <= 0x3 );
+    gdcm_assert( MessageHeader <= 0x3 );
   }
   //flip the least significant bit of the message header to 1
   //if this is a command, else set it to 0.

--- a/Source/MessageExchangeDefinition/gdcmQueryFactory.cxx
+++ b/Source/MessageExchangeDefinition/gdcmQueryFactory.cxx
@@ -228,7 +228,7 @@ DataElement QueryFactory::ProduceCharacterSetDataElement(const std::vector<EChar
       {
       theOutputString += "\\";
       // the following code will not work for UTF-8 and eGB18030
-      assert( itor < inCharSetType.end() );
+      gdcm_assert( itor < inCharSetType.end() );
       visited[*itor] = true;
       }
   }

--- a/Source/MessageExchangeDefinition/gdcmQueryPatient.cxx
+++ b/Source/MessageExchangeDefinition/gdcmQueryPatient.cxx
@@ -58,7 +58,7 @@ std::vector<Tag> QueryPatient::GetUniqueTags(const ERootType& inRootType) const
 
 std::vector<Tag> QueryPatient::GetHierachicalSearchTags(const ERootType& inRootType) const
 {
-  assert( inRootType == ePatientRootType );
+  gdcm_assert( inRootType == ePatientRootType );
   std::vector<Tag> tags;
   // Patient is always toplevel !
   // just return Required and Unique

--- a/Source/MessageExchangeDefinition/gdcmRoleSelectionSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmRoleSelectionSub.cxx
@@ -30,14 +30,14 @@ RoleSelectionSub::RoleSelectionSub()
   SCPRole = 0;
 
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &RoleSelectionSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -51,7 +51,7 @@ std::istream &RoleSelectionSub::Read(std::istream &is)
   UIDLength = uidlength;
 
   char name[256];
-  assert( uidlength < 256 );
+  gdcm_assert( uidlength < 256 );
   is.read( name, uidlength );
   Name = std::string(name,uidlength);
 
@@ -63,14 +63,14 @@ std::istream &RoleSelectionSub::Read(std::istream &is)
   is.read( (char*)&scprole, sizeof(SCPRole) );
   SCPRole = scprole;
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 
   return is;
 }
 
 const std::ostream &RoleSelectionSub::Write(std::ostream &os) const
 {
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 
   os.write( (const char*)&ItemType, sizeof(ItemType) );
   os.write( (const char*)&Reserved2, sizeof(Reserved2) );
@@ -79,20 +79,20 @@ const std::ostream &RoleSelectionSub::Write(std::ostream &os) const
   SwapperDoOp::SwapArray(&copy,1);
   os.write( (const char*)&copy, sizeof(ItemLength) );
 
-  assert( ItemLength > UIDLength );
+  gdcm_assert( ItemLength > UIDLength );
   uint16_t uidlength = UIDLength;
   SwapperDoOp::SwapArray(&uidlength,1);
   os.write( (const char*)&uidlength, sizeof(UIDLength) );
 
-  assert( (size_t)UIDLength == Name.size() );
+  gdcm_assert( (size_t)UIDLength == Name.size() );
   os.write( Name.c_str(), Name.size() );
 
   uint8_t scurole = SCURole;
-  assert( scurole == 0 || scurole == 1 );
+  gdcm_assert( scurole == 0 || scurole == 1 );
   os.write( (const char*)&scurole, sizeof(SCURole) );
 
   uint8_t scprole = SCPRole;
-  assert( scprole == 0 || scprole == 1 );
+  gdcm_assert( scprole == 0 || scprole == 1 );
   os.write( (const char*)&scprole, sizeof(SCPRole) );
 
   return os;
@@ -105,7 +105,7 @@ size_t RoleSelectionSub::Size() const
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);
   ret += sizeof(UIDLength);
-  assert( Name.size() == UIDLength );
+  gdcm_assert( Name.size() == UIDLength );
   ret += UIDLength;
   ret += sizeof(SCURole);
   ret += sizeof(SCPRole);
@@ -134,13 +134,13 @@ void RoleSelectionSub::SetTuple(const char *uid, uint8_t scurole, uint8_t scprol
     {
     Name = uid;
     UIDLength = (uint16_t)strlen( uid );
-    assert( (size_t)UIDLength == Name.size() );
+    gdcm_assert( (size_t)UIDLength == Name.size() );
     SCURole = scurole % 2;
     SCPRole = scprole % 2;
     ItemLength = (uint16_t)(Size() - 4);
     }
   // post condition
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 void RoleSelectionSub::Print(std::ostream &os) const

--- a/Source/MessageExchangeDefinition/gdcmSOPClassExtendedNegociationSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmSOPClassExtendedNegociationSub.cxx
@@ -28,14 +28,14 @@ SOPClassExtendedNegociationSub::SOPClassExtendedNegociationSub()
   UIDLength = 0;
 
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 std::istream &SOPClassExtendedNegociationSub::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -49,13 +49,13 @@ std::istream &SOPClassExtendedNegociationSub::Read(std::istream &is)
   UIDLength = uidlength;
 
   char name[256];
-  assert( uidlength < 256 );
+  gdcm_assert( uidlength < 256 );
   is.read( name, uidlength );
   Name = std::string(name,uidlength);
 
-  assert( uidlength < ItemLength );
+  gdcm_assert( uidlength < ItemLength );
   uint16_t bloblength = (uint16_t)(ItemLength - 2 - uidlength);
-  assert( bloblength == 6 ); (void)bloblength;
+  gdcm_assert( bloblength == 6 ); (void)bloblength;
   SCAI.Read( is );
 
   return is;
@@ -120,7 +120,7 @@ void SOPClassExtendedNegociationSub::SetTuple(const char *uid, uint8_t levelofsu
     ItemLength = (uint16_t)(Size() - 4);
     }
   // post condition
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 } // end namespace network

--- a/Source/MessageExchangeDefinition/gdcmServiceClassApplicationInformation.cxx
+++ b/Source/MessageExchangeDefinition/gdcmServiceClassApplicationInformation.cxx
@@ -36,19 +36,19 @@ std::istream &ServiceClassApplicationInformation::Read(std::istream &is)
 
 const std::ostream &ServiceClassApplicationInformation::Write(std::ostream &os) const
 {
-  assert( InternalArray[0] < 4 );
-  assert( InternalArray[1] == 0 );
-  assert( InternalArray[2] < 4 );
-  assert( InternalArray[3] == 0 );
-  assert( InternalArray[4] < 3 );
-  assert( InternalArray[5] == 0 );
+  gdcm_assert( InternalArray[0] < 4 );
+  gdcm_assert( InternalArray[1] == 0 );
+  gdcm_assert( InternalArray[2] < 4 );
+  gdcm_assert( InternalArray[3] == 0 );
+  gdcm_assert( InternalArray[4] < 3 );
+  gdcm_assert( InternalArray[5] == 0 );
   os.write( (const char*)InternalArray, sizeof(InternalArray) );
   return os;
 }
 
 size_t ServiceClassApplicationInformation::Size() const
 {
-  assert( sizeof(InternalArray) == 6 );
+  gdcm_assert( sizeof(InternalArray) == 6 );
   return 6;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmServiceClassUser.cxx
+++ b/Source/MessageExchangeDefinition/gdcmServiceClassUser.cxx
@@ -148,7 +148,7 @@ bool ServiceClassUser::StartAssociation()
     for( std::vector<BasePDU*>::const_iterator itor
       = thePDUs.begin(); itor != thePDUs.end(); itor++)
       {
-      assert(*itor);
+      gdcm_assert(*itor);
       if (*itor == nullptr) continue; //can have a nulled pdu, apparently
       (*itor)->Print(Trace::GetErrorStream());
       }
@@ -272,11 +272,11 @@ bool ServiceClassUser::SendStore(File const &file)
 
   ULEvent theEvent(ePDATArequest, theDataPDU);
   EStateID stateid = RunEventLoop(theEvent, mConnection, inCallback, false);
-  assert( stateid == eSta6TransferReady ); (void)stateid;
+  gdcm_assert( stateid == eSta6TransferReady ); (void)stateid;
   std::vector<DataSet> const &theDataSets = theCallback.GetResponses();
 
   bool ret = true;
-  assert( theDataSets.size() == 1 );
+  gdcm_assert( theDataSets.size() == 1 );
   const DataSet &ds = theDataSets[0];
   assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );
   DataElement const & de = ds.GetDataElement(Tag(0x0,0x0900));
@@ -299,7 +299,7 @@ bool ServiceClassUser::SendStore(File const &file)
       Attribute<0x0,0x0902> errormsg;
       errormsg.SetFromDataSet( ds );
       const char *themsg = errormsg.GetValue();
-      assert( themsg ); (void)themsg;
+      gdcm_assert( themsg ); (void)themsg;
       gdcmErrorMacro( "Response Status: " << themsg );
       ret = false; // at least one file was not sent correctly
       }
@@ -326,7 +326,7 @@ bool ServiceClassUser::SendFind(const BaseRootQuery* query, std::vector<DataSet>
   std::vector<DataSet> const & theResponses = theCallback.GetResponses();
 
   bool ret = false; // by default an error
-  assert( !theResponses.empty() );
+  gdcm_assert( !theResponses.empty() );
   // take the last one:
   const DataSet &ds = theResponses[ theResponses.size() - 1 ]; // FIXME
   assert ( ds.FindDataElement(Tag(0x0, 0x0900)) );
@@ -364,7 +364,7 @@ bool ServiceClassUser::SendFind(const BaseRootQuery* query, std::vector<DataSet>
       Attribute<0x0,0x0902> errormsg;
       errormsg.SetFromDataSet( ds );
       const char *themsg = errormsg.GetValue();
-      assert( themsg ); (void)themsg;
+      gdcm_assert( themsg ); (void)themsg;
       gdcmErrorMacro( "Response Status: [" << themsg << "]" );
       }
     break;
@@ -381,7 +381,7 @@ bool ServiceClassUser::SendFind(const BaseRootQuery* query, std::vector<DataSet>
         Attribute<0x0,0x0902> errormsg;
         errormsg.SetFromDataSet( ds );
         const char *themsg = errormsg.GetValue();
-        assert( themsg ); (void)themsg;
+        gdcm_assert( themsg ); (void)themsg;
         gdcmErrorMacro( "Response Status: " << themsg );
         }
       }
@@ -462,7 +462,7 @@ bool ServiceClassUser::SendMove(const BaseRootQuery* query, std::vector<File> &r
 {
   (void)query;
   (void)retFiles;
-  assert( 0 && "unimplemented do not use" );
+  gdcm_assert( 0 && "unimplemented do not use" );
   return false;
 }
 
@@ -535,7 +535,7 @@ EStateID ServiceClassUser::RunEventLoop(network::ULEvent& currentEvent,
         catch (...)
           {
           //handle the exception, which is basically that nothing came in over the pipe.
-          assert( 0 );
+          gdcm_assert( 0 );
           }
       }
       //now, we have to figure out the event that just happened based on the PDU that was received.
@@ -805,7 +805,7 @@ EStateID ServiceClassUser::RunMoveEventLoop(ULEvent& currentEvent, ULConnectionC
         }
       catch ( ... )
         {
-        assert( 0 );
+        gdcm_assert( 0 );
         }
     }
     if (secondConnectionEstablished &&

--- a/Source/MessageExchangeDefinition/gdcmTransferSyntaxSub.cxx
+++ b/Source/MessageExchangeDefinition/gdcmTransferSyntaxSub.cxx
@@ -34,7 +34,7 @@ void TransferSyntaxSub::SetName( const char *name )
   if( name )
     {
     Name = name;
-    assert( Name.size() <= std::numeric_limits<uint16_t>::max() );
+    gdcm_assert( Name.size() <= std::numeric_limits<uint16_t>::max() );
     ItemLength = (uint16_t)Name.size();
     }
 }
@@ -43,7 +43,7 @@ std::istream &TransferSyntaxSub::Read(std::istream &is)
 {
   uint8_t itemtype = 0xf;
   is.read( (char*)&itemtype, sizeof(ItemType) );
-  assert( itemtype == ItemType );
+  gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -52,7 +52,7 @@ std::istream &TransferSyntaxSub::Read(std::istream &is)
   ItemLength = itemlength;
 
   char name[256];
-  assert( itemlength < 256 );
+  gdcm_assert( itemlength < 256 );
   is.read( name, itemlength );
   Name = std::string(name,itemlength);
 
@@ -68,7 +68,7 @@ const std::ostream &TransferSyntaxSub::Write(std::ostream &os) const
   SwapperDoOp::SwapArray(&copy,1);
   os.write( (const char*)&copy, sizeof(ItemLength) );
 
-  assert( Name.size() < 256 );
+  gdcm_assert( Name.size() < 256 );
   os.write( Name.c_str(), Name.size() );
   return os;
 }
@@ -76,7 +76,7 @@ const std::ostream &TransferSyntaxSub::Write(std::ostream &os) const
 size_t TransferSyntaxSub::Size() const
 {
   size_t ret = 0;
-  assert( Name.size() == ItemLength );
+  gdcm_assert( Name.size() == ItemLength );
   ret += sizeof(ItemType);
   ret += sizeof(Reserved2);
   ret += sizeof(ItemLength);
@@ -94,7 +94,7 @@ void TransferSyntaxSub::UpdateName( const char *name )
       {
       Name = name;
       ItemLength = (uint16_t)Name.size();
-      assert( (size_t)ItemLength + 4 == Size() );
+      gdcm_assert( (size_t)ItemLength + 4 == Size() );
       return;
       }
     }

--- a/Source/MessageExchangeDefinition/gdcmULActionAE.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULActionAE.cxx
@@ -96,10 +96,10 @@ EStateID ULActionAE3::PerformAction(Subject *, ULEvent& inEvent, ULConnection& i
 
 
   // Mark please check this junk:
-  assert(!inEvent.GetPDUs().empty());
+  gdcm_assert(!inEvent.GetPDUs().empty());
   AAssociateACPDU* acpdu;
     acpdu = dynamic_cast<AAssociateACPDU*>(inEvent.GetPDUs()[0]);
-  assert( acpdu );
+  gdcm_assert( acpdu );
   uint32_t maxpdu = acpdu->GetUserInformation().GetMaximumLengthSub().GetMaximumLength();
   inConnection.SetMaxPDUSize(maxpdu);
 
@@ -175,7 +175,7 @@ EStateID ULActionAE6::PerformAction(Subject *, ULEvent& inEvent, ULConnection& i
 
     AAssociateACPDU acpdu;
 
-    assert( rqpdu->GetNumberOfPresentationContext() );
+    gdcm_assert( rqpdu->GetNumberOfPresentationContext() );
     for( unsigned int index = 0; index < rqpdu->GetNumberOfPresentationContext(); index++ )
       {
       // FIXME / HARDCODED We only ever accept Little Endian
@@ -229,7 +229,7 @@ EStateID ULActionAE6::PerformAction(Subject *, ULEvent& inEvent, ULConnection& i
       pcac1.SetReason( result );
       acpdu.AddPresentationContextAC( pcac1 );
     }
-    assert( acpdu.GetNumberOfPresentationContextAC() );
+    gdcm_assert( acpdu.GetNumberOfPresentationContextAC() );
 
     // Init AE-Titles:
     acpdu.InitFromRQ( *rqpdu );

--- a/Source/MessageExchangeDefinition/gdcmULActionAR.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULActionAR.cxx
@@ -117,7 +117,7 @@ EStateID ULActionAR6::PerformAction(Subject *, ULEvent& , ULConnection& ,
 EStateID ULActionAR7::PerformAction(Subject *, ULEvent& , ULConnection& inConnection,
         bool& , EEventID& ){
 
-assert(0);
+gdcm_assert(0);
   PDataTFPDU thePDU;//for now, use Matheiu's default values
   thePDU.Write(*inConnection.GetProtocol());
   inConnection.GetProtocol()->flush();
@@ -130,7 +130,7 @@ assert(0);
 EStateID ULActionAR8::PerformAction(Subject *, ULEvent& , ULConnection& ,
         bool& , EEventID& ){
 
-assert(0);
+gdcm_assert(0);
   return eSta10ReleaseCollisionAc;
 }
 

--- a/Source/MessageExchangeDefinition/gdcmULActionDT.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULActionDT.cxx
@@ -48,7 +48,7 @@ static void process_input(iosockinet& sio)
 {
   uint8_t itemtype = 0x0;
   sio.read( (char*)&itemtype, 1 );
-  assert( itemtype == 0x1 );
+  gdcm_assert( itemtype == 0x1 );
 
   AAssociateRQPDU rqpdu;
   //rqpdu.SetCallingAETitle( "MOTESCU" );
@@ -82,7 +82,7 @@ static void process_input(iosockinet& sio)
   //std::cout << "done AAssociateACPDU !" << std::endl;
 
   sio.read( (char*)&itemtype, 1 );
-  assert( itemtype == 0x4 );
+  gdcm_assert( itemtype == 0x4 );
 
   PDataTFPDU pdata;
   pdata.Read( sio );
@@ -90,7 +90,7 @@ static void process_input(iosockinet& sio)
   // pick the first one:
   size_t n = pdata.GetNumPDVs();
 
-  assert( n == 1 );
+  gdcm_assert( n == 1 );
   PresentationDataValue const &input_pdv = pdata.GetPresentationDataValue(0);
 
   //std::cout << "done PDataTFPDU 1!" << std::endl;
@@ -104,7 +104,7 @@ static void process_input(iosockinet& sio)
   //at.SetFromDataSet( input_pdv.GetDataSet() );
   unsigned short commanddatasettype = at.GetValue();
   //std::cout << "CommandDataSetType: " << at.GetValue() << std::endl;
-  assert( messageheader == 3 );
+  gdcm_assert( messageheader == 3 );
 
   // C-STORE
   if( commanddatasettype == 0 )
@@ -117,7 +117,7 @@ static void process_input(iosockinet& sio)
       pdata2.ReadInto( sio, out );
       //pdata2.Print( std::cout );
       size_t n2 = pdata.GetNumPDVs();
-      assert( n2 == 1 );
+      gdcm_assert( n2 == 1 );
       PresentationDataValue const &pdv = pdata2.GetPresentationDataValue(0);
       messageheader = pdv.GetMessageHeader();
       //std::cout << "---------------- done PDataTFPDU: " << i << std::endl;
@@ -125,7 +125,7 @@ static void process_input(iosockinet& sio)
       ++i;
       }
     while( messageheader == 0 );
-    assert( messageheader == 2 ); // end of data
+    gdcm_assert( messageheader == 2 ); // end of data
     out.close();
 
     PresentationDataValue pdv;
@@ -155,7 +155,7 @@ static void process_input(iosockinet& sio)
     }
 
   //sio.read( (char*)&itemtype, 1 );
-  //assert( itemtype == 0x4 );
+  //gdcm_assert( itemtype == 0x4 );
   //AReleaseRQPDU rel0;
   //rel0.Read( sio );
 

--- a/Source/MessageExchangeDefinition/gdcmULConnection.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULConnection.cxx
@@ -139,7 +139,7 @@ void ULConnection::AddAcceptedPresentationContext(const PresentationContextAC& i
 PresentationContextRQ ULConnection::FindContext(const DataElement& ) const
 {
   PresentationContextRQ empty;
-  assert( 0 && "TODO" );
+  gdcm_assert( 0 && "TODO" );
   return empty;
 }
 
@@ -323,7 +323,7 @@ uint8_t ULConnection::GetPresentationContextIDFromPresentationContext(Presentati
     ret = it->GetPresentationContextID();
     }
 
-  assert( ret );
+  gdcm_assert( ret );
   return ret;
 }
 
@@ -340,7 +340,7 @@ TransferSyntaxSub const & ULConnection::GetCStoreTransferSyntax( ) const
   TransferSyntaxSub ts2;
   ts2.SetNameFromUID( UIDs::ExplicitVRLittleEndian );
 
-  assert( strcmp(cstorets.GetName(), ts1.GetName()) == 0
+  gdcm_assert( strcmp(cstorets.GetName(), ts1.GetName()) == 0
        || strcmp(cstorets.GetName(), ts2.GetName()) == 0
   );
 

--- a/Source/MessageExchangeDefinition/gdcmULConnectionInfo.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULConnectionInfo.cxx
@@ -57,10 +57,10 @@ bool ULConnectionInfo::Initialize(UserInformation const & inUserInformation,
   if (inCalledIPAddress == 0 && inCalledComputerName.empty()){
     return false;
   }
-  assert( inCalledAETitle );
-  assert( inCallingAETitle );
-  assert( AAssociateRQPDU::IsAETitleValid( inCalledAETitle ) );
-  assert( AAssociateRQPDU::IsAETitleValid( inCallingAETitle ) );
+  gdcm_assert( inCalledAETitle );
+  gdcm_assert( inCallingAETitle );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid( inCalledAETitle ) );
+  gdcm_assert( AAssociateRQPDU::IsAETitleValid( inCallingAETitle ) );
   const size_t lcalled  = strlen( inCalledAETitle );
   const size_t lcalling = strlen( inCallingAETitle );
   mCalledAETitle = std::string(inCalledAETitle, lcalled > 16 ? 16 : lcalled );

--- a/Source/MessageExchangeDefinition/gdcmULConnectionManager.cxx
+++ b/Source/MessageExchangeDefinition/gdcmULConnectionManager.cxx
@@ -196,7 +196,7 @@ bool ULConnectionManager::EstablishConnection(const std::string& inAETitle,
     for( std::vector<BasePDU*>::const_iterator itor
       = thePDUs.begin(); itor != thePDUs.end(); itor++)
       {
-      //assert(*itor);
+      //gdcm_assert(*itor);
       if (*itor == nullptr) continue; //can have a nulled pdu, apparently
       (*itor)->Print(Trace::GetErrorStream());
       }
@@ -207,7 +207,7 @@ bool ULConnectionManager::EstablishConnection(const std::string& inAETitle,
     for( std::vector<BasePDU*>::const_iterator itor
       = thePDUs.begin(); itor != thePDUs.end(); itor++)
       {
-      assert(*itor);
+      gdcm_assert(*itor);
       if (*itor == nullptr) continue; //can have a nulled pdu, apparently
       (*itor)->Print(Trace::GetDebugStream());
       }
@@ -421,7 +421,7 @@ void ULConnectionManager::SendStore(const File & file, ULConnectionCallback* inC
 
   ULEvent theEvent(ePDATArequest, theDataPDU, pStream, dataSetOffset );
   EStateID theState = RunEventLoop(theEvent, mConnection, inCallback, false);
-  assert( theState == eSta6TransferReady || theState == eStaDoesNotExist ); (void)theState;
+  gdcm_assert( theState == eSta6TransferReady || theState == eStaDoesNotExist ); (void)theState;
 }
 
 std::vector<DataSet> ULConnectionManager::SendNEventReport	(const BaseQuery* inQuery)
@@ -677,7 +677,7 @@ EStateID ULConnectionManager::RunMoveEventLoop(ULEvent& currentEvent, ULConnecti
             Attribute<0x0,0x0800> at;
             at.SetFromDataElement( de );
             unsigned short datasettype = at.GetValue();
-            assert( datasettype == 0x0101 || datasettype == 0x1 ); (void)datasettype;
+            gdcm_assert( datasettype == 0x0101 || datasettype == 0x1 ); (void)datasettype;
           }
           if (theRSP.FindDataElement(Tag(0x0, 0x0900))){
             DataElement const & de = theRSP.GetDataElement(Tag(0x0,0x0900));
@@ -1134,7 +1134,7 @@ EStateID ULConnectionManager::RunEventLoop(ULEvent& currentEvent, ULConnection* 
                     {
                     delete theData[i];
                     }
-                  assert(inCallback);
+                  gdcm_assert(inCallback);
                     {
                     inCallback->HandleDataSet(theCompleteFindResponse);
                     }

--- a/Source/MessageExchangeDefinition/gdcmUserInformation.cxx
+++ b/Source/MessageExchangeDefinition/gdcmUserInformation.cxx
@@ -133,7 +133,7 @@ UserInformation::UserInformation()
   if( !RSSI->Empty() ) ItemLength += RSSI->Size();
   if( !SOPCENSI->Empty() ) ItemLength += SOPCENSI->Size();
 #endif
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 UserInformation::~UserInformation()
@@ -147,7 +147,7 @@ std::istream &UserInformation::Read(std::istream &is)
 {
   //uint8_t itemtype = 0x0;
   //is.read( (char*)&itemtype, sizeof(ItemType) );
-  //assert( itemtype == ItemType );
+  //gdcm_assert( itemtype == ItemType );
   uint8_t reserved2;
   is.read( (char*)&reserved2, sizeof(Reserved2) );
   uint16_t itemlength;
@@ -175,13 +175,13 @@ std::istream &UserInformation::Read(std::istream &is)
       curlen += ICUID.Size();
       break;
     case 0x53: // AsynchronousOperationsWindowSub
-      assert( !AOWS );
+      gdcm_assert( !AOWS );
       AOWS = new AsynchronousOperationsWindowSub;
       AOWS->Read( is );
       curlen += AOWS->Size();
       break;
     case 0x54: // RoleSelectionSub
-      assert( RSSI );
+      gdcm_assert( RSSI );
         {
         RoleSelectionSub rss;
         rss.Read( is );
@@ -194,7 +194,7 @@ std::istream &UserInformation::Read(std::istream &is)
       curlen += IVNS.Size();
       break;
     case 0x56: // SOPClassExtendedNegociationSub
-      assert( SOPCENSI );
+      gdcm_assert( SOPCENSI );
         {
         SOPClassExtendedNegociationSub sopcens;
         sopcens.Read( is );
@@ -205,19 +205,19 @@ std::istream &UserInformation::Read(std::istream &is)
     default:
       gdcmErrorMacro( "Unknown ItemType: " << std::hex << (int) itemtype2 );
       curlen = ItemLength; // make sure to exit
-      assert(0);
+      gdcm_assert(0);
       break;
       }
     }
-  assert( curlen == ItemLength );
+  gdcm_assert( curlen == ItemLength );
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   return is;
 }
 
 const std::ostream &UserInformation::Write(std::ostream &os) const
 {
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
   os.write( (const char*)&ItemType, sizeof(ItemType) );
   os.write( (const char*)&Reserved2, sizeof(Reserved2) );
   uint16_t copy = ItemLength;
@@ -240,7 +240,7 @@ const std::ostream &UserInformation::Write(std::ostream &os) const
     SOPCENSI->Write(os);
     }
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 
   return os;
 }
@@ -305,7 +305,7 @@ UserInformation &UserInformation::operator=(const UserInformation& ui)
   *SOPCENSI = *ui.SOPCENSI;
   IVNS = ui.IVNS;
 
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 
   return *this;
 }
@@ -314,14 +314,14 @@ void UserInformation::AddRoleSelectionSub( RoleSelectionSub const & rss )
 {
   RSSI->RSSArray.push_back( rss );
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 void UserInformation::AddSOPClassExtendedNegociationSub( SOPClassExtendedNegociationSub const & sopcens )
 {
   SOPCENSI->SOPCENSArray.push_back( sopcens );
   ItemLength = (uint16_t)(Size() - 4);
-  assert( (size_t)ItemLength + 4 == Size() );
+  gdcm_assert( (size_t)ItemLength + 4 == Size() );
 }
 
 } // end namespace network

--- a/Testing/Source/Common/Cxx/TestCryptographicMessageSyntax.cxx
+++ b/Testing/Source/Common/Cxx/TestCryptographicMessageSyntax.cxx
@@ -188,8 +188,8 @@ bool TestCMSCompatibility(gdcm::CryptographicMessageSyntax& cms1, const char * p
     cms2.SetCipherType(ciphers[i]);
     //cms2.Encrypt(encout, encoutlen, tstr, tstr_l);
     //cms1.Decrypt(decout, decoutlen, encout, encoutlen);
-    //assert(decoutlen == tstr_l);
-    //assert(memcmp(tstr, decout, tstr_l) == 0);
+    //gdcm_assert(decoutlen == tstr_l);
+    //gdcm_assert(memcmp(tstr, decout, tstr_l) == 0);
 
     bool encryptSuccess = cms1.Encrypt(encout, encoutlen, tstr, tstr_l);
     if (!encryptSuccess)

--- a/Testing/Source/Common/Cxx/TestSystem1.cxx
+++ b/Testing/Source/Common/Cxx/TestSystem1.cxx
@@ -121,7 +121,7 @@ int TestSystem1(int, char *[])
     std::cerr << "bres" << std::endl;
     return 1;
     }
-  assert( datetime[21] == 0 );
+  gdcm_assert( datetime[21] == 0 );
   std::cerr << datetime << std::endl;
 
   const char *cwd = gdcm::System::GetCWD();
@@ -169,7 +169,7 @@ int TestSystem1(int, char *[])
     std::cerr << "GetCurrentDateTime: " << date << std::endl;
     return 1;
     }
-  assert( date[21] == 0 );
+  gdcm_assert( date[21] == 0 );
   time_t timep; long milliseconds;
   if( !gdcm::System::ParseDateTime(timep, milliseconds, date) )
     {
@@ -181,7 +181,7 @@ int TestSystem1(int, char *[])
     {
     return 1;
     }
-  assert( date2[21] == 0 );
+  gdcm_assert( date2[21] == 0 );
 
   if( strcmp( date, date2 ) != 0 )
     {
@@ -326,7 +326,7 @@ return 1;
     std::cerr << "FormatDateTime" << std::endl;
   return 1;
 }
-assert( fixed_date2[21] == 0 );
+gdcm_assert( fixed_date2[21] == 0 );
   if( strcmp( fixed_date, fixed_date2 ) != 0 )
 {
     std::cerr << "fixed_date | fixed_date2" << std::endl;

--- a/Testing/Source/Common/Cxx/TestUnpacker12Bits.cxx
+++ b/Testing/Source/Common/Cxx/TestUnpacker12Bits.cxx
@@ -77,7 +77,7 @@ int TestUnpacker12Bits(int, char *[])
     unsigned short * output_s = (unsigned short*)output;
     const unsigned short outputvalues[] = { 0x301, 0x452, 0x967, 0xab8 };
     const size_t outputlen = sizeof(outputvalues) / sizeof(*outputvalues);
-    assert( outlen / 2 == outputlen );
+    gdcm_assert( outlen / 2 == outputlen );
     for(size_t i = 0; i < outputlen; ++i)
       {
       if( outputvalues[i] != output_s[i] )
@@ -102,7 +102,7 @@ int TestUnpacker12Bits(int, char *[])
     {
     if( values[i] != ref[i] )
       {
-      assert(0);
+      gdcm_assert(0);
       ++res;
       }
     }
@@ -114,8 +114,8 @@ int TestUnpacker12Bits(int, char *[])
     {
     v.push_back( val );
     }
-  assert( v.size() == 4096 );
-  assert( v[0] == 0 );
+  gdcm_assert( v.size() == 4096 );
+  gdcm_assert( v[0] == 0 );
   const size_t outsize = 4096 / 2 * 3;
   unsigned char outvalues[outsize] = {};
   gdcm::Unpacker12Bits::Pack( (char*)outvalues, (char*)v.data(), 4096 * sizeof(unsigned short) );

--- a/Testing/Source/DataDictionary/Cxx/TestGlobal.cxx
+++ b/Testing/Source/DataDictionary/Cxx/TestGlobal.cxx
@@ -98,7 +98,7 @@ int TestGlobal(int, char *[])
   std::cout << s.empty() << std::endl;
   const gdcm::DictEntry& de = pub.GetDictEntry( gdcm::Tag(0x0028,0x0015) );
   const char *v = de.GetName();
-  //assert( v );
+  //gdcm_assert( v );
   std::cout << "TOTO:" << de << std::endl;
 #endif
 

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestDS.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestDS.cxx
@@ -175,7 +175,7 @@ static bool singleTestDS(double d, int sz, bool se = false)
   if ( checkerror(d, s, se) )
     fail = true;
 
-  assert(sz >= 0);
+  gdcm_assert(sz >= 0);
   if( s.size() != (unsigned int)sz )
   {
     std::cout << "ERROR: Size = " << s.size() << " (should be " << sz << ")" << std::endl;

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestDataElement.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestDataElement.cxx
@@ -92,7 +92,7 @@ int TestDataElement2(const uint16_t group, const uint16_t element,
   ss.write(vr, strlen(vr) );
   str = reinterpret_cast<const char*>(&vl);
   ss.write(str, sizeof(vl));
-  assert( !(strlen(value) % 2) );
+  gdcm_assert( !(strlen(value) % 2) );
   ss.write(value, strlen(value) );
   //DebugElement(ss);
 

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestItem.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestItem.cxx
@@ -25,7 +25,7 @@ void CreateDataElement(gdcm::ExplicitDataElement &de, int offset)
   gdcm::VR vr = gdcm::VR::UN;
   const char str[] = "GDCM";
   uint32_t len = (uint32_t)strlen(str);
-  assert( sizeof(uint32_t) == 4 );
+  gdcm_assert( sizeof(uint32_t) == 4 );
   gdcm::ByteValue val(str, len);
   tag.Write<gdcm::SwapperNoOp>(ss);
   vr.Write(ss);

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReader3.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReader3.cxx
@@ -225,7 +225,7 @@ int TestRead3(const char *subdir, const char * filename)
   DoTheMMapRead(is);
 
   // cleanup
-  assert( handle );
+  gdcm_assert( handle );
   bool error = false;
   error = ::munmap(data, size) != 0 || error;
   error = ::close(handle) != 0 || error;

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReaderCanRead.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReaderCanRead.cxx
@@ -59,7 +59,7 @@ int TestReadCanRead(const char *subdir, const char* filename, bool verbose = fal
     std::cerr << "TestReadCanRead: incompatible result " << filename << std::endl;
     if( b1 )
       std::cerr << "TestReadCanRead: CanRead was true: " << filename << std::endl;
-    //assert( !ret );
+    //gdcm_assert( !ret );
     return ret;
     }
 
@@ -91,7 +91,7 @@ int TestReadCanRead(const char *subdir, const char* filename, bool verbose = fal
     reader2.SetFileName( outfilename.c_str() );
     b1 = reader2.CanRead( );
     //reader2.GetFile().GetHeader().GetPreamble().Remove();
-    //assert( reader2.GetFile().GetHeader().GetPreamble().IsEmpty() );
+    //gdcm_assert( reader2.GetFile().GetHeader().GetPreamble().IsEmpty() );
     b2 = reader2.Read();
     if ( (b1 && !b2) || (!b1 && b2)  )
       {

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReaderSelectedTags.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestReaderSelectedTags.cxx
@@ -50,7 +50,7 @@ int TestReadSelectedTags(const char* filename, bool verbose = false)
     return 1;
     }
   size_t filesize = gdcm::System::FileSize(filename);
-  assert( (size_t)refoffset <= filesize );
+  gdcm_assert( (size_t)refoffset <= filesize );
 
   std::streamoff refoffset2 = gdcm::Testing::GetStreamOffsetFromFile(filename);
   (void)refoffset2;
@@ -76,11 +76,11 @@ int TestReadSelectedTags(const char* filename, bool verbose = false)
       {
       if( ts.GetNegociatedType() == gdcm::TransferSyntax::Explicit )
         {
-        assert( refoffset + 12 == refoffset2 );
+        gdcm_assert( refoffset + 12 == refoffset2 );
         }
       else
         {
-        assert( refoffset + 8 == refoffset2 );
+        gdcm_assert( refoffset + 8 == refoffset2 );
         }
       }
     }

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestWriter.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestWriter.cxx
@@ -94,7 +94,7 @@ int TestWrite(const char *subdir, const char* filename, bool recursing, bool ver
        // readable by dcmtk and such
        //size_t size1 = System::FileSize( filename );
        //size_t size2 = System::FileSize( outfilename.c_str() );
-       //assert( size1 == size2 ); // cannot deal with implicit VR meta data header
+       //gdcm_assert( size1 == size2 ); // cannot deal with implicit VR meta data header
        return 0;
        }
       std::cerr << "incompatible ref: " << ref << " vs " << outdigest << " for file: " << filename << " & " << outfilename << std::endl;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner2.cxx
@@ -24,7 +24,7 @@ static const DataSet &GetNestedDataSet(const DataSet &ds,
                                        const PrivateTag &path) {
   const DataElement &de = ds.GetDataElement(path);
   SmartPointer<SequenceOfItems> sqi = de.GetValueAsSQ();
-  assert(sqi && sqi->GetNumberOfItems() == 1);
+  gdcm_assert(sqi && sqi->GetNumberOfItems() == 1);
   const Item &item = sqi->GetItem(1);
   const DataSet &subds = item.GetNestedDataSet();
   return subds;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner3.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner3.cxx
@@ -24,7 +24,7 @@ static const DataSet &GetNestedDataSet(const DataSet &ds,
                                        const PrivateTag &path) {
   const DataElement &de = ds.GetDataElement(path);
   SmartPointer<SequenceOfItems> sqi = de.GetValueAsSQ();
-  assert(sqi && sqi->GetNumberOfItems() == 1);
+  gdcm_assert(sqi && sqi->GetNumberOfItems() == 1);
   const Item &item = sqi->GetItem(1);
   const DataSet &subds = item.GetNestedDataSet();
   return subds;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner4.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCleaner4.cxx
@@ -24,7 +24,7 @@ template <typename T>
 static const DataSet &GetNestedDataSet(const DataSet &ds, const T &path) {
   const DataElement &de = ds.GetDataElement(path);
   SmartPointer<SequenceOfItems> sqi = de.GetValueAsSQ();
-  assert(sqi && sqi->GetNumberOfItems() == 1);
+  gdcm_assert(sqi && sqi->GetNumberOfItems() == 1);
   const Item &item = sqi->GetItem(1);
   const DataSet &subds = item.GetNestedDataSet();
   return subds;
@@ -328,7 +328,7 @@ struct TestCleaner4Impl4 : public TestCleaner4Impl {
     const bool b5 = IsTagEmpty(ds, path1, t5);
 
     if (!b1 || !b2 || !b3 || !b4 || !b5) {
-      assert(0);
+      gdcm_assert(0);
       return false;
     }
     return true;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCurve2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestCurve2.cxx
@@ -145,7 +145,7 @@ static int TestCurve2Read(const char* filename, bool verbose = false)
         {
         // new regression image needs a md5 sum
         std::cout << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-        //assert(0);
+        //gdcm_assert(0);
         res = 1;
         }
       else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestDataSetHelper.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestDataSetHelper.cxx
@@ -37,42 +37,42 @@ public:
       const PrivateTag pt4(0x0029,0x1140,"SIEMENS MEDCOM HEADER");
       if( PrivateTag(de.GetTag(),"GEMS_IMAG_01") == pt1 )
       {
-        assert( vr == VR::UL );
-        assert( vr2 == VR::SL );
+        gdcm_assert( vr == VR::UL );
+        gdcm_assert( vr2 == VR::SL );
         return vr;
       }
       if( PrivateTag(de.GetTag(),"GEMS_IMAG_01") == pt2
        || PrivateTag(de.GetTag(),"GEMS_IMAG_01") == pt3 )
       {
-        assert( vr == VR::IS );
-        assert( vr2 == VR::DS );
+        gdcm_assert( vr == VR::IS );
+        gdcm_assert( vr2 == VR::DS );
         return vr;
       }
       if( PrivateTag(de.GetTag(),"SIEMENS MEDCOM HEADER") == pt4 )
       {
-        assert( vr == VR::OB );
-        assert( vr2 == VR::SQ );
+        gdcm_assert( vr == VR::OB );
+        gdcm_assert( vr2 == VR::SQ );
         return vr;
       }
       // ELSCINT1_PMSCT_RLE1.dcm
       if( de.GetTag() == Tag(0x0020,0x0070) )
       {
-        assert( vr == VR::CS );
-        assert( vr2 == VR::LO );
+        gdcm_assert( vr == VR::CS );
+        gdcm_assert( vr2 == VR::LO );
         return vr;
       }
       // EmptyIcon_Bug417.dcm
       if( de.GetTag() == Tag(0x0040,0x1008) )
       {
-        assert( vr == VR::ST );
-        assert( vr2 == VR::LO );
+        gdcm_assert( vr == VR::ST );
+        gdcm_assert( vr2 == VR::LO );
         return vr;
       }
       // GE_CT_With_Private_compressed-icon.dcm
       if( de.GetTag() == Tag(0x0040,0x0253) )
       {
-        assert( vr == VR::CS );
-        assert( vr2 == VR::SH );
+        gdcm_assert( vr == VR::CS );
+        gdcm_assert( vr2 == VR::SH );
         return vr;
       }
       // JPEGInvalidSecondFrag.dcm
@@ -81,8 +81,8 @@ public:
        || de.GetTag() == Tag(0x0018,0x9307)
        || de.GetTag() == Tag(0x0023,0x1070) )
       {
-        assert( vr == VR::OB );
-        assert( vr2 == VR::FD );
+        gdcm_assert( vr == VR::OB );
+        gdcm_assert( vr2 == VR::FD );
         return vr;
       }
       // NM-PAL-16-PixRep1.dcm...FIXME: dcmconv +te
@@ -93,8 +93,8 @@ public:
        || de.GetTag() == Tag(0x0028,0x1202)
        || de.GetTag() == Tag(0x0028,0x1203) )
       {
-        assert( vr == VR::US );
-        assert( vr2 == VR::SS || vr2 == VR::OW );
+        gdcm_assert( vr == VR::US );
+        gdcm_assert( vr2 == VR::SS || vr2 == VR::OW );
         return vr;
       }
       // PHILIPS_Gyroscan-12-MONO2-Jpeg_Lossless.dcm
@@ -102,8 +102,8 @@ public:
        || de.GetTag() == Tag(0x0018,0x4000)
        || de.GetTag() == Tag(0x0020,0x3402) )
       {
-        assert( vr == VR::LO );
-        assert( vr2 == VR::CS || vr2 == VR::LT || vr2 == VR::SH );
+        gdcm_assert( vr == VR::LO );
+        gdcm_assert( vr2 == VR::CS || vr2 == VR::LT || vr2 == VR::SH );
         return vr;
       }
       // PHILIPS_Gyroscan-12-MONO2-Jpeg_Lossless.dcm
@@ -112,22 +112,22 @@ public:
        || de.GetTag() == Tag(0x0028,0x0040)
        || de.GetTag() == Tag(0x0028,0x0200) )
       {
-        assert( vr == VR::DS || vr == VR::SS || vr == VR::SH );
-        assert( vr2 == VR::IS || vr2 == VR::US || vr2 == VR::CS );
+        gdcm_assert( vr == VR::DS || vr == VR::SS || vr == VR::SH );
+        gdcm_assert( vr2 == VR::IS || vr2 == VR::US || vr2 == VR::CS );
         return vr;
       }
       // PHILIPS_Gyroscan-12-Jpeg_Extended_Process_2_4.dcm
       if( de.GetTag() == Tag(0x0008,0x0040) )
       {
-        assert( vr == VR::SS );
-        assert( vr2 == VR::US );
+        gdcm_assert( vr == VR::SS );
+        gdcm_assert( vr2 == VR::US );
         return vr;
       }
       if( vr == VR::SQ || vr2 == VR::SQ )
-        assert( vr == vr2 );
+        gdcm_assert( vr == vr2 );
       if( !de.GetTag().IsPrivate() )
-        assert( vr == vr2 );
-      //assert( vr.Compatible(vr2) );
+        gdcm_assert( vr == vr2 );
+      //gdcm_assert( vr.Compatible(vr2) );
     }
     return vr;
   }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax1.cxx
@@ -147,8 +147,8 @@ static int TestFileChangeTransferSyntax1Func(const char *filename, bool verbose 
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -162,7 +162,7 @@ static int TestFileChangeTransferSyntax1Func(const char *filename, bool verbose 
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax2.cxx
@@ -147,8 +147,8 @@ static int TestFileChangeTransferSyntax2Func(const char *filename, bool verbose 
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -162,7 +162,7 @@ static int TestFileChangeTransferSyntax2Func(const char *filename, bool verbose 
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax3.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax3.cxx
@@ -147,8 +147,8 @@ static int TestFileChangeTransferSyntax3Func(const char *filename, bool verbose 
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -162,7 +162,7 @@ static int TestFileChangeTransferSyntax3Func(const char *filename, bool verbose 
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax4.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileChangeTransferSyntax4.cxx
@@ -147,8 +147,8 @@ static int TestFileChangeTransferSyntax4Func(const char *filename, bool verbose 
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -162,7 +162,7 @@ static int TestFileChangeTransferSyntax4Func(const char *filename, bool verbose 
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileStreamer4.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestFileStreamer4.cxx
@@ -77,7 +77,7 @@ int TestFileStream4(const char *filename, bool verbose = false)
     }
 
   std::vector<char> vbuffer;
-  assert( dims[0] );
+  gdcm_assert( dims[0] );
   vbuffer.resize( dims[0] * pixsize );
   char *buffer = vbuffer.data();
   const size_t len = vbuffer.size();

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageFilter.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageFilter.cxx
@@ -116,7 +116,7 @@ int TestIconImageFilterFunc(const char *filename, bool verbose = false)
     }
   else
     {
-    assert( refmd5 == nullptr );
+    gdcm_assert( refmd5 == nullptr );
     }
 
   return 0;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator.cxx
@@ -327,7 +327,7 @@ int TestIconImageGenerate(const char *subdir, const char* filename, bool verbose
     }
   else
     {
-    assert( refmd5 == 0 );
+    gdcm_assert( refmd5 == 0 );
     std::cerr << "Could not generate Icon for: " << filename << std::endl;
     return 1;
     }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator2.cxx
@@ -327,7 +327,7 @@ int TestIconImageGenerate2(const char *subdir, const char* filename, bool verbos
     }
   else
     {
-    assert( refmd5 == 0 );
+    gdcm_assert( refmd5 == 0 );
     std::cerr << "Could not generate Icon for: " << filename << std::endl;
     return 1;
     }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator3.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator3.cxx
@@ -331,7 +331,7 @@ int TestIconImageGenerate3(const char *subdir, const char* filename, bool verbos
     }
   else
     {
-    assert( refmd5 == 0 );
+    gdcm_assert( refmd5 == 0 );
     std::cerr << "Could not generate Icon for: " << filename << std::endl;
     return 1;
     }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator4.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestIconImageGenerator4.cxx
@@ -277,7 +277,7 @@ int TestIconImageGenerate4(const char *subdir, const char* filename, bool verbos
   if( is >> val )
     {
     iig.SetOutsideValuePixel( val );
-    assert( !strval.empty() );
+    gdcm_assert( !strval.empty() );
     }
   const unsigned int idims[2] = { 64, 64 };
   //const unsigned int idims[2] = { 600,430 };
@@ -354,7 +354,7 @@ int TestIconImageGenerate4(const char *subdir, const char* filename, bool verbos
     }
   else
     {
-    assert( refmd5 == 0 );
+    gdcm_assert( refmd5 == 0 );
     std::cerr << "Could not generate Icon for: " << filename << std::endl;
     return 1;
     }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangePhotometricInterpretation.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangePhotometricInterpretation.cxx
@@ -21,7 +21,7 @@ namespace gdcm
 {
 PhotometricInterpretation InvertPI(PhotometricInterpretation pi)
 {
-  assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
+  gdcm_assert( pi == PhotometricInterpretation::MONOCHROME1 || pi == PhotometricInterpretation::MONOCHROME2 );
   if( pi == PhotometricInterpretation::MONOCHROME1 )
     {
     return PhotometricInterpretation::MONOCHROME2;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangePlanarConfiguration.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangePlanarConfiguration.cxx
@@ -40,7 +40,7 @@ int TestImageChangePlanarConfigurationFunc(const char *filename, bool verbose = 
   const gdcm::Image &image = reader.GetImage();
 
   unsigned int oldpc = image.GetPlanarConfiguration();
-  assert( oldpc == 1 || oldpc == 0 );
+  gdcm_assert( oldpc == 1 || oldpc == 0 );
 
   gdcm::ImageChangePlanarConfiguration pcfilt;
   pcfilt.SetPlanarConfiguration( !oldpc );
@@ -119,8 +119,8 @@ int TestImageChangePlanarConfigurationFunc(const char *filename, bool verbose = 
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -138,7 +138,7 @@ int TestImageChangePlanarConfigurationFunc(const char *filename, bool verbose = 
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax1.cxx
@@ -125,8 +125,8 @@ int TestImageChangeTransferSyntaxJPEG(const char *filename, bool verbose = false
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -140,7 +140,7 @@ int TestImageChangeTransferSyntaxJPEG(const char *filename, bool verbose = false
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax2.cxx
@@ -125,8 +125,8 @@ int TestImageChangeTransferSyntaxJ2K(const char *filename, bool verbose = false)
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -140,7 +140,7 @@ int TestImageChangeTransferSyntaxJ2K(const char *filename, bool verbose = false)
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax3.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax3.cxx
@@ -132,8 +132,8 @@ int TestImageChangeTransferSyntaxRLE(const char *filename, bool verbose = false)
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -147,7 +147,7 @@ int TestImageChangeTransferSyntaxRLE(const char *filename, bool verbose = false)
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax4.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax4.cxx
@@ -118,8 +118,8 @@ int TestImageChangeTransferSyntaxRAW(const char *filename, bool verbose = false)
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -133,7 +133,7 @@ int TestImageChangeTransferSyntaxRAW(const char *filename, bool verbose = false)
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax5.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax5.cxx
@@ -119,8 +119,8 @@ int TestImageChangeTransferSyntaxJPEGLS(const char *filename, bool verbose = fal
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -134,7 +134,7 @@ int TestImageChangeTransferSyntaxJPEGLS(const char *filename, bool verbose = fal
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax6.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax6.cxx
@@ -108,8 +108,8 @@ int TestImageChangeTransferSyntaxRAWBE(const char *filename, bool verbose = fals
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -123,7 +123,7 @@ int TestImageChangeTransferSyntaxRAWBE(const char *filename, bool verbose = fals
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax7.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageChangeTransferSyntax7.cxx
@@ -150,8 +150,8 @@ int TestImageChangeTransferSyntaxIM2RAWBE(const char *filename, bool verbose = f
 #ifdef GDCM_WORDS_BIGENDIAN
   if( img.GetPixelFormat().GetBitsAllocated() == 16 )
     {
-    assert( !(len % 2) );
-    assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+    gdcm_assert( !(len % 2) );
+    gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
     gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
       (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -165,7 +165,7 @@ int TestImageChangeTransferSyntaxIM2RAWBE(const char *filename, bool verbose = f
     {
     // new regression image needs a md5 sum
     std::cerr << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-    //assert(0);
+    //gdcm_assert(0);
     res = 1;
     }
   else if( strcmp(digest, ref) != 0 )

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageReader.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageReader.cxx
@@ -63,9 +63,9 @@ int TestImageRead(const char* filename, bool verbose = false, bool lossydump = f
 #ifdef GDCM_WORDS_BIGENDIAN
     if( img.GetPixelFormat().GetBitsAllocated() == 16 )
       {
-      assert( !(len % 2) );
+      gdcm_assert( !(len % 2) );
       // gdcm-US-ALOKA is a 16 bits image with PALETTE
-      //assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
+      //gdcm_assert( img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME1
       //  || img.GetPhotometricInterpretation() == gdcm::PhotometricInterpretation::MONOCHROME2 );
       gdcm::ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
         (unsigned short*)buffer, gdcm::SwapCode::LittleEndian, len/2);
@@ -84,7 +84,7 @@ int TestImageRead(const char* filename, bool verbose = false, bool lossydump = f
       {
       // new regression image needs a md5 sum
       std::cout << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-      //assert(0);
+      //gdcm_assert(0);
       res = 1;
       }
     else if( strcmp(digest, ref) != 0 )
@@ -96,7 +96,7 @@ int TestImageRead(const char* filename, bool verbose = false, bool lossydump = f
       std::ofstream debug("/tmp/dump.gray",std::ios::binary);
       debug.write(buffer, len);
       debug.close();
-      //assert(0);
+      //gdcm_assert(0);
 #endif
       }
     delete[] buffer;
@@ -122,7 +122,7 @@ int TestImageRead(const char* filename, bool verbose = false, bool lossydump = f
   // else
   // well this is not an image, so thankfully we fail to read it
   std::cerr << "Could not read image(" << filename << "), since file is a: " << ms << std::endl;
-  //assert( ms != gdcm::MediaStorage::MS_END );
+  //gdcm_assert( ms != gdcm::MediaStorage::MS_END );
   return 0;
 }
 

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageRegionReader3.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageRegionReader3.cxx
@@ -89,12 +89,12 @@ static int TestImageRegionRead(const char* filename, bool verbose = false)
       box.SetDomain(0, xdelta - 1, 0 + y * ydelta, (unsigned int)(maxy - 1), z, z);
       reader.SetRegion(box);
       zlen = reader.ComputeBufferLength();
-      assert( zlen );
+      gdcm_assert( zlen );
       vbuffer.resize( zlen );
       char* buffer = vbuffer.data();
       b = reader.ReadIntoBuffer(buffer, zlen);
       if( !b ) return 1;
-      assert( zlen );
+      gdcm_assert( zlen );
       of.write( buffer, zlen );
       }
     }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageWriter.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageWriter.cxx
@@ -84,8 +84,8 @@ int TestImageWrite(const char *subdir, const char* filename)
 #ifdef GDCM_WORDS_BIGENDIAN
     if( img.GetPixelFormat().GetBitsAllocated() == 16 )
       {
-      assert( !(len % 2) );
-      assert( img.GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
+      gdcm_assert( !(len % 2) );
+      gdcm_assert( img.GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME1
         || img.GetPhotometricInterpretation() == PhotometricInterpretation::MONOCHROME2 );
       ByteSwap<unsigned short>::SwapRangeFromSwapCodeIntoSystem(
         (unsigned short*)buffer, SwapCode::LittleEndian, len/2);
@@ -100,7 +100,7 @@ int TestImageWrite(const char *subdir, const char* filename)
       {
       // new regression image needs a md5 sum
       std::cout << "Missing md5 " << digest << " for: " << outfilename <<  std::endl;
-      //assert(0);
+      //gdcm_assert(0);
       res = 1;
       }
     else if( strcmp(digest, ref) != 0 )
@@ -112,7 +112,7 @@ int TestImageWrite(const char *subdir, const char* filename)
       std::ofstream debug("/tmp/dump.gray", std::ios::binary);
       debug.write(buffer, len);
       debug.close();
-      //assert(0);
+      //gdcm_assert(0);
 #endif
       }
     delete[] buffer;

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageWriter2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestImageWriter2.cxx
@@ -168,7 +168,7 @@ int TestImageWriter2(int , char *[])
   image.SetPhotometricInterpretation( pi );
 
   unsigned long len = image.GetBufferLength();
-  assert( len = ir.GetBufferLength() );
+  gdcm_assert( len = ir.GetBufferLength() );
   std::vector<char> buffer;
   buffer.resize(len); // black image
 

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestScanner1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestScanner1.cxx
@@ -163,7 +163,7 @@ int TestScanner1(int argc, char *argv[])
   // The following breaks with Papyrus file: PET-cardio-Multiframe-Papyrus.dcm
   unsigned int i = 0;
   gdcm::Scanner::MappingType::const_iterator it = mt.find(filename);
-  assert( it != mt.end() );
+  gdcm_assert( it != mt.end() );
   while( it == mt.end() )
     {
     ++i;
@@ -197,7 +197,7 @@ int TestScanner1(int argc, char *argv[])
     const char *value =  s.GetValue( filename, reftag );
     if( value )
       {
-      assert( value );
+      gdcm_assert( value );
       std::cout << filename << " has " << reftag << " = " << value << std::endl;
       }
     else

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestScanner2_1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestScanner2_1.cxx
@@ -163,7 +163,7 @@ int TestScanner2_1(int argc, char *argv[])
   // The following breaks with Papyrus file: PET-cardio-Multiframe-Papyrus.dcm
   unsigned int i = 0;
   gdcm::Scanner2::PublicMappingType::const_iterator it = mt.find(filename);
-  assert( it != mt.end() );
+  gdcm_assert( it != mt.end() );
   while( it == mt.end() )
     {
     ++i;
@@ -197,7 +197,7 @@ int TestScanner2_1(int argc, char *argv[])
     const char *value =  s.GetPublicValue( filename, reftag );
     if( value )
       {
-      assert( value );
+      gdcm_assert( value );
       std::cout << filename << " has " << reftag << " = " << value << std::endl;
       }
     else

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStreamImageReader.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStreamImageReader.cxx
@@ -128,7 +128,7 @@ int TestStreamImageRead(const char* filename, bool verbose = false, bool lossydu
       {
       // new regression image needs a md5 sum
       std::cout << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-      //assert(0);
+      //gdcm_assert(0);
       res = 1;
       }
     else if( strcmp(digest, ref) != 0 )
@@ -201,7 +201,7 @@ int TestStreamImageRead(const char* filename, bool verbose = false, bool lossydu
   // else
   // well this is not an image, so thankfully we fail to read it
   std::cerr << "Could not read image(" << filename << "), since file is a: " << ms << std::endl;
-  //assert( ms != gdcm::MediaStorage::MS_END );
+  //gdcm_assert( ms != gdcm::MediaStorage::MS_END );
   return 0;
 #endif
 }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStreamImageWriter.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStreamImageWriter.cxx
@@ -158,7 +158,7 @@ int TestStreamImageWrite(const char *subdir, const char* filename, bool verbose 
         {
           // new regression image needs a md5 sum
           std::cout << "Missing md5 " << digest << " for: " << filename <<  std::endl;
-          //assert(0);
+          //gdcm_assert(0);
           res = 1;
         }
       else if( strcmp(digest, ref) )
@@ -203,7 +203,7 @@ int TestStreamImageWrite(const char *subdir, const char* filename, bool verbose 
   // else
   // well this is not an image, so thankfully we fail to read it
   std::cerr << "Could not read image(" << filename << "), since file is a: " << ms << std::endl;
-  //assert( ms != gdcm::MediaStorage::MS_END );
+  //gdcm_assert( ms != gdcm::MediaStorage::MS_END );
 #endif
   return 0;
 }

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStrictScanner1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStrictScanner1.cxx
@@ -165,7 +165,7 @@ int TestStrictScanner1(int argc, char *argv[])
   // The following breaks with Papyrus file: PET-cardio-Multiframe-Papyrus.dcm
   unsigned int i = 0;
   gdcm::StrictScanner::MappingType::const_iterator it = mt.find(filename);
-  assert( it != mt.end() );
+  gdcm_assert( it != mt.end() );
   while( it == mt.end() )
     {
     ++i;
@@ -199,7 +199,7 @@ int TestStrictScanner1(int argc, char *argv[])
     const char *value =  s.GetValue( filename, reftag );
     if( value )
       {
-      assert( value );
+      gdcm_assert( value );
       std::cout << filename << " has " << reftag << " = " << value << std::endl;
       }
     else

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStrictScanner2_1.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestStrictScanner2_1.cxx
@@ -166,7 +166,7 @@ int TestStrictScanner2_1(int argc, char *argv[])
   // The following breaks with Papyrus file: PET-cardio-Multiframe-Papyrus.dcm
   unsigned int i = 0;
   gdcm::StrictScanner2::PublicMappingType::const_iterator it = mt.find(filename);
-  assert( it != mt.end() );
+  gdcm_assert( it != mt.end() );
   while( it == mt.end() )
     {
     ++i;
@@ -200,7 +200,7 @@ int TestStrictScanner2_1(int argc, char *argv[])
     const char *value =  s.GetPublicValue( filename, reftag );
     if( value )
       {
-      assert( value );
+      gdcm_assert( value );
       std::cout << filename << " has " << reftag << " = " << value << std::endl;
       }
     else

--- a/Testing/Source/MediaStorageAndFileFormat/Cxx/TestUIDGenerator2.cxx
+++ b/Testing/Source/MediaStorageAndFileFormat/Cxx/TestUIDGenerator2.cxx
@@ -64,7 +64,7 @@ int TestUIDGenerator2(int , char *[])
     it += nuids*2;
     }
   std::cout << v_one.size() << std::endl;
-  assert( v_one.size() == nuids * nthreads ); // programmer error
+  gdcm_assert( v_one.size() == nuids * nthreads ); // programmer error
 
   std::copy(v_one.begin(), v_one.end(), std::ostream_iterator<std::string>(std::cout, "\n"));
 

--- a/Utilities/gdcmcharls/jpegmarkersegment.cpp
+++ b/Utilities/gdcmcharls/jpegmarkersegment.cpp
@@ -34,7 +34,7 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateStartOfFrameSegment(int w
         content.push_back(0);                                   // Tqi = Quantization table destination selector (reserved for JPEG-LS, should be set to 0)
     }
 
-    return make_unique<JpegMarkerSegment>(JpegMarkerCode::StartOfFrameJpegLS, move(content));
+    return make_unique<JpegMarkerSegment>(JpegMarkerCode::StartOfFrameJpegLS, std::move(content));
 }
 
 
@@ -65,7 +65,7 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateJpegFileInterchangeFormat
             static_cast<uint8_t*>(params.thumbnail) + 3 * params.Xthumbnail * params.Ythumbnail);
     }
 
-    return make_unique<JpegMarkerSegment>(JpegMarkerCode::ApplicationData0, move(content));
+    return make_unique<JpegMarkerSegment>(JpegMarkerCode::ApplicationData0, std::move(content));
 }
 
 
@@ -82,7 +82,7 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateJpegLSExtendedParametersS
     push_back(content, static_cast<uint16_t>(params.T3));
     push_back(content, static_cast<uint16_t>(params.RESET));
 
-    return make_unique<JpegMarkerSegment>(JpegMarkerCode::JpegLSExtendedParameters, move(content));
+    return make_unique<JpegMarkerSegment>(JpegMarkerCode::JpegLSExtendedParameters, std::move(content));
 }
 
 
@@ -113,5 +113,5 @@ unique_ptr<JpegMarkerSegment> JpegMarkerSegment::CreateStartOfScanSegment(int co
     content.push_back(static_cast<uint8_t>(interleaveMode)); // ILV parameter
     content.push_back(0); // transformation
 
-    return make_unique<JpegMarkerSegment>(JpegMarkerCode::StartOfScan, move(content));
+    return make_unique<JpegMarkerSegment>(JpegMarkerCode::StartOfScan, std::move(content));
 }

--- a/Utilities/gdcmcharls/jpegstreamreader.cpp
+++ b/Utilities/gdcmcharls/jpegstreamreader.cpp
@@ -78,7 +78,7 @@ void JpegImageDataSegment::Serialize(JpegStreamWriter& streamWriter)
     auto codec = JlsCodecFactory<EncoderStrategy>().GetCodec(info, _params.custom);
     unique_ptr<ProcessLine> processLine(codec->CreateProcess(_rawStreamInfo));
     ByteStreamInfo compressedData = streamWriter.OutputStream();
-    size_t cbyteWritten = codec->EncodeScan(move(processLine), compressedData, streamWriter._bCompare ? streamWriter.GetPos() : nullptr);
+    size_t cbyteWritten = codec->EncodeScan(std::move(processLine), compressedData, streamWriter._bCompare ? streamWriter.GetPos() : nullptr);
     streamWriter.Seek(cbyteWritten);
 }
 
@@ -119,7 +119,7 @@ void JpegStreamReader::Read(ByteStreamInfo rawPixels)
 
         unique_ptr<DecoderStrategy> qcodec = JlsCodecFactory<DecoderStrategy>().GetCodec(_params, _params.custom);
         unique_ptr<ProcessLine> processLine(qcodec->CreateProcess(rawPixels));
-        qcodec->DecodeScan(move(processLine), _rect, _byteStream, _bCompare); 
+        qcodec->DecodeScan(std::move(processLine), _rect, _byteStream, _bCompare);
         SkipBytes(rawPixels, static_cast<size_t>(bytesPerPlane));
 
         if (_params.interleaveMode != InterleaveMode::None)

--- a/Wrapping/Python/gdcmPythonFilter.cxx
+++ b/Wrapping/Python/gdcmPythonFilter.cxx
@@ -35,7 +35,7 @@ PythonFilter::~PythonFilter()
 
 void PythonFilter::SetDicts(const Dicts &dicts)
 {
-  assert(0); // FIXME
+  gdcm_assert(0); // FIXME
 }
 
 void PythonFilter::SetFile(const File& f) { F = f; }
@@ -163,7 +163,7 @@ const char *GetPythonTypeFromVR(VR const &vr)
       s = "s";
       break;
     default:
-      assert( 0 );
+      gdcm_assert( 0 );
       s = nullptr;
     }
   return s;
@@ -233,7 +233,7 @@ PyObject *PythonFilter::ToPyObject(const Tag& t) const
     }
 
   const DataElement &de = ds.GetDataElement( t );
-  assert( de.GetTag().IsPublic() );
+  gdcm_assert( de.GetTag().IsPublic() );
   const DictEntry &entry = dicts.GetDictEntry(de.GetTag());
   if( entry.GetVR() == VR::INVALID )
     {
@@ -249,11 +249,11 @@ PyObject *PythonFilter::ToPyObject(const Tag& t) const
     {
     vr = de.GetVR();
     }
-  assert( vr != VR::UN && vr != VR::INVALID );
+  gdcm_assert( vr != VR::UN && vr != VR::INVALID );
   //std::cerr << "Found " << vr << " for " << de.GetTag() << std::endl;
   //if( VR::IsASCII( vr ) )
     {
-    //assert( vr & VR::VRASCII );
+    //gdcm_assert( vr & VR::VRASCII );
     if( de.IsEmpty() )
       {
       return nullptr;

--- a/Wrapping/Python/gdcmswig.i
+++ b/Wrapping/Python/gdcmswig.i
@@ -626,7 +626,7 @@ static bool callback_helper(gdcm::DataSet const & ds1, gdcm::DataSet const & ds2
   func = 0; //(PyObject *)data;
   if (!(arglist = Py_BuildValue("()"))) {
     /* fail */
-    assert(0);
+    gdcm_assert(0);
   }
   result = PyObject_CallObject(func, arglist);
   Py_DECREF(arglist);
@@ -635,10 +635,10 @@ static bool callback_helper(gdcm::DataSet const & ds1, gdcm::DataSet const & ds2
                     "Callback function should return nothing");
     Py_DECREF(result);
     /* fail */
-    assert(0);
+    gdcm_assert(0);
   } else if (!result) {
     /* fail: a Python exception was raised */
-    assert(0);
+    gdcm_assert(0);
   }
   return true;
 }


### PR DESCRIPTION
in C++ library code, it’s generally considered bad practice to use assert for input validation or error handling. Here’s why, and what to do instead:

⸻

⚠️ Why you should not use assert in library code


- [ ] Stripped in release builds
assert() is disabled if NDEBUG is defined (typical for optimized builds), so important checks may silently disappear.

- [ ] Terminates the program
assert calls abort() on failure — not ideal for libraries meant to be reused safely by others.

- [ ] Not user-friendly
Gives no chance to recover or handle the failure gracefully.

- [ ] Violates encapsulation
Forces application behavior based on internal library assumptions.
