### PR TITLE
Increase cmake_minimum_required for CMake 4 compatibility

### DIFF
--- a/gdcm_common.cmake
+++ b/gdcm_common.cmake
@@ -88,7 +88,7 @@
 #
 #==========================================================================*/
 
-cmake_minimum_required(VERSION 2.8.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 set(dashboard_user_home "$ENV{HOME}")
 


### PR DESCRIPTION
Ever since updating my bots to CMake 4, they were failing to build.

Here I just copied @bradking's same solution that he did for VTK.