### PR TITLE
Defaulting non-zero frame time to spacing of 1 instead of 0

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmImageHelper.cxx
@@ -1744,13 +1744,9 @@ $ dcmdump D_CLUNIE_NM1_JPLL.dcm" | grep 0028,0009
           {
           if( at2.GetValue() != 0. )
             {
-            gdcmErrorMacro( "Number of Frame should be equal to 0" );
-            sp.push_back( 0.0 );
+            gdcmErrorMacro( "Frame time for a single frame image should equal to 0, but found "<< at.GetValue() << ". Default to 1.0.");
             }
-          else
-            {
-            sp.push_back( 1.0 );
-            }
+          sp.push_back( 1.0 );
           }
         }
       else


### PR DESCRIPTION
A single frame image that has FrameTime != 0 should either have spacing equal to:
1. The values referenced by FrameTime, as with line 1741, or
2. Defaulting to 1.0 spacing.

The default 1.0 spacing makes more sense since it is the value used when we don't know what the actual value should be and doing this provides behavioural consistency. Using the value reference by the FrameTime time could work, but that value needs to have at least 2 frames have spacing associated with it to have some meaning.

In either case, using 0.0 spacing when a single frame image has FrameTime != 0 does not make sense and we should change this, preferably, defaulting to 1.0.