### PR TITLE
This changes the inclusion of "zlib/zlib.h" to "gdcm_zlib.h"

### DIFF
--- a/Applications/Cxx/deflate.cxx
+++ b/Applications/Cxx/deflate.cxx
@@ -5,7 +5,7 @@
 #include <assert.h>
 #include <errno.h>
 
-#include "zlib/zlib.h"
+#include "gdcm_zlib.h"
 
 #define CHUNK 16384
 


### PR DESCRIPTION
* If there is no system-wide zlib installed there should not even be a `zlib/zlib.h`, because inside of GDCM it'd be `gdcmzlib/zlib.h`