### PR TITLE
Fix CVE-2026-3650: reject DICOM Value Length exceeding stream size

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
@@ -242,6 +242,23 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    if( readvalues )
+      {
+      const std::streampos cur = is.tellg();
+      if( cur != std::streampos(-1) )
+        {
+        is.seekg(0, std::ios::end);
+        const std::streampos end = is.tellg();
+        is.seekg(cur);
+        if( end != std::streampos(-1) && is.good()
+          && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+          {
+          gdcmWarningMacro( "Value Length " << ValueLengthField
+            << " exceeds remaining stream size for tag " << TagField );
+          throw Exception( "Value Length exceeds remaining stream size" );
+          }
+        }
+      }
     }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );

--- a/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
@@ -91,6 +91,18 @@ public:
     {
     // Self
     SmartPointer<ByteValue> bv = new ByteValue;
+    const std::streampos cur = is.tellg();
+    if( cur != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end = is.tellg();
+      is.seekg(cur);
+      if( end != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        throw Exception( "Fragment Value Length exceeds remaining stream size" );
+        }
+      }
     bv->SetLength(ValueLengthField);
     if( !bv->Read<TSwap>(is) )
       {
@@ -144,6 +156,18 @@ public:
 
     // Self
     SmartPointer<ByteValue> bv = new ByteValue;
+    const std::streampos cur2 = is.tellg();
+    if( cur2 != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end2 = is.tellg();
+      is.seekg(cur2);
+      if( end2 != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end2 - cur2) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        throw Exception( "Fragment Value Length exceeds remaining stream size" );
+        }
+      }
     bv->SetLength(ValueLengthField);
     if( !bv->Read<TSwap>(is) )
       {

--- a/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
@@ -215,6 +215,23 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     ValueLengthField = 202; // 0xca
     }
 #endif
+  if( !ValueLengthField.IsUndefined() && readvalues )
+    {
+    const std::streampos cur = is.tellg();
+    if( cur != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end = is.tellg();
+      is.seekg(cur);
+      if( end != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        gdcmWarningMacro( "Value Length " << ValueLengthField
+          << " exceeds remaining stream size for tag " << TagField );
+        throw Exception( "Value Length exceeds remaining stream size" );
+        }
+      }
+    }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );
   bool failed;

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
@@ -167,7 +167,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       {
       gdcm_assert( Fragments.size() == 1 );
       const ByteValue *bv = Fragments[0].GetByteValue();
-      gdcm_assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
+      gdcm_assert( bv->GetLength() >= 1 && (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
       // Yes this is an extra copy, this is a bug anyway, go fix YOUR code
       Fragments[0].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       gdcmWarningMacro( "JPEG Fragment length was declared with an extra byte"
@@ -188,7 +188,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
-      gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 1 ] == 0xfe );
+      gdcmAssertAlwaysMacro( bv->GetLength() >= 1 && (unsigned char)a[ bv->GetLength() - 1 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       is.seekg( -9, std::ios::cur );
       gdcm_assert( is.good() );
@@ -212,7 +212,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
-      gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 2 ] == 0xfe );
+      gdcmAssertAlwaysMacro( bv->GetLength() >= 2 && (unsigned char)a[ bv->GetLength() - 2 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 2 );
       is.seekg( -10, std::ios::cur );
       gdcm_assert( is.good() );

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/CMakeLists.txt
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/CMakeLists.txt
@@ -47,6 +47,7 @@ set(DSED_TEST_SRCS
   TestVL.cxx
   TestVM.cxx
   TestVR.cxx
+  TestCVE20263650.cxx
   #TestValue.cxx
   #TestTorture.cxx
   TestElement2.cxx

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestCVE20263650.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestCVE20263650.cxx
@@ -1,0 +1,144 @@
+/*=========================================================================
+
+  Program: GDCM (Grassroots DICOM). A DICOM library
+
+  Copyright (c) 2006-2011 Mathieu Malaterre
+  All rights reserved.
+  See Copyright.txt or http://gdcm.sourceforge.net/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "gdcmExplicitDataElement.h"
+#include "gdcmImplicitDataElement.h"
+#include "gdcmFragment.h"
+#include "gdcmSwapper.h"
+
+#include <sstream>
+#include <new>
+
+// CVE-2026-3650: Verify that crafted DICOM data elements with a Value Length
+// exceeding the remaining stream size are rejected without attempting the
+// allocation.
+
+static int TestExplicitVR()
+{
+  // Explicit VR data element: Tag (0008,0060), VR = OB, VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0x0008;
+  const uint16_t element = 0x0060;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  ss.write("OB", 2);
+  const uint16_t reserved = 0;
+  ss.write(reinterpret_cast<const char*>(&reserved), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::ExplicitDataElement de;
+  try
+    {
+    de.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: ExplicitDataElement::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: ExplicitDataElement allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: ExplicitDataElement::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+static int TestImplicitVR()
+{
+  // Implicit VR data element: Tag (0008,0060), VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0x0008;
+  const uint16_t element = 0x0060;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::ImplicitDataElement de;
+  try
+    {
+    de.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: ImplicitDataElement::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: ImplicitDataElement allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: ImplicitDataElement::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+static int TestFragment()
+{
+  // Fragment: Item tag (fffe,e000), VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0xfffe;
+  const uint16_t element = 0xe000;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::Fragment frag;
+  try
+    {
+    frag.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: Fragment::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: Fragment allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: Fragment::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+int TestCVE20263650(int, char *[])
+{
+  int ret = 0;
+  ret += TestExplicitVR();
+  ret += TestImplicitVR();
+  ret += TestFragment();
+  return ret;
+}


### PR DESCRIPTION
## Summary

Fixes CVE-2026-3650, a denial-of-service vulnerability where a crafted DICOM file can trigger excessive memory allocation by declaring a Value Length far exceeding the actual stream data.

## Problem

When parsing DICOM files, the Value Length (VL) field is read as a raw 32-bit unsigned integer and passed directly to `ByteValue::SetLength()`, which calls `std::vector::resize()`. A malicious file can set VL up to ~4 GB, causing a massive memory allocation **before** any data is read from the stream. This enables denial-of-service via memory exhaustion.

Four code paths were unprotected:
- `ExplicitDataElement::ReadValue()` — explicit VR data elements
- `ImplicitDataElement::ReadValue()` — implicit VR data elements
- `Fragment::ReadValue()` — encapsulated pixel data fragments
- `Fragment::ReadBacktrack()` — fragment error-recovery path

Additionally, `SequenceOfFragments::ReadValue()` had three out-of-bounds array accesses where `bv->GetLength() - N` was used without minimum length guards — two via `gdcmAssertAlwaysMacro` (active in release builds).

## Changes

### Stream-size validation (4 sites)
Before allocating a `ByteValue`, the code now compares the declared VL against remaining bytes in the stream via `tellg()`/`seekg()`. If VL exceeds available data, an `Exception` is thrown. Non-seekable streams skip the check gracefully. Stream state (`end` position validity and `is.good()`) is verified after seeking.

**Files:**
- `Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx`
- `Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx`
- `Source/DataStructureAndEncodingDefinition/gdcmFragment.h`

### Out-of-bounds access fixes (3 sites)
Added minimum-length guards before array accesses in broken-implementation recovery paths:
- Line 170: `bv->GetLength() >= 1` (debug assert)
- Line 191: `bv->GetLength() >= 1` (release assert)
- Line 215: `bv->GetLength() >= 2` (release assert)

**File:** `Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h`

### Test
Added `TestCVE20263650.cxx` covering all three vulnerability vectors (Explicit VR, Implicit VR, Fragment) with a 1 GB VL on a ~20-byte stream. The test verifies `gdcm::Exception` is thrown and specifically fails on `std::bad_alloc` (which would indicate the allocation was attempted).

## Test plan
- [x] `TestCVE20263650` passes — all three sub-tests reject oversized VL
- [x] All 42 existing DSED tests pass with no regressions
- [x] CodeRabbit review — all findings addressed

## References
- [ITK Discourse: Is ITK vulnerable to GDCM CVE-2026-3650?](https://discourse.itk.org/t/is-itk-vulnerable-to-gdcm-cve-2026-3650-memory-consumption-issue/7748/3)