### PR TITLE
Restore default initializer for RLEHeader::Offset[15] (accidentally dropped in 666bb534)

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmRLECodec.cxx
@@ -36,7 +36,7 @@ class RLEHeader
 {
 private:
   uint32_t NumSegments = 0;
-  uint32_t Offset[15];
+  uint32_t Offset[15]{};
 
 public:
   uint32_t GetNumSegments() const { return NumSegments; }


### PR DESCRIPTION
One-line fix — restore the `= {0}` default initializer that was accidentally dropped from `RLEHeader::Offset[15]` in commit 666bb5340508 ("Fix compilation on VS 2012/appveyor"). The paired sibling `NumSegments = 0` on the previous line was kept, which is a strong signal the removal was unintended collateral of the VS 2012 build fix rather than a deliberate design change.

<details>
<summary>Root cause</summary>

Commit [`666bb5340508`](https://github.com/malaterre/GDCM/commit/666bb5340508) changed:

```cpp
private:
  uint32_t NumSegments = 0;
- uint32_t Offset[15] = {0};
+ uint32_t Offset[15];
```

The `Offset` array is now indeterminate between object construction and the first successful `Read()`. Any code path that queries an offset from a freshly-constructed-but-not-yet-read `RLEHeader` reads uninitialized memory — undefined behavior under C++ `[dcl.init]/12`.

The sibling `NumSegments = 0` initializer on the immediately preceding line was retained by that commit, which would be inconsistent if dropping `Offset[15] = {0}` had been deliberate.

</details>

<details>
<summary>Fix</summary>

Use the value-initialization brace syntax instead of `= {0}`:

```cpp
  uint32_t Offset[15]{};
```

This is semantically equivalent (zeroes all 15 `uint32_t` elements) but:

- avoids the `-Wmissing-braces` warning some compilers emit for `= {0}` on an array of fundamental type,
- is accepted by every C++11-conforming toolchain including VS 2012 (the compiler that motivated `666bb5340508`),
- is zero-cost at runtime.

No behavioral change for correct DICOM inputs — `Read()` overwrites every element before any accessor is legal to call. This is defense-in-depth against premature queries and against the static analyzers (clang-analyzer, MSVC /analyze) and runtime sanitizers (MSan) that correctly flag the current code.

</details>

<details>
<summary>Reported by</summary>

greptile's AI review on the ITK vendoring PR that ingests the current `master`:
https://github.com/InsightSoftwareConsortium/ITK/pull/6090

</details>
