### PR TITLE
Removing unused function `System::GetHostName()` (fixes issue 584)

### DIFF
--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -954,41 +954,6 @@ int System::StrCaseCmp(const char *s1, const char *s2)
 #endif
 }
 
-bool System::GetHostName(char name[255])
-{
-// http://msdn.microsoft.com/en-us/library/ms738527.aspx
-// WSANOTINITIALISED A successful WSAStartup call must occur before using this function.
-#ifdef _WIN32
-  // Get the hostname
-  WORD wVersionRequested;
-  WSADATA wsaData;
-  wVersionRequested = MAKEWORD(2,0);
-
-  if ( WSAStartup( wVersionRequested, &wsaData ) == 0 )
-    {
-    bool ret = false;
-    if( gethostname(name,255) == 0 )
-      {
-      ret = true;
-      }
-    else
-      {
-      *name = 0;
-      }
-    WSACleanup( );
-    return ret;
-    }
-#else
-  if( gethostname(name, 255) == 0 )
-    {
-    return true;
-    }
-#endif
-  // If reach here gethostname failed, uninit name just in case
-  *name = 0;
-  return false;
-}
-
 char *System::StrTokR(char *str, const char *delim, char **nextp)
 {
 #if 1

--- a/Source/Common/gdcmSystem.h
+++ b/Source/Common/gdcmSystem.h
@@ -73,10 +73,6 @@ public:
   // Chdir
   // copy a file
 
-  /// Retrieve the hostname, only the first 255 byte are copied.
-  /// This may come handy to specify the Station Name
-  static bool GetHostName(char hostname[255]);
-
   // In the following the size '22' is explicitly listed. You need to pass in
   // at least 22bytes of array. If the string is an output it will be
   // automatically padded ( array[21] == 0 ) for you.

--- a/Testing/Source/Common/Cxx/TestSystem1.cxx
+++ b/Testing/Source/Common/Cxx/TestSystem1.cxx
@@ -284,18 +284,6 @@ int TestSystem1(int, char *[])
   //int n = sscanf( long_str8, "%8ld", &l );
   //std::cout << "Long:" << l << std::endl;
 
-  char hostname[255+1];
-  hostname[255] = 0;
-  if( gdcm::System::GetHostName( hostname ) )
-    {
-    std::cout << "Host:" <<  hostname << std::endl;
-    }
-  else
-  {
-    std::cerr << "cannot get Hostname" << std::endl;
-  return 1;
-  }
-
   //time_t t = gdcm::System::FileTime("/etc/debian_version");
   //char date3[22];
   //gdcm::System::FormatDateTime(date3, t);


### PR DESCRIPTION
The function `bool System::GetHostName(char name[255])` (aka
`gdcm::System::GetHostName`) from `Source/Common/gdcmSystem.cxx` is
superfluous, it appears.

The adjacent header even declares its visibility as `static`, but there's a
test for the function inside `Testing/Source/Common/Cxx/TestSystem1.cxx`.
Other than that, it's unused.

Therefore it should be removed.