### PR TITLE
Default implied special members of DataSet and Item

### DIFF
--- a/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmDataSet.h
@@ -227,6 +227,10 @@ public:
   /// Returns if the dataset is empty
   bool IsEmpty() const { return DES.empty(); }
 
+  DataSet() = default;
+
+  DataSet(DataSet const &) = default;
+
   DataSet& operator=(DataSet const &)
   = default;
 

--- a/Source/DataStructureAndEncodingDefinition/gdcmItem.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmItem.h
@@ -93,6 +93,8 @@ public:
     NestedDataSet = val.NestedDataSet;
     }
 
+  Item& operator=(Item const &) = default;
+
   template <typename TDE, typename TSwap>
   std::istream &Read(std::istream &is) {
     // Superclass


### PR DESCRIPTION
Explicitly default the previously implied special members of `gdcm::DataSet` and `gdcm::Item`, fixing Clang `-Wextra` `-Wdeprecated-copy` warnings with no semantic change.

<details>
<summary>Details</summary>

- `DataSet` has a user-declared copy assignment (`= default`), which deprecates the implicitly-generated copy constructor. Declaring the copy constructor suppresses the implicit default constructor, so both are explicitly defaulted.
- `Item` has a user-provided copy constructor, which deprecates the implicitly-generated copy assignment; it is now explicitly defaulted.
- Move members are intentionally left undeclared: they were already suppressed by the user-declared copy members, and declaring them `= delete` would change overload resolution.

Reproduced with `clang++ -Wextra -Wdeprecated-copy` on a TU exercising copy construction/assignment of both classes:

```
gdcmDataSet.h:230:12: warning: definition of implicit copy constructor for 'DataSet' is deprecated because it has a user-declared copy assignment operator [-Wdeprecated-copy]
gdcmItem.h:91:3: warning: definition of implicit copy assignment operator for 'Item' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]
```

Both warnings are gone after this change. These also surface when building GDCM vendored inside ITK with Apple Clang (Xcode 16.4); ITK is carrying the same patch in InsightSoftwareConsortium/ITK#6430.
</details>
