### PR TITLE
CMake issue with libexpat/gdcmexpat fixed

### DIFF
--- a/Source/InformationObjectDefinition/CMakeLists.txt
+++ b/Source/InformationObjectDefinition/CMakeLists.txt
@@ -37,11 +37,10 @@ include_directories(
   "${GDCM_SOURCE_DIR}/Source/DataStructureAndEncodingDefinition"
   "${GDCM_SOURCE_DIR}/Source/DataDictionary"
   "${GDCM_SOURCE_DIR}/Utilities"
-  "${GDCM_BINARY_DIR}/Utilities/gdcmexpat" # expat_mangle.h
   )
-if(GDCM_USE_SYSTEM_EXPAT)
+if(NOT GDCM_USE_SYSTEM_EXPAT) # only needed _without_ find_package
   include_directories(
-    ${EXPAT_INCLUDE_DIRS}
+    "${GDCM_BINARY_DIR}/Utilities/gdcmexpat" # expat_mangle.h
   )
 endif()
 


### PR DESCRIPTION
- There was an asymmetry in `GDCM_USE_SYSTEM_EXPAT` `ON`/`OFF`
  * `Utilities/gdcmexpat/expat_mangle.h.in` gets rewritten by CMake into an `expat_mangle.h` that _isn't_ present in upstream libexpat!
    * created at: `${CMAKE_CURRENT_BINARY_DIR}` aka `${GDCM_BINARY_DIR}/Utilities/gdcmexpat`
    * it is included by `Utilities/gdcmexpat/lib/expat_external.h`
      * but _only_ by the vendored flavor of `expat_external.h`
      * which in turn is included by `expat.h`
        * which in turn is included by `Utilities/gdcm_expat.h`
          * but conditioned on `GDCM_USE_SYSTEM_EXPAT` being undefined
  * with CMake's `find_package(EXPAT)` the include directories were already supposed to be populated (a contract that may only have been broken by local module overrides via a `FindEXPAT.cmake`); testing after the fix suggests this assumption to hold up
    * yet `${GDCM_BINARY_DIR}/Utilities/gdcmexpat` got unconditionally added
    * this led to include path confusion where the include path from the `gdcmexpat` came before the system one, leading to inclusion of the wrong `expat.h` -> `expat_external.h` -> expat_mangle.h`
      * but when `GDCM_USE_SYSTEM_EXPAT=ON` this `expat.h` shouldn't even be "visible" as include path
  * with the vendored libexpat everything would be fine, since only it depends on the `expat_mangle.h`