### PR TITLE
BUG: Remove OpenJPEG cache entries that break re-configuration

### DIFF
--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -177,9 +177,6 @@ configure_file(
 #-----------------------------------------------------------------------------
 # OpenJPEG build configuration options.
 #option(BUILD_SHARED_LIBS "Build OpenJPEG shared library and link executables against it." ON)
-set (EXECUTABLE_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all executables.")
-set (LIBRARY_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
-mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
 
 #-----------------------------------------------------------------------------
 # configure name mangling to allow multiple libraries to coexist


### PR DESCRIPTION
Re-configuring a GDCM build tree breaks the build:

```
cmake -G "Unix Makefiles" ../gdcm -DBUILD_TESTING:BOOL=OFF
make          # succeeds
cmake .
make          # ar: /bin/libgdcmmd5.a: Permission denied
```

`Utilities/gdcmopenjpeg/CMakeLists.txt` sets `EXECUTABLE_OUTPUT_PATH` / `LIBRARY_OUTPUT_PATH` as **CACHE** entries from `OPENJPEG_BINARY_DIR`, which is never defined — so the cached value is the literal path `/bin`. Reproduced on `master` (69b7aea5f) and present in v3.2.8, v3.2.9 and v3.2.10.

<details>
<summary>Root cause</summary>

`Utilities/CMakeLists.txt:26` sets `OPENJPEG_NAMESPACE "GDCMOPENJPEG"`, so `project(${OPENJPEG_NAMESPACE} C)` defines `GDCMOPENJPEG_BINARY_DIR` — not `OPENJPEG_BINARY_DIR`. The two `set(... CACHE PATH ...)` calls therefore expand to `/bin`, and `CMakeCache.txt` after the very first configure contains:

```
EXECUTABLE_OUTPUT_PATH:PATH=/bin
LIBRARY_OUTPUT_PATH:PATH=/bin
```

Ordering is what makes this a second-pass-only failure:

- **Configure 1** — the compatibility block in `CMakeLists.txt` runs *before* `add_subdirectory(Utilities)`, so both variables are still undefined. No warning, and the `CMAKE_*_OUTPUT_DIRECTORY` defaults place the targets correctly. OpenJPEG then writes the `/bin` cache entries.
- **Configure 2** — the cache is preloaded first, so `if(EXECUTABLE_OUTPUT_PATH)` is now true. The block re-emits both warnings *and* points `CMAKE_RUNTIME_OUTPUT_DIRECTORY`, `CMAKE_LIBRARY_OUTPUT_DIRECTORY` and `CMAKE_ARCHIVE_OUTPUT_DIRECTORY` at `/bin` for all of GDCM.

On Linux `/bin` is unwritable, so the build fails. On Windows it resolves against the current drive and silently misplaces the artifacts instead.

</details>

<details>
<summary>Why removal is the right fix</summary>

Nothing inside `gdcmopenjpeg` reads either variable — the three lines are the only occurrences in that directory, and the surrounding `CMAKE_*_OUTPUT_DIRECTORY` defaults already place the targets correctly. Verified by building with them removed: the OpenJPEG targets land exactly where they did before.

Correcting the typo instead (`${${OPENJPEG_NAMESPACE}_BINARY_DIR}`) is **not** sufficient. The CACHE entries would still exist, so the compatibility block would still fire on every re-configure, both warnings would still return, and all of GDCM's libraries would be redirected into OpenJPEG's `bin` directory.

</details>

<details>
<summary>Testing</summary>

Linux, GNU Make generator, `master` @ 69b7aea5f.

| | configure ×2 | warnings | make ×2 | ctest |
|---|---|---|---|---|
| master | cache → `/bin` | 2 | **exit 2** | 195/198 |
| this PR | no cache entries | 0 | exit 0 | 195/198 |

The three failures (`TestSCUValidation`, `TestEcho`, `TestFind`) are pre-existing on unmodified `master` and unrelated to this change — the failing set is identical before and after.

Also verified with a third `cmake . && make` pass to confirm the result is idempotent rather than merely surviving one re-configure, and confirmed no files are written to `/bin`.

</details>

<details>
<summary>Downstream context</summary>

Found while investigating InsightSoftwareConsortium/ITK#6617, where ITK's vendored GDCM copy hit this on `release-5.4`. ITK had been masking it by setting the two variables as normal (non-cache) variables before `add_subdirectory(gdcm)`, which shadowed the poisoned cache values; removing that workaround exposed the underlying problem. The reproduction above is plain GDCM with no ITK involved.

</details>
