### PR TITLE
ENH: Drop legacy EXECUTABLE_OUTPUT_PATH/LIBRARY_OUTPUT_PATH handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,18 +121,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 #-----------------------------------------------------------------------------
-# Compatibility with older usage of EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH.
-# This should be removed in the future.
-if(EXECUTABLE_OUTPUT_PATH)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
-  message(WARNING "EXECUTABLE_OUTPUT_PATH is deprecated. Use CMAKE_RUNTIME_OUTPUT_DIRECTORY instead.")
-endif()
-if(LIBRARY_OUTPUT_PATH)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
-  message(WARNING "LIBRARY_OUTPUT_PATH is deprecated. Use CMAKE_LIBRARY_OUTPUT_DIRECTORY and CMAKE_ARCHIVE_OUTPUT_DIRECTORY instead.")
-endif()
-
 if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
@@ -143,16 +131,11 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
 
-# Set for legacy internal usage of EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH
-if (NOT EXECUTABLE_OUTPUT_PATH)
-  set(EXECUTABLE_OUTPUT_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-endif()
-if (NOT LIBRARY_OUTPUT_PATH)
-  if (BUILD_SHARED_LIBS)
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  else()
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-  endif()
+# Shared libraries land in the library directory, static ones in the archive directory.
+if(BUILD_SHARED_LIBS)
+  set(GDCM_LIBRARY_OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+else()
+  set(GDCM_LIBRARY_OUTPUT_DIR ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 endif()
 
 #-----------------------------------------------------------------------------
@@ -601,8 +584,8 @@ if(GDCM_STANDALONE)
   endif()
 endif()
 
-set(GDCM_LIBRARY_DIR ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
-set(GDCM_EXECUTABLE_DIR ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
+set(GDCM_LIBRARY_DIR ${GDCM_LIBRARY_OUTPUT_DIR}/${CMAKE_CFG_INTDIR})
+set(GDCM_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
 
 #-----------------------------------------------------------------------------
 # we need to link against CoreFoundation so that we can use CFBundle to get the executable path.
@@ -1199,7 +1182,7 @@ if(GDCM_USE_VTK)
       "${GDCM_SOURCE_DIR}/Utilities/VTK"
       )
 endif()
-set(GDCM_LIBRARY_DIRS ${LIBRARY_OUTPUT_PATH})
+set(GDCM_LIBRARY_DIRS ${GDCM_LIBRARY_OUTPUT_DIR})
 if(GDCM_STANDALONE)
 add_subdirectory(CMake/ExportConfiguration)
 endif()

--- a/Source/Common/gdcmConfigure.h.in
+++ b/Source/Common/gdcmConfigure.h.in
@@ -38,8 +38,8 @@
 /* Useful in particular for loadshared where the full path
  * to the lib is needed */
 #define GDCM_SOURCE_DIR "@GDCM_SOURCE_DIR@"
-#define GDCM_EXECUTABLE_OUTPUT_PATH "@EXECUTABLE_OUTPUT_PATH@"
-#define GDCM_LIBRARY_OUTPUT_PATH    "@LIBRARY_OUTPUT_PATH@"
+#define GDCM_EXECUTABLE_OUTPUT_PATH "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@"
+#define GDCM_LIBRARY_OUTPUT_PATH    "@GDCM_LIBRARY_OUTPUT_DIR@"
 
 #cmakedefine GDCM_BUILD_TESTING
 

--- a/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -177,9 +177,6 @@ configure_file(
 #-----------------------------------------------------------------------------
 # OpenJPEG build configuration options.
 #option(BUILD_SHARED_LIBS "Build OpenJPEG shared library and link executables against it." ON)
-set (EXECUTABLE_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all executables.")
-set (LIBRARY_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
-mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
 
 #-----------------------------------------------------------------------------
 # configure name mangling to allow multiple libraries to coexist


### PR DESCRIPTION
Removes GDCM's handling of the old `EXECUTABLE_OUTPUT_PATH` / `LIBRARY_OUTPUT_PATH` variables, whose compatibility block is already marked *"This should be removed in the future"*. GDCM requires CMake >= 3.9.2, while the superseding `CMAKE_*_OUTPUT_DIRECTORY` variables have existed since CMake 2.6 — the legacy path cannot be reached by any supported configuration.

The public `GDCM_EXECUTABLE_OUTPUT_PATH` / `GDCM_LIBRARY_OUTPUT_PATH` defines in `gdcmConfigure.h` are **retained**, with unchanged values.

⚠️ **Behavior change:** setting `EXECUTABLE_OUTPUT_PATH` or `LIBRARY_OUTPUT_PATH` no longer redirects GDCM's output — it is now silently ignored. See the open question below; happy to adjust.

Builds on #226 (the OpenJPEG cache-entry fix) and should merge after it.

<details>
<summary>Rationale</summary>

CMake documents both variables as the *"Old executable location variable"* and *"Old library location variable"*, superseded by the `RUNTIME_OUTPUT_DIRECTORY`, `LIBRARY_OUTPUT_DIRECTORY` and `ARCHIVE_OUTPUT_DIRECTORY` target properties and their `CMAKE_*_OUTPUT_DIRECTORY` initializers. Those replacements are documented as far back as CMake 2.6 (2008) — roughly nine years before GDCM's own `cmake_minimum_required(VERSION 3.9.2...3.13.4)` floor (`CMakeLists.txt:4`).

To be precise: CMake does **not** deprecate these variables and emits no warning of its own — they remain documented and functional. The `message(WARNING)` calls removed here were GDCM's own. The argument for removal is not that CMake forbids them, but that GDCM's minimum CMake version makes the compatibility path dead code.

</details>

<details>
<summary>What changed</summary>

- Removed the compatibility block that read the old variables into `CMAKE_*_OUTPUT_DIRECTORY` (and its two `message(WARNING)` calls).
- Removed the "legacy internal usage" block that populated the old variables from the modern ones.
- Internal consumers now read the modern variables directly. `GDCM_LIBRARY_DIR` and `GDCM_LIBRARY_DIRS` use a new internal `GDCM_LIBRARY_OUTPUT_DIR`, preserving the previous shared/static distinction between `CMAKE_LIBRARY_OUTPUT_DIRECTORY` and `CMAKE_ARCHIVE_OUTPUT_DIRECTORY`.
- `gdcmConfigure.h.in` now substitutes `@CMAKE_RUNTIME_OUTPUT_DIRECTORY@` and `@GDCM_LIBRARY_OUTPUT_DIR@` in place of the old variables.

</details>

<details>
<summary>Public API is preserved</summary>

The two defines are consumed, so they are kept rather than removed:

- `Testing/Source/Common/Cxx/TestSystem1.cxx:148-151` uses `GDCM_EXECUTABLE_OUTPUT_PATH`.
- `TestKakaduDecompressionMD5.py` and `TestDCMTKMD5.py` use `gdcm.GDCM_EXECUTABLE_OUTPUT_PATH` via the SWIG bindings.

For any configuration that does not set the old variables, the generated values are byte-identical to before — both resolve to `<build>/bin`, verified by diffing the generated `gdcmConfigure.h` against `master`. `TestSystem1` passes.

</details>

<details>
<summary>Testing</summary>

Linux, GNU Make generator, `GDCM_BUILD_TESTING=ON`.

| | ctest | `TestSystem1` |
|---|---|---|
| master | 195/198 | pass |
| this PR | 195/198 | pass |

The failing set is identical before and after (`TestSCUValidation`, `TestEcho`, `TestFind` — pre-existing network-DICOM failures unrelated to this change). Also verified re-configure idempotency across three `cmake . && make` passes.

</details>

<details>
<summary>Open question: silent vs. warned</summary>

With this change, a project that still sets `LIBRARY_OUTPUT_PATH` gets it silently ignored: libraries land in `<build>/bin` and `GDCM_LIBRARY_DIRS` agrees, so the result is internally consistent — but the setting quietly loses effect, where previously it was honored (with a warning).

I kept the patch minimal, but silently ignoring an explicitly-set variable is arguably worse than the status quo. If you prefer, I can add a short warning along the lines of:

```cmake
if(EXECUTABLE_OUTPUT_PATH OR LIBRARY_OUTPUT_PATH)
  message(WARNING "EXECUTABLE_OUTPUT_PATH/LIBRARY_OUTPUT_PATH are ignored. Use CMAKE_RUNTIME_OUTPUT_DIRECTORY, CMAKE_LIBRARY_OUTPUT_DIRECTORY and CMAKE_ARCHIVE_OUTPUT_DIRECTORY.")
endif()
```

That would only fire for projects that genuinely set them (nothing writes those cache entries once #226 lands). Your call — happy to add it, drop this PR, or reduce it to just the `GDCM_LIBRARY_OUTPUT_PATH` define, which has no consumers at all.

</details>
