### PR TITLE
Use off_t instead of the glibc-specific off64_t in FileStreamer

### DIFF
--- a/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
@@ -11,6 +11,12 @@
      PURPOSE.  See the above copyright notice for more information.
 
 =========================================================================*/
+// The GNU C library (glibc) requires this be defined to have fseeko() and ftello().
+// Must precede every #include: this is what makes off_t 64-bit on 32-bit POSIX.
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
 #include "gdcmFileStreamer.h"
 
 #include "gdcmTag.h"
@@ -22,27 +28,31 @@
 #include "gdcmEvent.h"
 #include "gdcmProgressEvent.h"
 
-// The GNU C library (glibc) requires this be defined to have fseeko() and ftello().
-#ifdef __GNU_LIBRARY__
-#define _FILE_OFFSET_BITS 64
-#endif
-
+#include <cstdint> // int64_t
 #include <cstdio>
 #include <limits>
 #include <sys/stat.h> // fstat
 
 #if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
 #include <io.h>
-typedef int64_t off64_t;
 #else
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)
-#  define off64_t off_t
-#endif
 #include <unistd.h> // ftruncate
 #endif
 
 namespace gdcm
 {
+
+// 64-bit file offset type. off_t is 64-bit on every platform except the
+// Microsoft CRT (MSVC/MinGW), given _FILE_OFFSET_BITS above. Not off64_t: that
+// is a glibc LFS64 name musl gates on _LARGEFILE64_SOURCE, deprecated there.
+#if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
+using offset_t = int64_t;
+#else
+using offset_t = off_t;
+#endif
+
+static_assert(sizeof(offset_t) >= 8,
+  "GDCM requires 64-bit file offsets; build with _FILE_OFFSET_BITS=64");
 
 // Implementation detail:
 // FILE* have been chosen over std::fstream since it has been reported to lead
@@ -50,9 +60,7 @@ namespace gdcm
 // handling of 64bits offset. Create thin wrapper:
 // See here for discussion:
 // http://stackoverflow.com/questions/17863594/size-of-off-t-at-compilation-time
-// Basically enforce use of off64_t over off_t since on windows off_t is pretty
-// much guarantee to be 32bits only.
-static inline int FSeeko(FILE *stream, off64_t offset, int whence)
+static inline int FSeeko(FILE *stream, offset_t offset, int whence)
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -65,7 +73,7 @@ static inline int FSeeko(FILE *stream, off64_t offset, int whence)
 #endif
 }
 
-static inline off64_t FTello(FILE *stream)
+static inline offset_t FTello(FILE *stream)
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -78,7 +86,7 @@ static inline off64_t FTello(FILE *stream)
 #endif
 }
 
-static inline bool FTruncate( const int fd, const off64_t len )
+static inline bool FTruncate( const int fd, const offset_t len )
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -96,7 +104,7 @@ static inline bool FTruncate( const int fd, const off64_t len )
 #endif
 }
 
-static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t inslen )
+static bool prepare_file( FILE * pFile, const offset_t offset, const offset_t inslen )
 {
   // fast path
   if( inslen == 0 ) return true;
@@ -111,13 +119,13 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
     {
     if( inslen < 0 )
       {
-      off64_t bytes_to_move = sb.st_size - offset;
-      off64_t read_start_offset = offset;
+      offset_t bytes_to_move = sb.st_size - offset;
+      offset_t read_start_offset = offset;
       while (bytes_to_move != 0)
         {
-        const size_t bytes_this_time = static_cast<size_t>(std::min((off64_t)BUFFERSIZE, bytes_to_move));
-        const off64_t rd_off = read_start_offset;
-        const off64_t wr_off = rd_off + inslen;
+        const size_t bytes_this_time = static_cast<size_t>(std::min((offset_t)BUFFERSIZE, bytes_to_move));
+        const offset_t rd_off = read_start_offset;
+        const offset_t wr_off = rd_off + inslen;
         if( FSeeko(pFile, rd_off, SEEK_SET) )
           {
           return false;
@@ -151,14 +159,14 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
 #endif
       if (sb.st_size > offset)
         {
-        off64_t bytes_to_move = sb.st_size - offset;
-        off64_t read_end_offset = sb.st_size;
+        offset_t bytes_to_move = sb.st_size - offset;
+        offset_t read_end_offset = sb.st_size;
         while (bytes_to_move != 0)
           {
-          const size_t bytes_this_time = static_cast<size_t>(std::min((off64_t)BUFFERSIZE, bytes_to_move));
-          const off64_t rd_off = read_end_offset - bytes_this_time;
-          gdcm_assert( (off64_t)rd_off >= offset );
-          const off64_t wr_off = rd_off + inslen;
+          const size_t bytes_this_time = static_cast<size_t>(std::min((offset_t)BUFFERSIZE, bytes_to_move));
+          const offset_t rd_off = read_end_offset - bytes_this_time;
+          gdcm_assert( (offset_t)rd_off >= offset );
+          const offset_t wr_off = rd_off + inslen;
           if( FSeeko(pFile, rd_off, SEEK_SET) )
             {
             return false;
@@ -329,15 +337,15 @@ public:
       size_t dicomlen = 4 + 4; // Tag + VL for Implicit
       if( TS.GetNegociatedType() == TransferSyntax::Explicit )
         dicomlen += 4;
-      off64_t newlen = len;
+      offset_t newlen = len;
       gdcm_assert( (size_t)newlen == len );
       newlen += dicomlen;
       newlen -= actualde;
-      off64_t plength = newlen;
+      offset_t plength = newlen;
       gdcm_assert( ReservedDataLength >= 0 );
       if( ReservedDataLength )
         {
-        if( (newlen + ReservedDataLength) >= (off64_t)len )
+        if( (newlen + ReservedDataLength) >= (offset_t)len )
           {
           plength = newlen + ReservedDataLength - len;
           }
@@ -348,8 +356,8 @@ public:
         ReservedDataLength -= len;
         gdcm_assert( ReservedDataLength >= 0 );
         }
-      //if( !prepare_file( pFile, (off64_t)thepos + actualde, newlen ) )
-      if( !prepare_file( pFile, (off64_t)thepos + actualde, plength ) )
+      //if( !prepare_file( pFile, (offset_t)thepos + actualde, newlen ) )
+      if( !prepare_file( pFile, (offset_t)thepos + actualde, plength ) )
         {
         return false;
         }
@@ -363,18 +371,18 @@ public:
     else
       {
       gdcm_assert( pFile );
-      const off64_t curpos = FTello(pFile);
+      const offset_t curpos = FTello(pFile);
       gdcm_assert( curpos == thepos );
-      if( ReservedDataLength >= (off64_t)len )
+      if( ReservedDataLength >= (offset_t)len )
         {
         // simply update remaining reserved buffer:
         ReservedDataLength -= len;
         }
       else
         {
-        const off64_t plength = len - ReservedDataLength;
+        const offset_t plength = len - ReservedDataLength;
         gdcm_assert( plength >= 0 );
-        if( !prepare_file( pFile, (off64_t)curpos, plength) )
+        if( !prepare_file( pFile, (offset_t)curpos, plength) )
           {
           return false;
           }
@@ -395,14 +403,14 @@ public:
     // Update DataElement:
     const size_t currentdatalenth = CurrentDataLenth;
     gdcm_assert( ReservedDataLength >= 0);
-    //const off64_t refpos = FTello(pFile);
+    //const offset_t refpos = FTello(pFile);
     if( !UpdateDataElement( t ) )
       {
       return false;
       }
     if( ReservedDataLength > 0)
       {
-      const off64_t curpos = thepos;
+      const offset_t curpos = thepos;
       if( !prepare_file( pFile, curpos + ReservedDataLength, - ReservedDataLength) )
         {
         return false;
@@ -587,7 +595,7 @@ public:
     pFile = fopen(outfilename, "r+b");
     gdcm_assert( pFile );
 
-    if( !prepare_file( pFile, (off64_t)thepcpos, pclen ) )
+    if( !prepare_file( pFile, (offset_t)thepcpos, pclen ) )
       {
       return false;
       }
@@ -673,7 +681,7 @@ private:
   size_t actualde;
   size_t CurrentDataLenth;
   Tag CurrentGroupTag;
-  off64_t ReservedDataLength{0};
+  offset_t ReservedDataLength{0};
   unsigned short ReservedGroupDataElement{0};
 public:
   FileStreamer *Self{nullptr};
@@ -685,7 +693,7 @@ private:
       {
       if( CurrentDataLenth % 2 == 1 )
         {
-        const off64_t curpos = FTello(pFile);
+        const offset_t curpos = FTello(pFile);
         if( ReservedDataLength >= 1 )
           {
           // simply update remaining reserved buffer:
@@ -693,7 +701,7 @@ private:
           }
         else
           {
-          if( !prepare_file( pFile, (off64_t)curpos, 1) )
+          if( !prepare_file( pFile, (offset_t)curpos, 1) )
             {
             return false;
             }
@@ -705,7 +713,7 @@ private:
         CurrentDataLenth += 1;
         }
       gdcm_assert( CurrentDataLenth % 2 == 0 );
-      off64_t vlpos = thepos;
+      offset_t vlpos = thepos;
       vlpos -= CurrentDataLenth;
       vlpos -= 4; // VL
       if( TS.GetNegociatedType() == TransferSyntax::Explicit )
@@ -723,7 +731,7 @@ private:
       }
     return true;
     }
-  size_t WriteHelper( off64_t offset, const Tag & tag, const VL & vl )
+  size_t WriteHelper( offset_t offset, const Tag & tag, const VL & vl )
     {
     FSeeko(pFile, offset, SEEK_SET);
     std::stringstream ss;
@@ -768,7 +776,7 @@ bool FileStreamer::InitializeCopy()
   static int checksize = 0;
   if( !checksize )
     {
-    const int soff = sizeof( off64_t );
+    const int soff = sizeof( offset_t );
     const int si64 = sizeof( int64_t );
     if( soff != si64 ) return false;
     if( !(sizeof(sb.st_size) > 4) ) // LFS ?


### PR DESCRIPTION
`gdcmFileStreamer.cxx` fails to build on musl-based distributions (Alpine) because `off64_t` is a glibc LFS64 name. This replaces it with a GDCM-owned `gdcm::offset_t`, deleting the hand-maintained platform list without adding to it.

It also fixes a latent large-file bug found while investigating: the file's `_FILE_OFFSET_BITS 64` definition is placed after the include block, which makes it a no-op, so writes past 2 GB are silently broken on 32-bit glibc today.

Reported downstream as InsightSoftwareConsortium/ITK#6779.

**Question for you before this is worth reviewing in detail:** defining `_FILE_OFFSET_BITS` in a single TU changes `struct stat` layout and `off_t` width for that TU only. It is safe here (the only `struct stat` use is a local `fstat()`, and `offset_t` does not appear in `gdcmFileStreamer.h`), but if you would rather set it project-wide in CMake I am happy to redo it that way — say the word.

<details>
<summary>Root cause</summary>

musl gates its LFS64 names strictly on `_LARGEFILE64_SOURCE` and, unlike glibc, does not imply that from `_GNU_SOURCE`:

```c
/* musl 1.2.4, sys/types.h */
#if defined(_LARGEFILE64_SOURCE)
#define off64_t off_t
#endif
```

musl upstream is also removing these aliases, so enabling `_LARGEFILE64_SOURCE` is not a durable answer. musl's `off_t` is unconditionally 64-bit, so `off_t` was always the right type there.

Extending the platform list would fix Alpine but not the class of bug. `off64_t` is a *typedef*, so the preprocessor can never test for it — every guard is necessarily a proxy for "which libc is this", which is why the list has grown one platform at a time.

The glibc build works only because the C++ frontend implicitly defines `_GNU_SOURCE`, which turns on `__USE_LARGEFILE64`. Nothing in GDCM requests it, and the same block does not compile as C:

```
$ g++ -dM -E -x c++ /dev/null | grep _GNU_SOURCE
#define _GNU_SOURCE 1
$ gcc -dM -E -x c   /dev/null | grep _GNU_SOURCE      # nothing
```

Separately, `#define _FILE_OFFSET_BITS 64` must precede every libc header. In this file it sits after nine `gdcm*.h` includes, all of which transitively pull `<string>` → `<features.h>`. Once that include guard is set, a later `_FILE_OFFSET_BITS` is ignored. `__GNU_LIBRARY__` is likewise only defined *after* a libc header has been read, so the guard is order-dependent in the same way.

</details>

<details>
<summary>What changed</summary>

- Move `#define _FILE_OFFSET_BITS 64` ahead of all includes, unconditionally and `#ifndef`-guarded. It is ignored on macOS, the BSDs, musl and Windows, where `off_t` is already correct or unused for file offsets.
- Replace `off64_t` with `gdcm::offset_t`: `off_t` on POSIX, `int64_t` on the Windows CRT. This deletes the `__APPLE__ || __FreeBSD__ || __OpenBSD__ || __NetBSD__ || __EMSCRIPTEN__` list without adding anything.
- Add `static_assert(sizeof(offset_t) >= 8, ...)` so a 32-bit `off_t` is a build error rather than silent truncation.
- Add an explicit `<cstdint>` for `int64_t`, which was previously reached only transitively.

The one remaining `#if` tests "is this the Windows CRT", a genuine API difference. `offset_t` does not appear in `gdcmFileStreamer.h`, so this is contained to one translation unit and changes no public API.

| Property | before | after |
|---|---|---|
| Platform names in the guard | 5 + Windows | Windows only |
| Breaks on the next unlisted libc | yes | no |
| Depends on include order | yes | no |
| Depends on implicit `_GNU_SOURCE` | yes | no |
| Uses a libc-reserved name as a macro | yes | no |
| 32-bit `off_t` outcome | silent truncation | build error |
| `_FILE_OFFSET_BITS` takes effect | no | yes |

</details>

<details>
<summary>Testing</summary>

Synthetic probes, three libc/arch combinations:

| | musl x86_64 | glibc x86_64 | glibc i386 |
|---|---|---|---|
| LFS define, current placement | dead, `off_t`=8 | dead, `off_t`=8 | dead, `off_t`=4 |
| LFS define, patched placement | dead, `off_t`=8 | active | active, `off_t`=8 |
| current `off64_t` logic | does not compile | compiles | compiles |
| patched `offset_t` logic | clean, 8 | clean, 8 | clean, 8 |

Against the real source rather than probes:

- Alpine/musl, unpatched: `error: 'off64_t' has not been declared` at `gdcmFileStreamer.cxx:55`, `:68`, `:81` — reproduces the report.
- Alpine/musl, patched: TU compiles clean at `-Wall -Wextra`.
- i386 glibc, patched: TU compiles, so the `static_assert` passing is itself proof that `off_t` is now 64-bit in GDCM's own TU.
- i386 glibc, patched but with the LFS define restored to its current placement: `static_assert failed: GDCM requires 64-bit file offsets` — evidence that 32-bit builds truncate today.

macOS arm64, full build, `-DGDCM_BUILD_TESTING=ON` with `GDCM_DATA_ROOT` set, `-Wall -Wextra`:

- Builds clean; the only warning is a pre-existing one in `gdcmPrivateTag.h`.
- `TestFileStreamer1..6`: 6/6 pass.
- Full suite 206/230. The 24 failures are identical on unpatched `master` (verified by reverting only this file and re-running the same set), so they are pre-existing and unrelated.

Not covered: MSVC, MinGW-w64, and a >2 GB `FileStreamer` round-trip — no such fixture exists in `gdcmData`, so the 32-bit claim rests on the `static_assert` and the probes above rather than a runtime test.

</details>

<details>
<summary>Two follow-ups, deliberately not bundled here</summary>

1. **Hoist `_FILE_OFFSET_BITS=64` to CMake** (`target_compile_definitions(gdcmMSFF PRIVATE ...)` or global) and drop the per-file define. This is what `AC_SYS_LARGEFILE` does and removes the single-TU caveat above entirely. Happy to open it if you prefer that shape.

2. **MinGW-w64 truncates at 2 GB.** All three wrappers take 32-bit paths under `__MINGW32__` (`fseek`, `ftell`, `_chsize` with a `long`), and mingw-w64 also defines `__MINGW32__`, so every mingw-w64 build silently caps at 2 GB. mingw-w64 provides `_fseeki64`, `_ftelli64` and `_chsize_s`, so those branches can likely fold into the MSVC path. The `static_assert` here does not catch it — the type is fine, the calls are wrong. Needs a real mingw-w64 build to confirm; untouched by this PR.

</details>

<!--
provenance: claude-code session 2026-08-21, from GDCM-off64_t-upstream-handoff.md
branch: BRAINSia/GDCM fix/off64_t-portability, commit d2e9a6f62, base 2cd05d132
file: Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx (+50/-44), sole TU using off64_t
verification_record: <gdcm-checkout>/.devlocal/off64t-verification.md
probe_suite: <gdcm-checkout>/.devlocal/off64t-probes.sh (self-contained sh, any libc)
key_facts:
  - off64_t appears in this file only; absent from gdcmFileStreamer.h; zlib's z_off64_t unrelated
  - affected region byte-identical on upstream master (3.3.0), release (3.2.11), ITK-vendored 3.2.8
  - macOS pre-existing failure set (24 tests) confirmed identical with and without patch
  - SourceForge tracker is robots-blocked; not searched for a pre-existing musl ticket
post_merge_action: ITK PR #6779 can be dropped at the next GDCM vendor bump
-->
