### PR TITLE
Fix GetCurrentModuleFileName: feature-test dladdr and correct inverted success check

### DIFF
--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -67,6 +67,14 @@ CHECK_CXX_SOURCE_COMPILES(
 CHECK_CXX_SOURCE_COMPILES(
   "\#include <string>\n#include <codecvt>\n#include <locale>\nint main() { std::u16string u16; std::string utf8 = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(u16); }"
   GDCM_HAVE_CODECVT)
+set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
+# Compiled as C++ because that is how the caller is compiled: glibc declares
+# dladdr only under _GNU_SOURCE, which the C++ driver supplies but a C check
+# would not.
+CHECK_CXX_SOURCE_COMPILES(
+  "\#include <dlfcn.h>\nint main() { Dl_info i; return dladdr((void*)0, &i); }"
+  GDCM_HAVE_DLADDR)
+unset(CMAKE_REQUIRED_LIBRARIES)
 if(GDCM_USE_SYSTEM_OPENSSL)
 set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
 set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES}

--- a/Source/Common/gdcmConfigure.h.in
+++ b/Source/Common/gdcmConfigure.h.in
@@ -96,6 +96,7 @@
 #cmakedefine GDCM_HAVE_SYS_TIME_H
 #cmakedefine GDCM_HAVE_WINSOCK_H
 #cmakedefine GDCM_HAVE_BYTESWAP_H
+#cmakedefine GDCM_HAVE_DLADDR
 #cmakedefine GDCM_HAVE_RPC_H
 // CMS with PBE (added in OpenSSL 1.0.0 ~ Fri Nov 27 15:33:25 CET 2009)
 #cmakedefine GDCM_HAVE_CMS_RECIPIENT_PASSWORD

--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -554,16 +554,17 @@ const char *System::GetCurrentProcessFileName()
    return nullptr;
 }
 
-#ifdef __USE_GNU
+#ifdef GDCM_HAVE_DLADDR
 static void where_am_i() {}
 #endif
 
 const char *System::GetCurrentModuleFileName()
 {
-#ifdef __USE_GNU
+#ifdef GDCM_HAVE_DLADDR
   static char path[PATH_MAX];
   Dl_info info;
-  if (dladdr( (void*)&where_am_i, &info ) == 0)
+  // dladdr returns non-zero on success, unlike most POSIX calls.
+  if (dladdr( (void*)&where_am_i, &info ) != 0)
     {
     size_t len = strlen(info.dli_fname);
     if( len >= PATH_MAX ) return nullptr; // throw error ?


### PR DESCRIPTION
`System::GetCurrentModuleFileName()` never returns a path — it yields `nullptr` on macOS, glibc and musl alike. Two independent causes in the same five lines: the implementation is gated on the glibc-internal `__USE_GNU` macro, and the `dladdr` success test is inverted.

Independent of #228; no shared files.

<details>
<summary>Cause 1 — <code>__USE_GNU</code> is not a feature test</summary>

`__USE_GNU` is glibc-internal. It is defined by `<features.h>` only when `_GNU_SOURCE` is set, and never on musl or macOS. On those platforms the entire body is compiled out and the function unconditionally returns `nullptr` — even though `dladdr` is available and works there. `dladdr` is POSIX-2001, not a GNU extension, so the macro is testing the wrong thing entirely.

The commented-out `//#include <features.h> // we want GNU extensions` just above the includes in this file suggests someone hit this and worked around it.

</details>

<details>
<summary>Cause 2 — inverted <code>dladdr</code> test</summary>

`dladdr` returns **non-zero on success**, unlike most POSIX calls. The code has:

```cpp
if (dladdr( (void*)&where_am_i, &info ) == 0)   // == 0 is FAILURE
  {
  size_t len = strlen(info.dli_fname);          // info never written
```

So on glibc, where the body *is* compiled, the function falls through to `return nullptr` whenever `dladdr` succeeds, and reads an uninitialized `Dl_info` in the rare case where it fails. In practice that means glibc also always returns `nullptr`; the uninitialized read is a latent hazard on the failure path rather than something seen on every call.

</details>

<details>
<summary>The fix, and why the check is CHECK_CXX_SOURCE_COMPILES</summary>

Replace the macro with a `GDCM_HAVE_DLADDR` feature test and correct the comparison.

The probe is a `CHECK_CXX_SOURCE_COMPILES` rather than `CHECK_SYMBOL_EXISTS` because glibc declares `dladdr` only under `_GNU_SOURCE`:

| | `gcc -x c` | `gcc -x c -D_GNU_SOURCE` | `g++ -x c++` |
|---|---|---|---|
| glibc | `unknown type name 'Dl_info'` | declared | declared |
| musl | declared | declared | declared |

`check_symbol_exists` compiles C, so it would report **false on glibc** and disable the feature on the one platform where the code path exists today. Compiling the probe the same way the caller is compiled keeps the two in agreement. This follows the existing precedent in the same file — the `GDCM_HAVE_BYTESWAP_H` check is a `CHECK_CXX_SOURCE_COMPILES` for a comparable reason (bug #324).

`gdcmCommon` already links `${CMAKE_DL_LIBS}` on UNIX, so there are no link changes.

</details>

<details>
<summary>Testing</summary>

Built and ran a probe calling the function, before and after, on three platforms:

| | master | this PR |
|---|---|---|
| macOS arm64 | `(nullptr)` | correct module path |
| glibc x86_64 (Debian bookworm) | `(nullptr)` | correct module path |
| musl x86_64 (Alpine) | `(nullptr)` | correct module path |

`GDCM_HAVE_DLADDR` is detected as present on all three.

Full test suite on macOS arm64 with `GDCM_DATA_ROOT` set: 206/230, identical to the unpatched tree (the 24 failures are pre-existing and unrelated, verified by reverting and re-running the same set).

There are no in-tree callers — only the declaration in `gdcmSystem.h` — so nothing in GDCM's own tests exercises this. It is public API, so downstream users may.

</details>

<!--
provenance: claude-code session 2026-08-21
branch: BRAINSia/GDCM fix/dladdr-feature-test, commit adf2877e9, base gitupstream/master
related_pr: malaterre/GDCM#228 (off64_t portability) -- independent, no shared files
files: Source/Common/CMakeLists.txt, Source/Common/gdcmConfigure.h.in, Source/Common/gdcmSystem.cxx
key_facts:
  - dladdr declaration on glibc is gated behind _GNU_SOURCE; C-mode check_symbol_exists returns false there (tested)
  - master returns nullptr on macOS/glibc/musl; uninit Dl_info read only on the dladdr-failure path
  - no in-tree callers of GetCurrentModuleFileName
adjacent_unfixed:
  - Utilities/gdcmext/mec_mr3_io.c:26 MEC3_HAS_ICONV platform list vs existing find_package(Iconv)
  - Source/Common/gdcmSystem.cxx:538 /proc/curproc/file on FreeBSD (procfs not mounted by default; sysctl KERN_PROC_PATHNAME is canonical); readlink result not NUL-terminated
-->
