### PR TITLE
Detect iconv with find_package instead of a platform list

### DIFF
--- a/Source/MediaStorageAndFileFormat/CMakeLists.txt
+++ b/Source/MediaStorageAndFileFormat/CMakeLists.txt
@@ -144,12 +144,40 @@ else()
                               )
 endif()
 
+# iconv availability is a feature, not a platform: detect it once here and
+# feed the answer to both the compile definition and the link line below.
+find_package(Iconv)
+if(Iconv_FOUND)
+  # find_package locates the header and the library independently. A GNU
+  # libiconv iconv.h renames iconv_open to libiconv_open, so a header reached
+  # ahead of Iconv_INCLUDE_DIRS can disagree with Iconv_LIBRARIES and only fail
+  # at link time; link-test the pair the compiler will actually see.
+  include(CheckCSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${Iconv_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARIES})
+  check_c_source_compiles(
+    "#include <iconv.h>
+     int main(void) {
+       iconv_t cd = iconv_open(\"UTF-8\", \"SHIFT-JIS\");
+       if (cd != (iconv_t)-1) iconv_close(cd);
+       return 0;
+     }"
+    GDCM_ICONV_HEADER_MATCHES_LIBRARY)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+if(Iconv_FOUND AND GDCM_ICONV_HEADER_MATCHES_LIBRARY)
+  set(GDCM_MEC3_HAS_ICONV 1)
+else()
+  set(GDCM_MEC3_HAS_ICONV 0)
+endif()
+
 set_source_files_properties(  ${GDCM_SOURCE_DIR}/Utilities/gdcmext/csa.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3_io.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3_dict.c
                               PROPERTIES
-                              COMPILE_DEFINITIONS _POSIX_C_SOURCE=200809L # posix_memalign and strnlen
+                              COMPILE_DEFINITIONS "_POSIX_C_SOURCE=200809L;MEC3_HAS_ICONV=${GDCM_MEC3_HAS_ICONV}" # posix_memalign and strnlen
 )
 
 # Add the include paths
@@ -253,8 +281,8 @@ endif()
 if(GDCM_USE_SYSTEM_JSON)
   target_link_libraries(gdcmMSFF LINK_PRIVATE ${JSON_LIBRARIES})
 endif()
-if(UNIX)
-  find_package(Iconv)
+if(GDCM_MEC3_HAS_ICONV)
+  target_include_directories(gdcmMSFF PRIVATE ${Iconv_INCLUDE_DIRS})
   target_link_libraries(gdcmMSFF LINK_PRIVATE ${Iconv_LIBRARIES})
 endif()
 # handling of static lib within shared is a mess:

--- a/Utilities/gdcmext/mec_mr3_io.c
+++ b/Utilities/gdcmext/mec_mr3_io.c
@@ -23,10 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_MSC_VER) || defined(__OpenBSD__)
+// Set by the build system from find_package(Iconv).
+#ifndef MEC3_HAS_ICONV
 #define MEC3_HAS_ICONV 0
-#else
-#define MEC3_HAS_ICONV 1
 #endif
 
 #if MEC3_HAS_ICONV


### PR DESCRIPTION
`mec_mr3_io.c` decided `MEC3_HAS_ICONV` from a hand-maintained platform list, even though `gdcmMSFF` already calls `find_package(Iconv)` in the same `CMakeLists.txt`. This uses the detection result instead of the guess.

While doing so it fixes MinGW, where the guess and the link line disagree today — see below.

Independent of #228 and #229; no shared files.

<details>
<summary>The problem</summary>

```c
#if defined(_MSC_VER) || defined(__OpenBSD__)
#define MEC3_HAS_ICONV 0
#else
#define MEC3_HAS_ICONV 1
#endif
```

iconv availability is a property of the toolchain, not of the platform name, so this list has to grow every time GDCM meets a system whose iconv situation differs from the guess. The build system already answers the question correctly — `find_package(Iconv)` at `Source/MediaStorageAndFileFormat/CMakeLists.txt:257` — but the source ignored the result.

**The guess is wrong on MinGW today.** MinGW does not define `_MSC_VER`, so `MEC3_HAS_ICONV` becomes 1, while the iconv link line sits inside `if(UNIX)` and never runs. That combination only builds if the toolchain happens to supply iconv in its CRT.

</details>

<details>
<summary>The change</summary>

`mec_mr3_io.c` is compiled directly into `gdcmMSFF` from the same `CMakeLists.txt` that runs the detection, so no new plumbing is needed — only hoisting `find_package(Iconv)` above the `set_source_files_properties` call that those sources already carry:

```cmake
find_package(Iconv)
if(Iconv_FOUND)
  set(GDCM_MEC3_HAS_ICONV 1)
else()
  set(GDCM_MEC3_HAS_ICONV 0)
endif()
```

The value rides along in the existing `COMPILE_DEFINITIONS` for the four `gdcmext` sources. The link line and include directories are keyed off `Iconv_FOUND` rather than `if(UNIX)`, so the compile definition and the link line can no longer disagree. The source keeps a conservative `#ifndef MEC3_HAS_ICONV` → `0` fallback for anyone compiling these files outside GDCM's CMake.

</details>

<details>
<summary>Testing</summary>

| Configuration | Detection | `MEC3_HAS_ICONV` | `gdcmMSFF` |
|---|---|---|---|
| macOS arm64 (separate `libiconv.tbd`) | Found | 1 | builds |
| glibc x86_64 (Debian bookworm) | built into libc | 1 | builds |
| musl x86_64 (Alpine) | built into libc | 1 | builds |
| macOS, `-DCMAKE_DISABLE_FIND_PACKAGE_Iconv=ON` | not found | 0 | builds, `-Wall -Wextra` clean |

The last row is the one worth calling out: the `MEC3_HAS_ICONV=0` path was previously reachable only on MSVC and OpenBSD, and this change makes it reachable wherever iconv is genuinely absent — so it needed checking for rot. It compiles clean.

Full test suite on macOS arm64: 206/230, identical to the unpatched tree (the 24 failures are pre-existing and unrelated).

Note for anyone reproducing on Alpine: the musl builds above have #228 applied on top, because master does not currently compile there for an unrelated reason (`off64_t`).

</details>

**Behaviour changes where guess and detection disagree**, called out explicitly since I cannot build these:

- **MSVC** and **OpenBSD** gain iconv support when libiconv is present, instead of being hardcoded off. If either was deliberately disabled for a reason not recorded in the code, say so and I will restore an explicit opt-out.
- **MinGW** no longer enables the code path without linking the library.

<!--
provenance: claude-code session 2026-08-21
branch: BRAINSia/GDCM fix/iconv-feature-test, commit 95e9fb114, base gitupstream/master
related_prs: malaterre/GDCM#228 (off64_t), #229 (dladdr) -- all independent, no shared files
files: Source/MediaStorageAndFileFormat/CMakeLists.txt, Utilities/gdcmext/mec_mr3_io.c
key_facts:
  - mec_mr3_io.c compiled into gdcmMSFF from the same CMakeLists that calls find_package(Iconv)
  - MinGW pre-existing mismatch: MEC3_HAS_ICONV=1 but link line gated on if(UNIX)
  - MEC3_HAS_ICONV=0 path verified to still compile (was only exercised on MSVC/OpenBSD)
  - untested platforms: MSVC, MinGW, OpenBSD
adjacent_unfixed:
  - Source/Common/gdcmSystem.cxx:538 /proc/curproc/file on FreeBSD (procfs not mounted by default;
    sysctl KERN_PROC_PATHNAME is canonical); readlink result not NUL-terminated
-->
