### PR TITLE
Use sysctl KERN_PROC_PATHNAME for the executable path on the BSDs

### DIFF
--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -50,6 +50,9 @@
 #else
 //#include <features.h> // we want GNU extensions
 #include <dlfcn.h>
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#endif
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h> /* gethostname */
@@ -529,23 +532,35 @@ const char *System::GetCurrentProcessFileName()
   // solaris
   const char *ret = getexecname();
   if( ret ) return ret;
-//#elif defined(__NetBSD__)
-//  static char path[PATH_MAX];
-//  if ( readlink ("/proc/curproc/exe", path, sizeof(path)) > 0)
-//    {
-//    return path;
-//    }
-#elif defined(__DragonFly__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
   static char path[PATH_MAX];
-  if ( readlink ("/proc/curproc/file", path, sizeof(path)) > 0)
+#if defined(KERN_PROC_PATHNAME)
+  // procfs is not mounted by default on these systems, so ask the kernel.
+#if defined(__NetBSD__)
+  int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+  size_t pathlen = sizeof(path);
+  if ( sysctl(mib, 4, path, &pathlen, nullptr, 0) == 0 && pathlen > 1 )
     {
+    return path;
+    }
+#endif
+  // Only reachable when procfs happens to be mounted.
+  const ssize_t len = readlink("/proc/curproc/file", path, sizeof(path) - 1);
+  if ( len > 0 )
+    {
+    path[len] = '\0';
     return path;
     }
 #elif defined(__linux__)
   static char path[PATH_MAX];
-  if ( readlink ("/proc/self/exe", path, sizeof(path)) > 0) // Technically 0 is not an error, but that would mean
-                                                            // 0 byte were copied ... thus considered it as an error
+  // readlink does not terminate, and returns the buffer size when it truncates.
+  const ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+  if ( len > 0 )
     {
+    path[len] = '\0';
     return path;
     }
 #else


### PR DESCRIPTION
`GetCurrentProcessFileName()` reads `/proc/curproc/file` on FreeBSD, DragonFly and OpenBSD. procfs is not mounted by default on modern FreeBSD, and OpenBSD has no equivalent at all, so on a default install the readlink fails and the function returns `nullptr`. This asks the kernel via `sysctl` instead, keeping the procfs read as a fallback.

**I could not execute this branch — I have no FreeBSD, DragonFly, NetBSD or OpenBSD machine.** It is type-checked only (details below). Please treat it as needing a BSD reviewer rather than as tested work; I would rather say so than have it read as verified.

<details>
<summary>The change</summary>

FreeBSD and DragonFly expose the executable path as `CTL_KERN.KERN_PROC.KERN_PROC_PATHNAME`. NetBSD spells the same thing `CTL_KERN.KERN_PROC_ARGS.KERN_PROC_PATHNAME`, hence the split:

```cpp
#if defined(KERN_PROC_PATHNAME)
#if defined(__NetBSD__)
  int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
#else
  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
#endif
  size_t pathlen = sizeof(path);
  if ( sysctl(mib, 4, path, &pathlen, nullptr, 0) == 0 && pathlen > 1 )
    {
    return path;
    }
#endif
```

Three deliberate choices:

- **The procfs `readlink` is kept as a fallback**, so any system that does mount procfs behaves exactly as it does today. This is additive; nothing that currently works can regress.
- **The guard is `KERN_PROC_PATHNAME`, not a platform name.** It is a real macro in `<sys/sysctl.h>`, so the preprocessor can test for it directly — no platform list to maintain. Verified that Darwin does *not* define it, so the guard genuinely discriminates.
- **OpenBSD** defines neither the macro nor an equivalent interface, so it keeps the fallback and is no worse off than before. I did not invent an OpenBSD path I could not justify.

The commented-out NetBSD block is dropped now that NetBSD is handled for real.

</details>

<details>
<summary>readlink termination — hardening, not a live bug</summary>

`readlink` does not NUL-terminate, and returns the buffer size when it truncates. Both call sites now pass `sizeof(path) - 1` and terminate explicitly.

To be precise about severity: the buffers are `static` and therefore zero-initialised, so in practice the strings *are* terminated. Measured:

```
full buffer : n=7  terminated_within_buffer=yes (zero-init saved it)
small buffer: n=7 (== sizeof -> truncated)  terminated=NO -> strlen would run off the end
```

So this is defensive. The only way it bites today is a link target at or beyond `PATH_MAX`, where readlink truncates and leaves no terminator. Worth removing the question; not worth calling a crash.

</details>

<details>
<summary>What was and was not verified</summary>

| Platform | Coverage |
|---|---|
| macOS arm64 | built and run — correct path; full suite 206/230, identical to master |
| glibc x86_64 (Debian bookworm) | built and run — correct path, 0 warnings in `gdcmSystem.cxx` |
| musl x86_64 (Alpine) | built and run — correct path, 0 warnings |
| **FreeBSD / DragonFly / NetBSD / OpenBSD** | **not executed — no host available** |

The BSD branch was compiled against Darwin's `<sys/sysctl.h>` with `KERN_PROC_PATHNAME` supplied, purely to type-check the `sysctl` call and the mib array. It builds clean at `-Wall -Wextra`. That establishes the code is well-formed against a BSD-derived libc; it does **not** establish that the sysctl returns what I expect on any actual BSD.

Concretely, what a BSD reviewer should check: that `GetCurrentProcessFileName()` returns the real executable path on FreeBSD with procfs *unmounted*, and that the NetBSD mib spelling is right.

macOS is unaffected — it takes the CoreFoundation branch, which this does not touch.

</details>

Independent of #228 and #230. Touches the same file as #229 but a different function; I verified the two merge cleanly (hunks at ~532 and ~554 do not overlap).

<!--
provenance: claude-code session 2026-08-21/22
branch: BRAINSia/GDCM fix/bsd-exe-path, commit 0889e6c80, base gitupstream/master
related_prs: #228 off64_t, #229 dladdr (same file, different function, merges clean), #230 iconv
key_facts:
  - procfs not mounted by default on modern FreeBSD; OpenBSD has no equivalent
  - KERN_PROC_PATHNAME is a real macro in sys/sysctl.h -> preprocessor-testable, not a platform proxy
  - Darwin does NOT define KERN_PROC_PATHNAME (verified via cc -E -dM)
  - NetBSD mib differs: CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME
  - readlink issue is latent only: static buffers are zero-init; bites only at target length >= PATH_MAX
UNVERIFIED: BSD branch never executed; type-checked against Darwin headers only. Needs BSD reviewer.
-->
