### PR TITLE
WIP: Integration branch for the open ITK-originated fixes plus the CVE-2026-3650 reapply

### DIFF
--- a/Source/Common/CMakeLists.txt
+++ b/Source/Common/CMakeLists.txt
@@ -67,6 +67,14 @@ CHECK_CXX_SOURCE_COMPILES(
 CHECK_CXX_SOURCE_COMPILES(
   "\#include <string>\n#include <codecvt>\n#include <locale>\nint main() { std::u16string u16; std::string utf8 = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{}.to_bytes(u16); }"
   GDCM_HAVE_CODECVT)
+set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_DL_LIBS})
+# Compiled as C++ because that is how the caller is compiled: glibc declares
+# dladdr only under _GNU_SOURCE, which the C++ driver supplies but a C check
+# would not.
+CHECK_CXX_SOURCE_COMPILES(
+  "\#include <dlfcn.h>\nint main() { Dl_info i; return dladdr((void*)0, &i); }"
+  GDCM_HAVE_DLADDR)
+unset(CMAKE_REQUIRED_LIBRARIES)
 if(GDCM_USE_SYSTEM_OPENSSL)
 set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
 set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES}

--- a/Source/Common/gdcmConfigure.h.in
+++ b/Source/Common/gdcmConfigure.h.in
@@ -96,6 +96,7 @@
 #cmakedefine GDCM_HAVE_SYS_TIME_H
 #cmakedefine GDCM_HAVE_WINSOCK_H
 #cmakedefine GDCM_HAVE_BYTESWAP_H
+#cmakedefine GDCM_HAVE_DLADDR
 #cmakedefine GDCM_HAVE_RPC_H
 // CMS with PBE (added in OpenSSL 1.0.0 ~ Fri Nov 27 15:33:25 CET 2009)
 #cmakedefine GDCM_HAVE_CMS_RECIPIENT_PASSWORD

--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -50,6 +50,9 @@
 #else
 //#include <features.h> // we want GNU extensions
 #include <dlfcn.h>
+#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/sysctl.h>
+#endif
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h> /* gethostname */
@@ -529,23 +532,35 @@ const char *System::GetCurrentProcessFileName()
   // solaris
   const char *ret = getexecname();
   if( ret ) return ret;
-//#elif defined(__NetBSD__)
-//  static char path[PATH_MAX];
-//  if ( readlink ("/proc/curproc/exe", path, sizeof(path)) > 0)
-//    {
-//    return path;
-//    }
-#elif defined(__DragonFly__) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
   static char path[PATH_MAX];
-  if ( readlink ("/proc/curproc/file", path, sizeof(path)) > 0)
+#if defined(KERN_PROC_PATHNAME)
+  // procfs is not mounted by default on these systems, so ask the kernel.
+#if defined(__NetBSD__)
+  int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+  size_t pathlen = sizeof(path);
+  if ( sysctl(mib, 4, path, &pathlen, nullptr, 0) == 0 && pathlen > 1 )
     {
+    return path;
+    }
+#endif
+  // Only reachable when procfs happens to be mounted.
+  const ssize_t len = readlink("/proc/curproc/file", path, sizeof(path) - 1);
+  if ( len > 0 )
+    {
+    path[len] = '\0';
     return path;
     }
 #elif defined(__linux__)
   static char path[PATH_MAX];
-  if ( readlink ("/proc/self/exe", path, sizeof(path)) > 0) // Technically 0 is not an error, but that would mean
-                                                            // 0 byte were copied ... thus considered it as an error
+  // readlink does not terminate, and returns the buffer size when it truncates.
+  const ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+  if ( len > 0 )
     {
+    path[len] = '\0';
     return path;
     }
 #else

--- a/Source/Common/gdcmSystem.cxx
+++ b/Source/Common/gdcmSystem.cxx
@@ -554,16 +554,17 @@ const char *System::GetCurrentProcessFileName()
    return nullptr;
 }
 
-#ifdef __USE_GNU
+#ifdef GDCM_HAVE_DLADDR
 static void where_am_i() {}
 #endif
 
 const char *System::GetCurrentModuleFileName()
 {
-#ifdef __USE_GNU
+#ifdef GDCM_HAVE_DLADDR
   static char path[PATH_MAX];
   Dl_info info;
-  if (dladdr( (void*)&where_am_i, &info ) == 0)
+  // dladdr returns non-zero on success, unlike most POSIX calls.
+  if (dladdr( (void*)&where_am_i, &info ) != 0)
     {
     size_t len = strlen(info.dli_fname);
     if( len >= PATH_MAX ) return nullptr; // throw error ?

--- a/Source/DataStructureAndEncodingDefinition/gdcmBasicOffsetTable.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmBasicOffsetTable.h
@@ -16,6 +16,7 @@
 #define GDCMBASICOFFSETTABLE_H
 
 #include "gdcmFragment.h"
+#include "gdcmValueLengthCheck.h"
 
 namespace gdcm_ns
 {
@@ -65,6 +66,10 @@ public:
       return is;
       }
     // Self
+    // Reject a Basic Offset Table length the stream cannot supply before
+    // allocating for it (CVE-2026-3650): this reader was not covered by the
+    // original fix, and 367 bytes were enough to request 4.26GB here.
+    CheckValueLengthAgainstStream( is, *this, ValueLengthField );
     SmartPointer<ByteValue> bv = new ByteValue;
     bv->SetLength(ValueLengthField);
     if( !bv->Read<TSwap>(is) )

--- a/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmCP246ExplicitDataElement.txx
@@ -19,6 +19,7 @@
 #include "gdcmSequenceOfFragments.h"
 #include "gdcmVL.h"
 #include "gdcmParseException.h"
+#include "gdcmValueLengthCheck.h"
 #include "gdcmImplicitDataElement.h"
 
 #include "gdcmValueIO.h"
@@ -176,6 +177,13 @@ std::istream &CP246ExplicitDataElement::ReadValue(std::istream &is, bool readval
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    }
+  // Recovery reader: cap rather than reject, so the fallback chain still
+  // works on files with a nonsense length, without allocating for it
+  // (CVE-2026-3650).
+  if( readvalues )
+    {
+    ValueLengthField = ClampValueLengthToStream( is, ValueLengthField );
     }
   // We have the length we should be able to read the value
   ValueField->SetLength(ValueLengthField); // perform realloc

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
@@ -242,6 +242,23 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    if( readvalues )
+      {
+      const std::streampos cur = is.tellg();
+      if( cur != std::streampos(-1) )
+        {
+        is.seekg(0, std::ios::end);
+        const std::streampos end = is.tellg();
+        is.seekg(cur);
+        if( end != std::streampos(-1) && is.good()
+          && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+          {
+          gdcmWarningMacro( "Value Length " << ValueLengthField
+            << " exceeds remaining stream size for tag " << TagField );
+          throw Exception( "Value Length exceeds remaining stream size" );
+          }
+        }
+      }
     }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitDataElement.txx
@@ -18,6 +18,7 @@
 #include "gdcmSequenceOfFragments.h"
 #include "gdcmVL.h"
 #include "gdcmParseException.h"
+#include "gdcmValueLengthCheck.h"
 #include "gdcmImplicitDataElement.h"
 
 #include "gdcmValueIO.h"
@@ -244,20 +245,7 @@ std::istream &ExplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     ValueField = new ByteValue;
     if( readvalues )
       {
-      const std::streampos cur = is.tellg();
-      if( cur != std::streampos(-1) )
-        {
-        is.seekg(0, std::ios::end);
-        const std::streampos end = is.tellg();
-        is.seekg(cur);
-        if( end != std::streampos(-1) && is.good()
-          && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
-          {
-          gdcmWarningMacro( "Value Length " << ValueLengthField
-            << " exceeds remaining stream size for tag " << TagField );
-          throw Exception( "Value Length exceeds remaining stream size" );
-          }
-        }
+      CheckValueLengthAgainstStream( is, *this, ValueLengthField );
       }
     }
   // We have the length we should be able to read the value

--- a/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmExplicitImplicitDataElement.txx
@@ -23,6 +23,7 @@
 #include "gdcmImplicitDataElement.h"
 #include "gdcmValueIO.h"
 #include "gdcmSwapper.h"
+#include "gdcmValueLengthCheck.h"
 
 namespace gdcm
 {
@@ -274,6 +275,8 @@ std::istream &ExplicitImplicitDataElement::ReadPreValue(std::istream &is)
     ValueLengthField = 202; // 0xca
     }
 #endif
+  // Recovery reader: cap rather than reject (CVE-2026-3650).
+  ValueLengthField = ClampValueLengthToStream( is, ValueLengthField );
   // We have the length we should be able to read the value
   ValueField->SetLength(ValueLengthField); // perform realloc
   if( !ValueIO<ImplicitDataElement,TSwap>::Read(is,*ValueField,true) )
@@ -398,6 +401,11 @@ std::istream &ExplicitImplicitDataElement::ReadValue(std::istream &is, bool read
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    // Recovery reader: cap rather than reject (CVE-2026-3650).
+    if( readvalues )
+      {
+      ValueLengthField = ClampValueLengthToStream( is, ValueLengthField );
+      }
     }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );

--- a/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmFragment.h
@@ -91,6 +91,18 @@ public:
     {
     // Self
     SmartPointer<ByteValue> bv = new ByteValue;
+    const std::streampos cur = is.tellg();
+    if( cur != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end = is.tellg();
+      is.seekg(cur);
+      if( end != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        throw Exception( "Fragment Value Length exceeds remaining stream size" );
+        }
+      }
     bv->SetLength(ValueLengthField);
     if( !bv->Read<TSwap>(is) )
       {
@@ -144,6 +156,18 @@ public:
 
     // Self
     SmartPointer<ByteValue> bv = new ByteValue;
+    const std::streampos cur2 = is.tellg();
+    if( cur2 != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end2 = is.tellg();
+      is.seekg(cur2);
+      if( end2 != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end2 - cur2) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        throw Exception( "Fragment Value Length exceeds remaining stream size" );
+        }
+      }
     bv->SetLength(ValueLengthField);
     if( !bv->Read<TSwap>(is) )
       {

--- a/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
@@ -215,6 +215,23 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
     ValueLengthField = 202; // 0xca
     }
 #endif
+  if( !ValueLengthField.IsUndefined() && readvalues )
+    {
+    const std::streampos cur = is.tellg();
+    if( cur != std::streampos(-1) )
+      {
+      is.seekg(0, std::ios::end);
+      const std::streampos end = is.tellg();
+      is.seekg(cur);
+      if( end != std::streampos(-1) && is.good()
+        && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
+        {
+        gdcmWarningMacro( "Value Length " << ValueLengthField
+          << " exceeds remaining stream size for tag " << TagField );
+        throw Exception( "Value Length exceeds remaining stream size" );
+        }
+      }
+    }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );
   bool failed;

--- a/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmImplicitDataElement.txx
@@ -217,20 +217,7 @@ std::istream &ImplicitDataElement::ReadValue(std::istream &is, bool readvalues)
 #endif
   if( !ValueLengthField.IsUndefined() && readvalues )
     {
-    const std::streampos cur = is.tellg();
-    if( cur != std::streampos(-1) )
-      {
-      is.seekg(0, std::ios::end);
-      const std::streampos end = is.tellg();
-      is.seekg(cur);
-      if( end != std::streampos(-1) && is.good()
-        && static_cast<uint64_t>(end - cur) < static_cast<uint32_t>(ValueLengthField) )
-        {
-        gdcmWarningMacro( "Value Length " << ValueLengthField
-          << " exceeds remaining stream size for tag " << TagField );
-        throw Exception( "Value Length exceeds remaining stream size" );
-        }
-      }
+    CheckValueLengthAgainstStream( is, *this, ValueLengthField );
     }
   // We have the length we should be able to read the value
   this->SetValueFieldLength( ValueLengthField, readvalues );

--- a/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmSequenceOfFragments.h
@@ -167,7 +167,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       {
       gdcm_assert( Fragments.size() == 1 );
       const ByteValue *bv = Fragments[0].GetByteValue();
-      gdcm_assert( (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
+      gdcm_assert( bv->GetLength() >= 1 && (unsigned char)bv->GetPointer()[ bv->GetLength() - 1 ] == 0xfe );
       // Yes this is an extra copy, this is a bug anyway, go fix YOUR code
       Fragments[0].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       gdcmWarningMacro( "JPEG Fragment length was declared with an extra byte"
@@ -188,7 +188,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
-      gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 1 ] == 0xfe );
+      gdcmAssertAlwaysMacro( bv->GetLength() >= 1 && (unsigned char)a[ bv->GetLength() - 1 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 1 );
       is.seekg( -9, std::ios::cur );
       gdcm_assert( is.good() );
@@ -212,7 +212,7 @@ std::istream& ReadValue(std::istream &is, bool /*readvalues*/)
       const size_t lastf = Fragments.size() - 1;
       const ByteValue *bv = Fragments[ lastf ].GetByteValue();
       const char *a = bv->GetPointer();
-      gdcmAssertAlwaysMacro( (unsigned char)a[ bv->GetLength() - 2 ] == 0xfe );
+      gdcmAssertAlwaysMacro( bv->GetLength() >= 2 && (unsigned char)a[ bv->GetLength() - 2 ] == 0xfe );
       Fragments[ lastf ].SetByteValue( bv->GetPointer(), bv->GetLength() - 2 );
       is.seekg( -10, std::ios::cur );
       gdcm_assert( is.good() );

--- a/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmUNExplicitDataElement.txx
@@ -19,6 +19,7 @@
 #include "gdcmSequenceOfFragments.h"
 #include "gdcmVL.h"
 #include "gdcmParseException.h"
+#include "gdcmValueLengthCheck.h"
 
 #include "gdcmValueIO.h"
 #include "gdcmSwapper.h"
@@ -193,6 +194,13 @@ std::istream &UNExplicitDataElement::ReadValue(std::istream &is, bool readvalues
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    }
+  // Recovery reader: cap rather than reject, so the fallback chain still
+  // works on files with a nonsense length, without allocating for it
+  // (CVE-2026-3650).
+  if( readvalues )
+    {
+    ValueLengthField = ClampValueLengthToStream( is, ValueLengthField );
     }
   // We have the length we should be able to read the value
   ValueField->SetLength(ValueLengthField); // perform realloc

--- a/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.txx
+++ b/Source/DataStructureAndEncodingDefinition/gdcmVR16ExplicitDataElement.txx
@@ -18,6 +18,7 @@
 #include "gdcmSequenceOfFragments.h"
 #include "gdcmVL.h"
 #include "gdcmParseException.h"
+#include "gdcmValueLengthCheck.h"
 #include "gdcmImplicitDataElement.h"
 
 #include "gdcmValueIO.h"
@@ -241,6 +242,13 @@ std::istream &VR16ExplicitDataElement::ReadValue(std::istream &is, bool readvalu
     {
     //gdcm_assert( TagField != Tag(0x7fe0,0x0010) );
     ValueField = new ByteValue;
+    }
+  // Recovery reader: cap rather than reject, so the fallback chain still
+  // works on files with a nonsense length, without allocating for it
+  // (CVE-2026-3650).
+  if( readvalues )
+    {
+    ValueLengthField = ClampValueLengthToStream( is, ValueLengthField );
     }
   // We have the length we should be able to read the value
   ValueField->SetLength(ValueLengthField); // perform realloc

--- a/Source/DataStructureAndEncodingDefinition/gdcmValueLengthCheck.h
+++ b/Source/DataStructureAndEncodingDefinition/gdcmValueLengthCheck.h
@@ -1,0 +1,110 @@
+/*=========================================================================
+
+  Program: GDCM (Grassroots DICOM). A DICOM library
+
+  Copyright (c) 2006-2011 Mathieu Malaterre
+  All rights reserved.
+  See Copyright.txt or http://gdcm.sourceforge.net/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#ifndef GDCMVALUELENGTHCHECK_H
+#define GDCMVALUELENGTHCHECK_H
+
+#include "gdcmParseException.h"
+#include "gdcmTrace.h"
+
+#include <istream>
+
+namespace gdcm_ns
+{
+
+/**
+ * \brief Reject a declared Value Length the stream cannot supply.
+ *
+ * Every data element reader sizes its value buffer from the length written
+ * in the file and only then reads the value, so a small crafted file that
+ * declares a large element makes GDCM allocate that much before the read
+ * fails (CVE-2026-3650). Call this before SetLength() on a ByteValue.
+ *
+ * Throws ParseException rather than Exception on purpose: the fallback
+ * parser chain in Reader::InternalReadCommon only catches ParseException,
+ * so a plain Exception here would skip the CP246 / UN / VR16 /
+ * ExplicitImplicit readers and fail files GDCM can otherwise recover.
+ *
+ * A stream that cannot report its size is left alone, so non-seekable
+ * inputs keep their previous behaviour.
+ */
+inline void CheckValueLengthAgainstStream(std::istream &is,
+                                          const DataElement &de,
+                                          uint32_t vl)
+{
+  // 0xffffffff is the undefined-length sentinel, not a size.
+  if( vl == 0xffffffff ) return;
+
+  const std::streampos cur = is.tellg();
+  if( cur == std::streampos(-1) ) return;
+
+  is.seekg(0, std::ios::end);
+  const std::streampos end = is.tellg();
+  is.clear();
+  is.seekg(cur);
+  if( end == std::streampos(-1) || !is.good() ) return;
+
+  if( static_cast<uint64_t>(end - cur) < static_cast<uint64_t>(vl) )
+    {
+    gdcmWarningMacro( "Value Length " << vl
+      << " exceeds remaining stream size for tag " << de.GetTag() );
+    ParseException pe;
+    pe.SetLastElement( de );
+    throw pe;
+    }
+}
+
+/**
+ * \brief Cap a declared Value Length at what the stream still holds.
+ *
+ * For the recovery readers (CP246 / UN / VR16 / ExplicitImplicit), which
+ * exist precisely to make sense of files whose lengths and VRs are already
+ * wrong. Throwing there would end the fallback chain and reject files GDCM
+ * can still read -- see SIEMENS_MAGNETOM-12-MONO2-GDCM12-VRUN.dcm, whose
+ * (0009,1214) carries a Value Length of 0x20202020, four ASCII spaces.
+ *
+ * A value can never be longer than the bytes that remain, so capping costs
+ * nothing that was readable anyway, and it removes the allocation. This is
+ * the same idiom ExplicitImplicitDataElement already uses when it reads a
+ * trailing element to end of stream.
+ *
+ * Returns vl unchanged when the stream cannot report its size.
+ */
+inline uint32_t ClampValueLengthToStream(std::istream &is, uint32_t vl)
+{
+  // 0xffffffff is the undefined-length sentinel, not a size: clamping it
+  // would destroy the marker the parsers key off.
+  if( vl == 0xffffffff ) return vl;
+
+  const std::streampos cur = is.tellg();
+  if( cur == std::streampos(-1) ) return vl;
+
+  is.seekg(0, std::ios::end);
+  const std::streampos end = is.tellg();
+  is.clear();
+  is.seekg(cur);
+  if( end == std::streampos(-1) || !is.good() ) return vl;
+
+  const uint64_t remaining = static_cast<uint64_t>(end - cur);
+  if( remaining < static_cast<uint64_t>(vl) )
+    {
+    gdcmWarningMacro( "Capping Value Length " << vl << " at remaining stream size "
+      << remaining );
+    return static_cast<uint32_t>(remaining);
+    }
+  return vl;
+}
+
+} // end namespace gdcm_ns
+
+#endif // GDCMVALUELENGTHCHECK_H

--- a/Source/MediaStorageAndFileFormat/CMakeLists.txt
+++ b/Source/MediaStorageAndFileFormat/CMakeLists.txt
@@ -144,12 +144,40 @@ else()
                               )
 endif()
 
+# iconv availability is a feature, not a platform: detect it once here and
+# feed the answer to both the compile definition and the link line below.
+find_package(Iconv)
+if(Iconv_FOUND)
+  # find_package locates the header and the library independently. A GNU
+  # libiconv iconv.h renames iconv_open to libiconv_open, so a header reached
+  # ahead of Iconv_INCLUDE_DIRS can disagree with Iconv_LIBRARIES and only fail
+  # at link time; link-test the pair the compiler will actually see.
+  include(CheckCSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${Iconv_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${Iconv_LIBRARIES})
+  check_c_source_compiles(
+    "#include <iconv.h>
+     int main(void) {
+       iconv_t cd = iconv_open(\"UTF-8\", \"SHIFT-JIS\");
+       if (cd != (iconv_t)-1) iconv_close(cd);
+       return 0;
+     }"
+    GDCM_ICONV_HEADER_MATCHES_LIBRARY)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+if(Iconv_FOUND AND GDCM_ICONV_HEADER_MATCHES_LIBRARY)
+  set(GDCM_MEC3_HAS_ICONV 1)
+else()
+  set(GDCM_MEC3_HAS_ICONV 0)
+endif()
+
 set_source_files_properties(  ${GDCM_SOURCE_DIR}/Utilities/gdcmext/csa.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3_io.c
                               ${GDCM_SOURCE_DIR}/Utilities/gdcmext/mec_mr3_dict.c
                               PROPERTIES
-                              COMPILE_DEFINITIONS _POSIX_C_SOURCE=200809L # posix_memalign and strnlen
+                              COMPILE_DEFINITIONS "_POSIX_C_SOURCE=200809L;MEC3_HAS_ICONV=${GDCM_MEC3_HAS_ICONV}" # posix_memalign and strnlen
 )
 
 # Add the include paths
@@ -253,8 +281,8 @@ endif()
 if(GDCM_USE_SYSTEM_JSON)
   target_link_libraries(gdcmMSFF LINK_PRIVATE ${JSON_LIBRARIES})
 endif()
-if(UNIX)
-  find_package(Iconv)
+if(GDCM_MEC3_HAS_ICONV)
+  target_include_directories(gdcmMSFF PRIVATE ${Iconv_INCLUDE_DIRS})
   target_link_libraries(gdcmMSFF LINK_PRIVATE ${Iconv_LIBRARIES})
 endif()
 # handling of static lib within shared is a mess:

--- a/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
+++ b/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
@@ -11,6 +11,12 @@
      PURPOSE.  See the above copyright notice for more information.
 
 =========================================================================*/
+// The GNU C library (glibc) requires this be defined to have fseeko() and ftello().
+// Must precede every #include: this is what makes off_t 64-bit on 32-bit POSIX.
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
 #include "gdcmFileStreamer.h"
 
 #include "gdcmTag.h"
@@ -22,27 +28,31 @@
 #include "gdcmEvent.h"
 #include "gdcmProgressEvent.h"
 
-// The GNU C library (glibc) requires this be defined to have fseeko() and ftello().
-#ifdef __GNU_LIBRARY__
-#define _FILE_OFFSET_BITS 64
-#endif
-
+#include <cstdint> // int64_t
 #include <cstdio>
 #include <limits>
 #include <sys/stat.h> // fstat
 
 #if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
 #include <io.h>
-typedef int64_t off64_t;
 #else
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)
-#  define off64_t off_t
-#endif
 #include <unistd.h> // ftruncate
 #endif
 
 namespace gdcm
 {
+
+// 64-bit file offset type. off_t is 64-bit on every platform except the
+// Microsoft CRT (MSVC/MinGW), given _FILE_OFFSET_BITS above. Not off64_t: that
+// is a glibc LFS64 name musl gates on _LARGEFILE64_SOURCE, deprecated there.
+#if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
+using offset_t = int64_t;
+#else
+using offset_t = off_t;
+#endif
+
+static_assert(sizeof(offset_t) >= 8,
+  "GDCM requires 64-bit file offsets; build with _FILE_OFFSET_BITS=64");
 
 // Implementation detail:
 // FILE* have been chosen over std::fstream since it has been reported to lead
@@ -50,9 +60,7 @@ namespace gdcm
 // handling of 64bits offset. Create thin wrapper:
 // See here for discussion:
 // http://stackoverflow.com/questions/17863594/size-of-off-t-at-compilation-time
-// Basically enforce use of off64_t over off_t since on windows off_t is pretty
-// much guarantee to be 32bits only.
-static inline int FSeeko(FILE *stream, off64_t offset, int whence)
+static inline int FSeeko(FILE *stream, offset_t offset, int whence)
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -65,7 +73,7 @@ static inline int FSeeko(FILE *stream, off64_t offset, int whence)
 #endif
 }
 
-static inline off64_t FTello(FILE *stream)
+static inline offset_t FTello(FILE *stream)
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -78,7 +86,7 @@ static inline off64_t FTello(FILE *stream)
 #endif
 }
 
-static inline bool FTruncate( const int fd, const off64_t len )
+static inline bool FTruncate( const int fd, const offset_t len )
 {
 #ifdef _WIN32
 #if defined(__MINGW32__)
@@ -96,7 +104,7 @@ static inline bool FTruncate( const int fd, const off64_t len )
 #endif
 }
 
-static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t inslen )
+static bool prepare_file( FILE * pFile, const offset_t offset, const offset_t inslen )
 {
   // fast path
   if( inslen == 0 ) return true;
@@ -111,13 +119,13 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
     {
     if( inslen < 0 )
       {
-      off64_t bytes_to_move = sb.st_size - offset;
-      off64_t read_start_offset = offset;
+      offset_t bytes_to_move = sb.st_size - offset;
+      offset_t read_start_offset = offset;
       while (bytes_to_move != 0)
         {
-        const size_t bytes_this_time = static_cast<size_t>(std::min((off64_t)BUFFERSIZE, bytes_to_move));
-        const off64_t rd_off = read_start_offset;
-        const off64_t wr_off = rd_off + inslen;
+        const size_t bytes_this_time = static_cast<size_t>(std::min((offset_t)BUFFERSIZE, bytes_to_move));
+        const offset_t rd_off = read_start_offset;
+        const offset_t wr_off = rd_off + inslen;
         if( FSeeko(pFile, rd_off, SEEK_SET) )
           {
           return false;
@@ -151,14 +159,14 @@ static bool prepare_file( FILE * pFile, const off64_t offset, const off64_t insl
 #endif
       if (sb.st_size > offset)
         {
-        off64_t bytes_to_move = sb.st_size - offset;
-        off64_t read_end_offset = sb.st_size;
+        offset_t bytes_to_move = sb.st_size - offset;
+        offset_t read_end_offset = sb.st_size;
         while (bytes_to_move != 0)
           {
-          const size_t bytes_this_time = static_cast<size_t>(std::min((off64_t)BUFFERSIZE, bytes_to_move));
-          const off64_t rd_off = read_end_offset - bytes_this_time;
-          gdcm_assert( (off64_t)rd_off >= offset );
-          const off64_t wr_off = rd_off + inslen;
+          const size_t bytes_this_time = static_cast<size_t>(std::min((offset_t)BUFFERSIZE, bytes_to_move));
+          const offset_t rd_off = read_end_offset - bytes_this_time;
+          gdcm_assert( (offset_t)rd_off >= offset );
+          const offset_t wr_off = rd_off + inslen;
           if( FSeeko(pFile, rd_off, SEEK_SET) )
             {
             return false;
@@ -329,15 +337,15 @@ public:
       size_t dicomlen = 4 + 4; // Tag + VL for Implicit
       if( TS.GetNegociatedType() == TransferSyntax::Explicit )
         dicomlen += 4;
-      off64_t newlen = len;
+      offset_t newlen = len;
       gdcm_assert( (size_t)newlen == len );
       newlen += dicomlen;
       newlen -= actualde;
-      off64_t plength = newlen;
+      offset_t plength = newlen;
       gdcm_assert( ReservedDataLength >= 0 );
       if( ReservedDataLength )
         {
-        if( (newlen + ReservedDataLength) >= (off64_t)len )
+        if( (newlen + ReservedDataLength) >= (offset_t)len )
           {
           plength = newlen + ReservedDataLength - len;
           }
@@ -348,8 +356,8 @@ public:
         ReservedDataLength -= len;
         gdcm_assert( ReservedDataLength >= 0 );
         }
-      //if( !prepare_file( pFile, (off64_t)thepos + actualde, newlen ) )
-      if( !prepare_file( pFile, (off64_t)thepos + actualde, plength ) )
+      //if( !prepare_file( pFile, (offset_t)thepos + actualde, newlen ) )
+      if( !prepare_file( pFile, (offset_t)thepos + actualde, plength ) )
         {
         return false;
         }
@@ -363,18 +371,18 @@ public:
     else
       {
       gdcm_assert( pFile );
-      const off64_t curpos = FTello(pFile);
+      const offset_t curpos = FTello(pFile);
       gdcm_assert( curpos == thepos );
-      if( ReservedDataLength >= (off64_t)len )
+      if( ReservedDataLength >= (offset_t)len )
         {
         // simply update remaining reserved buffer:
         ReservedDataLength -= len;
         }
       else
         {
-        const off64_t plength = len - ReservedDataLength;
+        const offset_t plength = len - ReservedDataLength;
         gdcm_assert( plength >= 0 );
-        if( !prepare_file( pFile, (off64_t)curpos, plength) )
+        if( !prepare_file( pFile, (offset_t)curpos, plength) )
           {
           return false;
           }
@@ -395,14 +403,14 @@ public:
     // Update DataElement:
     const size_t currentdatalenth = CurrentDataLenth;
     gdcm_assert( ReservedDataLength >= 0);
-    //const off64_t refpos = FTello(pFile);
+    //const offset_t refpos = FTello(pFile);
     if( !UpdateDataElement( t ) )
       {
       return false;
       }
     if( ReservedDataLength > 0)
       {
-      const off64_t curpos = thepos;
+      const offset_t curpos = thepos;
       if( !prepare_file( pFile, curpos + ReservedDataLength, - ReservedDataLength) )
         {
         return false;
@@ -587,7 +595,7 @@ public:
     pFile = fopen(outfilename, "r+b");
     gdcm_assert( pFile );
 
-    if( !prepare_file( pFile, (off64_t)thepcpos, pclen ) )
+    if( !prepare_file( pFile, (offset_t)thepcpos, pclen ) )
       {
       return false;
       }
@@ -673,7 +681,7 @@ private:
   size_t actualde;
   size_t CurrentDataLenth;
   Tag CurrentGroupTag;
-  off64_t ReservedDataLength{0};
+  offset_t ReservedDataLength{0};
   unsigned short ReservedGroupDataElement{0};
 public:
   FileStreamer *Self{nullptr};
@@ -685,7 +693,7 @@ private:
       {
       if( CurrentDataLenth % 2 == 1 )
         {
-        const off64_t curpos = FTello(pFile);
+        const offset_t curpos = FTello(pFile);
         if( ReservedDataLength >= 1 )
           {
           // simply update remaining reserved buffer:
@@ -693,7 +701,7 @@ private:
           }
         else
           {
-          if( !prepare_file( pFile, (off64_t)curpos, 1) )
+          if( !prepare_file( pFile, (offset_t)curpos, 1) )
             {
             return false;
             }
@@ -705,7 +713,7 @@ private:
         CurrentDataLenth += 1;
         }
       gdcm_assert( CurrentDataLenth % 2 == 0 );
-      off64_t vlpos = thepos;
+      offset_t vlpos = thepos;
       vlpos -= CurrentDataLenth;
       vlpos -= 4; // VL
       if( TS.GetNegociatedType() == TransferSyntax::Explicit )
@@ -723,7 +731,7 @@ private:
       }
     return true;
     }
-  size_t WriteHelper( off64_t offset, const Tag & tag, const VL & vl )
+  size_t WriteHelper( offset_t offset, const Tag & tag, const VL & vl )
     {
     FSeeko(pFile, offset, SEEK_SET);
     std::stringstream ss;
@@ -768,7 +776,7 @@ bool FileStreamer::InitializeCopy()
   static int checksize = 0;
   if( !checksize )
     {
-    const int soff = sizeof( off64_t );
+    const int soff = sizeof( offset_t );
     const int si64 = sizeof( int64_t );
     if( soff != si64 ) return false;
     if( !(sizeof(sb.st_size) > 4) ) // LFS ?

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/CMakeLists.txt
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/CMakeLists.txt
@@ -47,6 +47,7 @@ set(DSED_TEST_SRCS
   TestVL.cxx
   TestVM.cxx
   TestVR.cxx
+  TestCVE20263650.cxx
   #TestValue.cxx
   #TestTorture.cxx
   TestElement2.cxx

--- a/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestCVE20263650.cxx
+++ b/Testing/Source/DataStructureAndEncodingDefinition/Cxx/TestCVE20263650.cxx
@@ -1,0 +1,144 @@
+/*=========================================================================
+
+  Program: GDCM (Grassroots DICOM). A DICOM library
+
+  Copyright (c) 2006-2011 Mathieu Malaterre
+  All rights reserved.
+  See Copyright.txt or http://gdcm.sourceforge.net/Copyright.html for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+#include "gdcmExplicitDataElement.h"
+#include "gdcmImplicitDataElement.h"
+#include "gdcmFragment.h"
+#include "gdcmSwapper.h"
+
+#include <sstream>
+#include <new>
+
+// CVE-2026-3650: Verify that crafted DICOM data elements with a Value Length
+// exceeding the remaining stream size are rejected without attempting the
+// allocation.
+
+static int TestExplicitVR()
+{
+  // Explicit VR data element: Tag (0008,0060), VR = OB, VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0x0008;
+  const uint16_t element = 0x0060;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  ss.write("OB", 2);
+  const uint16_t reserved = 0;
+  ss.write(reinterpret_cast<const char*>(&reserved), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::ExplicitDataElement de;
+  try
+    {
+    de.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: ExplicitDataElement::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: ExplicitDataElement allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: ExplicitDataElement::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+static int TestImplicitVR()
+{
+  // Implicit VR data element: Tag (0008,0060), VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0x0008;
+  const uint16_t element = 0x0060;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::ImplicitDataElement de;
+  try
+    {
+    de.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: ImplicitDataElement::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: ImplicitDataElement allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: ImplicitDataElement::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+static int TestFragment()
+{
+  // Fragment: Item tag (fffe,e000), VL = 1 GB, 10 bytes data
+  std::stringstream ss;
+  const uint16_t group = 0xfffe;
+  const uint16_t element = 0xe000;
+  ss.write(reinterpret_cast<const char*>(&group), 2);
+  ss.write(reinterpret_cast<const char*>(&element), 2);
+  const uint32_t vl = 0x40000000;
+  ss.write(reinterpret_cast<const char*>(&vl), 4);
+  const char data[10] = {};
+  ss.write(data, sizeof(data));
+
+  gdcm::Fragment frag;
+  try
+    {
+    frag.Read<gdcm::SwapperNoOp>(ss);
+    std::cerr << "ERROR: Fragment::Read should have thrown" << std::endl;
+    return 1;
+    }
+  catch(const gdcm::Exception &)
+    {
+    return 0;
+    }
+  catch(const std::bad_alloc &)
+    {
+    std::cerr << "ERROR: Fragment allocated memory for oversized VL" << std::endl;
+    return 1;
+    }
+  catch(...)
+    {
+    std::cerr << "ERROR: Fragment::Read threw unexpected exception" << std::endl;
+    return 1;
+    }
+}
+
+int TestCVE20263650(int, char *[])
+{
+  int ret = 0;
+  ret += TestExplicitVR();
+  ret += TestImplicitVR();
+  ret += TestFragment();
+  return ret;
+}

--- a/Utilities/gdcmext/mec_mr3_io.c
+++ b/Utilities/gdcmext/mec_mr3_io.c
@@ -23,10 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_MSC_VER) || defined(__OpenBSD__)
+// Set by the build system from find_package(Iconv).
+#ifndef MEC3_HAS_ICONV
 #define MEC3_HAS_ICONV 0
-#else
-#define MEC3_HAS_ICONV 1
 #endif
 
 #if MEC3_HAS_ICONV


### PR DESCRIPTION
**WIP / draft — not for merge as-is.** This consolidates the four open ITK-originated PRs (#228, #229, #230, #231) plus @ahkarl13's CVE fix (#233) onto current `master`, so the whole set can be built and tested together. Each PR remains open and independently reviewable; this branch is the integration view.

ITK vendors GDCM and currently sits at `v3.2.8`. Master is **68 commits ahead of `v3.2.11`** (the latest release) and declares `3.3.0`. Verified that all seven commits also apply cleanly to `v3.2.11` if a release-anchored base is preferred.

<details>
<summary>Contents (7 commits, cherry-picked with <code>-x</code>)</summary>

| Source | Commits | Area |
|---|---|---|
| #233 (@ahkarl13) | 3 | CVE-2026-3650 reapplied, VRUN regression fixed |
| #228 | 1 | `off64_t` → `off_t` in `FileStreamer` |
| #229 | 1 | `GetCurrentModuleFileName`: feature-test `dladdr`, fix inverted check |
| #231 | 1 | `sysctl KERN_PROC_PATHNAME` for executable path on the BSDs |
| #230 | 1 | iconv via `find_package` + link probe |

`#229` and `#231` both touch `gdcmSystem.cxx` and are stacked in that order. `#233` is independent of the other four — no file overlap.

</details>

<details>
<summary>Verification</summary>

macOS arm64, shared libs, `GDCM_BUILD_TESTING=ON`:

| | overlay | pristine `master` |
|---|---|---|
| build | 765/765, exit 0 | 765/765, exit 0 |
| ctest | 196/199 | 196/199 |
| failures | `TestSCUValidation`, `TestEcho`, `TestFind` | same three |

The three failures are pre-existing and environmental — network DICOM tests failing with `protocol-version-not-supported` because no server is running. **No regressions from the overlay.**

`TestCVE20263650` passes and `TestReader3` (the VRUN case whose breakage caused the original revert in `ff5886ee9`) still passes.

The iconv probe added in #230 was exercised both ways: it succeeds under a system toolchain (iconv stays enabled, links `/usr/lib/libiconv.2.dylib`) and fails under a conda toolchain that puts a GNU libiconv `iconv.h` ahead of the SDK library, where `gdcmMSFF` then links clean with no undefined `libiconv_*` symbols.

</details>

<details>
<summary>Note on CVE-2026-3650</summary>

The revert `ff5886ee9` is an ancestor of `v3.2.11`, so the vulnerability is open in the latest release as well as on `master`. There is currently no GDCM version, released or development, that carries the fix. That is why #233 is included here rather than deferred to a version bump.

</details>

<!--
provenance: claude-code session 2026-09-03
overlay_branch: BRAINSia/GDCM for/itk-gdcm-master-2cd05d13
base: 2cd05d132 (master, project VERSION 3.3.0)
alt_base_tested: v3.2.11 = a91d1f64a (all 7 apply cleanly; branch for/itk-gdcm-3.2.11-a91d1f64a)
itk_vendored_base: 2b923808 = v3.2.8, imported 2026-06-18
cherry_picks: be11cef50 6aba5d66e a1df57b51 f12287735 adf2877e9 0889e6c80 ac750c106
itk_context: ITK does not vendor Testing/, so TestCVE20263650.cxx will not cross into
  ITK's subtree; an ITK-side VRUN regression test is needed if ITK carries this overlay.
-->
